### PR TITLE
Track C: add Stage2Output.g_eq_fun

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
@@ -61,6 +61,14 @@ theorem g_eq_start (out : Stage2Output f) (k : ℕ) :
     out.g k = f (k + out.start) := by
   simpa [Stage2Output.start] using (out.g_eq (f := f) k)
 
+/-- Function-level rewrite for the reduced sequence produced by Stage 2: it is the shifted sequence
+`fun k => f (k + out.start)`.
+-/
+theorem g_eq_fun (out : Stage2Output f) :
+    out.g = fun k => f (k + out.start) := by
+  funext k
+  simpa using out.g_eq_start (f := f) k
+
 /-- Convenience projection: positivity of the reduced step size. -/
 abbrev hd (out : Stage2Output f) : out.d > 0 := out.out1.hd
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add Stage2Output.g_eq_fun as a function-level shift rewrite for the reduced sequence.
- Lets downstream stages rewrite out.g without repeating funext boilerplate.
