### PR TITLE
Backlog: build all Tasks/Conjectures modules via lake globs

### DIFF
--- a/Conjectures.lean
+++ b/Conjectures.lean
@@ -1,6 +1,7 @@
-import Conjectures.C0001_example.src.C0001
-
 /-!
 Backlog conjectures live under `Conjectures/` and may contain `sorry`.
+
 This root file exists so Lake can index the library; it is not imported by default targets.
+
+Note: `lakefile.lean` uses `globs` so `lake build Conjectures` typechecks the whole backlog.
 -/

--- a/Tasks.lean
+++ b/Tasks.lean
@@ -1,6 +1,7 @@
-import Tasks.Tier0.T0_01
-
 /-!
 Backlog tasks live under `Tasks/` and may contain `sorry`.
+
 This root file exists so Lake can index the library; it is not imported by default targets.
+
+Note: `lakefile.lean` uses `globs` so `lake build Tasks` typechecks the whole backlog.
 -/

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -17,5 +17,9 @@ lean_lib MoltResearch
 lean_lib Solutions
 
 -- Backlog (not built by default target). Keep as lean_libs so editors work.
-lean_lib Tasks
-lean_lib Conjectures
+-- We use globs so `lake build Tasks` / `lake build Conjectures` typecheck the whole backlog.
+lean_lib Tasks where
+  globs := #[.submodules `Tasks]
+
+lean_lib Conjectures where
+  globs := #[.submodules `Conjectures]


### PR DESCRIPTION
Improves the open-problem scaffold by making the backlog libs robust and non-manual.

Before:
- Tasks.lean / Conjectures.lean imported a single example module just to "index" the library.

After:
- lakefile.lean uses globs so `lake build Tasks` / `lake build Conjectures` typecheck the *entire* backlog tree.
- Tasks.lean / Conjectures.lean are now pure doc modules.

This reduces agent friction and prevents backlog rot.
