### PR TITLE
Track C: core unboundedness wrapper

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Proof.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Proof.lean
@@ -57,6 +57,20 @@ theorem stage2_unboundedDiscOffset (f : ℕ → ℤ) (hf : IsSignSequence f) :
     ((stage2Out (f := f) (hf := hf)).out1.unboundedDiscrepancyAlong_iff_unboundedDiscOffset (f := f)).1
       (stage2Out (f := f) (hf := hf)).unbounded
 
+/-- Core-predicate form: Stage 2 yields unbounded fixed-step discrepancy along the reduced sequence,
+re-expressed using `MoltResearch.UnboundedDiscrepancyAlong`.
+
+This is a small convenience wrapper around the Track-C-local witness
+`(stage2Out ...).unbounded`, using `Tao2015.unboundedDiscrepancyAlong_iff_core`.
+-/
+theorem stage2_unboundedDiscrepancyAlong_core (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    MoltResearch.UnboundedDiscrepancyAlong (stage2_g (f := f) (hf := hf))
+      (stage2_d (f := f) (hf := hf)) := by
+  exact
+    (Tao2015.unboundedDiscrepancyAlong_iff_core (g := stage2_g (f := f) (hf := hf))
+        (d := stage2_d (f := f) (hf := hf))).1
+      (stage2Out (f := f) (hf := hf)).unbounded
+
 /-- Existential packaging: Stage 2 yields concrete parameters `d, m` with `1 ≤ d` such that the
 bundled offset discrepancy family `discOffset f d m` is unbounded. -/
 theorem stage2_exists_params_one_le_unboundedDiscOffset (f : ℕ → ℤ) (hf : IsSignSequence f) :


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add stage2_unboundedDiscrepancyAlong_core: re-express the Stage-2 unboundedness witness using the verified core predicate.
- No changes to the conjecture stub; this is a small API convenience lemma for consumers.
