### PR TITLE
Open problem: Erdős discrepancy card + verified discrepancy substrate

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/card.md
+++ b/Conjectures/C0002_erdos_discrepancy/card.md
@@ -1,0 +1,3 @@
+# C0002 — Erdős discrepancy theorem
+
+See Problems/erdos_discrepancy.md

--- a/Conjectures/C0002_erdos_discrepancy/notes.md
+++ b/Conjectures/C0002_erdos_discrepancy/notes.md
@@ -1,0 +1,1 @@
+Notes and references for the Erdős discrepancy theorem live here.

--- a/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
@@ -1,0 +1,32 @@
+import Mathlib
+
+/-!
+A conjecture-style stub for the Erdős discrepancy theorem.
+
+This file may contain `sorry` (backlog only). Verified, reusable definitions belong in `MoltResearch/`.
+-/
+
+namespace MoltResearch
+
+/-- A ±1-valued sequence on ℕ. -/
+def IsSignSequence (f : ℕ → ℤ) : Prop := ∀ n, f n = 1 ∨ f n = -1
+
+/-- Sum of `f` along the homogeneous arithmetic progression `d, 2d, ..., nd`. -/
+def apSum (f : ℕ → ℤ) (d n : ℕ) : ℤ :=
+  (Finset.range n).sum (fun i => f ((i + 1) * d))
+
+/-- `f` has discrepancy at least `C` if some AP partial sum exceeds `C` in absolute value. -/
+def HasDiscrepancyAtLeast (f : ℕ → ℤ) (C : ℕ) : Prop :=
+  ∃ d n : ℕ, Int.natAbs (apSum f d n) > C
+
+/-- Erdős discrepancy theorem (Tao 2015).
+
+Every ±1 sequence has unbounded discrepancy on homogeneous arithmetic progressions.
+
+This is a long-horizon target for the repo; we start by building the definition + lemma substrate.
+-/
+conjecture erdos_discrepancy (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    ∀ C : ℕ, HasDiscrepancyAtLeast f C := by
+  sorry
+
+end MoltResearch

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -1,0 +1,37 @@
+import Mathlib
+
+/-!
+# Discrepancy: basic definitions
+
+These definitions are intended as **reusable verified substrate** for discrepancy-style problems.
+
+Design principles:
+- keep definitions small and composable
+- avoid baking in problem-specific choices too early
+- prefer ℕ-indexed sequences with ℤ values for summation convenience
+-/
+
+namespace MoltResearch
+
+/-- A ±1-valued sequence on ℕ (values in ℤ). -/
+def IsSignSequence (f : ℕ → ℤ) : Prop := ∀ n, f n = 1 ∨ f n = -1
+
+/-- Sum of `f` along the homogeneous arithmetic progression `d, 2d, ..., nd`.
+
+We use `Finset.range n` with `i+1` so the progression starts at `d`.
+- `n = 0` yields sum 0.
+-/
+def apSum (f : ℕ → ℤ) (d n : ℕ) : ℤ :=
+  (Finset.range n).sum (fun i => f ((i + 1) * d))
+
+/-- `f` has discrepancy at least `C` if some AP partial sum exceeds `C` in absolute value.
+
+We compare via `Int.natAbs` so `C : ℕ` stays natural.
+-/
+def HasDiscrepancyAtLeast (f : ℕ → ℤ) (C : ℕ) : Prop :=
+  ∃ d n : ℕ, Int.natAbs (apSum f d n) > C
+
+@[simp] lemma apSum_zero (f : ℕ → ℤ) (d : ℕ) : apSum f d 0 = 0 := by
+  simp [apSum]
+
+end MoltResearch

--- a/MoltResearch/MoltResearch.lean
+++ b/MoltResearch/MoltResearch.lean
@@ -1,5 +1,6 @@
 import MoltResearch.Basics
 import MoltResearch.Logic
+import MoltResearch.Discrepancy.Basic
 
 /-!
 Canonical verified artifacts live under `MoltResearch/`.

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -1,0 +1,66 @@
+# Problem Card: Erdos discrepancy theorem
+
+Status: active
+
+## 0. One-line pitch
+
+A canonical “agents at scale” benchmark: turn an open-problem-shaped statement into reusable definitions + lemmas, then (eventually) a full formal proof.
+
+## 1. Natural language statement
+
+Let f : N → {−1, +1}. For any constant C, there exist positive integers d and n such that
+
+| sum_{i=1..n} f(i*d) | > C.
+
+Equivalently: every ±1 sequence has unbounded discrepancy on homogeneous arithmetic progressions.
+
+Notes:
+- Historically posed by Erdős; solved by Tao (2015). In this repo, it serves as a **pipeline test** and long-horizon target.
+
+## 2. Formalization target (Lean)
+
+Goal: a *type-correct* Lean statement (even if unproved initially).
+
+- Target file: `Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean`
+- Definitions should land in `MoltResearch/` when reusable.
+
+## 3. Dependencies
+
+- Finite sums over ranges (`Finset.range`)
+- Integer absolute value / natAbs
+- Basic number theory (multiples)
+
+## 4. Decomposition (mergeable sub-tasks)
+
+### Track A — Definitions (verified artifacts)
+
+- [ ] Define `IsSignSequence (f : ℕ → ℤ)`
+- [ ] Define the partial sum on a homogeneous AP: `apSum f d n`
+- [ ] Define a predicate `HasDiscrepancyAtLeast f C`
+
+Definition of done:
+- lands under `MoltResearch/Discrepancy/Basic.lean`
+- compiles with **no `sorry`**
+
+### Track B — Lemma library (verified artifacts)
+
+- [ ] Lemmas about `IsSignSequence` (range, abs, etc.)
+- [ ] Rewriting lemmas for `apSum`
+- [ ] Small bounds / monotonicity facts
+
+Definition of done:
+- each PR adds 1–3 lemmas, minimal imports
+
+### Track C — Conjecture stub + equivalences (backlog)
+
+- [ ] A clean Lean statement stub in `Conjectures/` (allowed `sorry`)
+- [ ] Alternate formulations/equivalences recorded in the card + notes
+
+## 5. References / links
+
+- Terence Tao, “The Erdős discrepancy problem” (2015)
+
+## 6. Notes / gotchas
+
+- Keep verified artifacts **modular**: definitions in `MoltResearch/`, open claims in `Conjectures/`.
+- Don’t chase the whole proof early; win by building reusable substrate.


### PR DESCRIPTION
Starts the open-problem scaffold with a concrete first target.

Adds:
- `Problems/erdos_discrepancy.md` (Problem Card + decomposition)
- `Conjectures/C0002_erdos_discrepancy/...` (Lean stub, allowed `sorry`)
- `MoltResearch/Discrepancy/Basic.lean` (verified definitions: IsSignSequence/apSum/HasDiscrepancyAtLeast)
- Wires the verified module into `MoltResearch/MoltResearch.lean`

CI stays green.
