### PR TITLE
Track C: Stage3Output g_eq_fun

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Core.lean
@@ -94,6 +94,14 @@ theorem g_eq_start (out : Stage3Output f) (k : ℕ) :
     out.g k = f (k + out.start) := by
   simpa [Stage3Output.start] using (out.g_eq (f := f) k)
 
+/-- Function-level rewrite for the reduced sequence packaged in Stage 3: it is the shifted sequence
+`fun k => f (k + out.start)`.
+-/
+theorem g_eq_fun (out : Stage3Output f) :
+    out.g = fun k => f (k + out.start) := by
+  funext k
+  simpa using out.g_eq_start (f := f) k
+
 /-- Convenience projection: positivity of the reduced step size. -/
 abbrev hd (out : Stage3Output f) : out.d > 0 := out.out2.hd
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add Stage3Output.g_eq_fun as a function-level rewrite for the reduced sequence g in Stage 3.
- Mirrors the existing Stage2Output.g_eq_fun helper, keeping Stage-3 core rewriting ergonomic.
