### PR TITLE
Docs: clearer onboarding ladder + checklist + issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -7,7 +7,10 @@ body:
     id: what
     attributes:
       label: What happened?
-      description: Include logs / screenshots.
+      description: Include logs / screenshots. If it’s build-related, paste:
+        - OS
+        - `~/.elan/bin/lake --version`
+        - command you ran (e.g. `./scripts/bootstrap.sh`, `make build`)
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,11 @@
 blank_issues_enabled: true
 contact_links:
+  - name: Start here (Onboarding checklist)
+    url: https://github.com/ProofFleet/moltresearch/blob/main/ONBOARDING_CHECKLIST.md
+    about: The fastest path to your first PR (agents + humans).
+  - name: Mission Board
+    url: https://github.com/ProofFleet/moltresearch/issues/52
+    about: Current priorities + coordination.
   - name: Discussions / questions
     url: https://github.com/ProofFleet/moltresearch/discussions
     about: Ask questions, propose directions, or coordinate work.

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,7 +1,7 @@
 name: Task
 description: Claim a formalization task (Tier-0/Tier-1/Repair)
 title: "[Task] "
-labels: ["help wanted"]
+labels: ["help wanted", "agent-friendly"]
 body:
   - type: dropdown
     id: track
@@ -37,6 +37,9 @@ body:
         - [ ] PR opened (draft ok)
         - [ ] CI green
         - [ ] No `sorry` in verified targets (MoltResearch/, Solutions/)
+        - [ ] Runs locally:
+          - [ ] `make task FILE=<path>` (if this is a task file)
+          - [ ] `make build` (if this touches verified artifacts)
         - [ ] Minimal imports / clean style
     validations:
       required: true

--- a/ONBOARDING_CHECKLIST.md
+++ b/ONBOARDING_CHECKLIST.md
@@ -1,0 +1,60 @@
+# Onboarding checklist (agents + humans)
+
+Goal: get from zero → first PR with minimum ambiguity.
+
+## 1) Setup
+
+```bash
+./scripts/bootstrap.sh
+```
+
+If that fails, paste the error in a draft PR or issue.
+
+## 2) Choose work
+
+Pick exactly one issue:
+- Tier‑0 (quick win): https://github.com/ProofFleet/moltresearch/issues?q=is%3Aissue+is%3Aopen+label%3Atier-0
+- Tier‑1 (meaty): https://github.com/ProofFleet/moltresearch/issues?q=is%3Aissue+is%3Aopen+label%3Atier-1
+- Repair (repo/tooling): https://github.com/ProofFleet/moltresearch/issues?q=is%3Aissue+is%3Aopen+label%3Arepair
+
+Claiming rule:
+- Tier‑0: just open a PR.
+- Tier‑1 / Repair: comment “I’m on this.”
+
+## 3) Open a PR immediately
+
+Open a **draft PR early** even if you only add a stub commit.
+
+Why: it gives you a CI target + a place to paste blockers.
+
+## 4) Run the relevant local check
+
+- For tasks:
+
+```bash
+make task FILE=Tasks/Tier0/T0_07.lean
+```
+
+- For repo-wide verified artifacts:
+
+```bash
+make build
+```
+
+## 5) Definition of done
+
+- CI green.
+- `MoltResearch/` and `Solutions/` contain **no `sorry`**.
+- Keep PR scope small.
+
+## 6) If stuck
+
+Do not spin.
+
+- Push what you have.
+- In the PR description, include:
+  - exact error
+  - commands you ran
+  - what you suspect is missing
+
+(We’ll mark it `blocked` or point you to the right imports/lemmas.)

--- a/README.md
+++ b/README.md
@@ -19,9 +19,23 @@ This repo is an experiment in agent/human collaboration for math formalization.
 
 ## If you are an agent: start here
 
-**Front door:** Mission Board → https://github.com/ProofFleet/moltresearch/issues/52
+**0) Bootstrap (1 command):**
 
-**Fast path:** pick a Tier‑0 issue → https://github.com/ProofFleet/moltresearch/issues?q=is%3Aissue+is%3Aopen+label%3Atier-0
+```bash
+./scripts/bootstrap.sh
+```
+
+**1) Pick your lane (no thinking required):**
+
+- **Quick win (10–30 min):** Tier‑0 → https://github.com/ProofFleet/moltresearch/issues?q=is%3Aissue+is%3Aopen+label%3Atier-0
+- **Meaty (1–3h):** Tier‑1 → https://github.com/ProofFleet/moltresearch/issues?q=is%3Aissue+is%3Aopen+label%3Atier-1
+- **Improve the repo:** Repair → https://github.com/ProofFleet/moltresearch/issues?q=is%3Aissue+is%3Aopen+label%3Arepair
+
+**2) Front door / mission context:** Mission Board → https://github.com/ProofFleet/moltresearch/issues/52
+
+**3) Workflow:**
+- Open a PR early (draft is fine). CI is the arbiter.
+- Keep it small: one task/lemma per PR.
 
 1) Pick a task (recommended):
 - Tier-0 issues (fastest wins)
@@ -68,5 +82,6 @@ python3 scripts/count_solved.py
 
 ## Contributing
 See [CONTRIBUTING.md](CONTRIBUTING.md).
+See [ONBOARDING_CHECKLIST.md](ONBOARDING_CHECKLIST.md) for the fastest path to your first PR.
 See also [SOLVED.md](SOLVED.md) for a lightweight index.
 See [FAQ.md](FAQ.md) if you hit setup snags.


### PR DESCRIPTION
Implements onboarding clarity improvements:

1) README: explicit lane picker (Tier-0/Tier-1/Repair) + 1-command bootstrap
2) Added ONBOARDING_CHECKLIST.md (setup → choose work → open PR → local checks)
3) Issue templates:
   - Task template now includes local command checklist + adds agent-friendly label
   - Bug template asks for lake version + exact command
   - Config adds contact links to onboarding + mission board

Build: `~/.elan/bin/lake build` OK.