### PR TITLE
Track C: use Stage-3 API for erdos_discrepancy

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
@@ -34,9 +34,8 @@ Track-C Stage-3 pipeline.
 -/
 theorem erdos_discrepancy (f : ℕ → ℤ) (hf : IsSignSequence f) :
     ∀ C : ℕ, HasDiscrepancyAtLeast f C := by
-  -- Derive the usual witness form from the core negation-normal-form statement.
-  exact (forall_hasDiscrepancyAtLeast_iff_not_boundedDiscrepancy f).2
-    (erdos_discrepancy_notBounded (f := f) (hf := hf))
+  -- Prefer consuming the Stage-3 entry-point API.
+  exact Tao2015.stage3_forall_hasDiscrepancyAtLeast (f := f) (hf := hf)
 
 /-!
 Additional witness-form corollaries live in


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Define erdos_discrepancy by delegating directly to Tao2015.stage3_forall_hasDiscrepancyAtLeast.
- Keeps Conjectures.C0002_erdos_discrepancy.src.ErdosDiscrepancy minimal and aligned with the Stage-3 entry-point API.
