### PR TITLE
Track C: Stage 2 lightweight import

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2.lean
@@ -1,20 +1,17 @@
-import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Entry
-import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Boundary
-import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Proof
+import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Light
 import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Output
 
 /-!
 # Track C: Stage 2 boundary (Tao 2015 plane)
 
 This file is intentionally thin: it re-exports
-- the Stage-2 entry point (the conjecture stub `stage2` and deterministic name `stage2Out`),
-- the Stage-2 boundary interface,
-- the tiny convenience projections/wrapper lemmas about `stage2Out` (from `TrackCStage2Proof`), and
-- the proved convenience lemmas about `Tao2015.Stage2Output`,
+- `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Light` (entry point + boundary + lightweight wrappers about `stage2Out`), and
+- the proved convenience lemmas about `Tao2015.Stage2Output` (from `TrackCStage2Output`),
 
 keeping `TrackCStage2.lean` as “API + wiring”.
 
 The conjecture stub itself lives in
-`Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Entry` and is imported here so consumers can
-just `import ...TrackCStage2`.
+`Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Entry` (imported via
+`Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Light`) so consumers can just
+`import ...TrackCStage2`.
 -/

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Light.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Light.lean
@@ -1,0 +1,18 @@
+import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Entry
+import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Boundary
+import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Proof
+
+/-!
+# Track C: Stage 2 (lightweight import)
+
+This file is intentionally thin: it re-exports
+- the Stage-2 entry point (the conjecture stub `stage2` and deterministic name `stage2Out`),
+- the Stage-2 boundary interface, and
+- the tiny convenience projections/wrapper lemmas about `stage2Out` (from `TrackCStage2Proof`),
+
+without importing the larger proved convenience-lemma library
+`Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Output`.
+
+Consumers that want the full Stage-2 convenience layer should import
+`Conjectures.C0002_erdos_discrepancy.src.TrackCStage2`.
+-/


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a new lightweight Stage 2 import module TrackCStage2Light that re-exports the Stage-2 stub, boundary interface, and small stage2Out wrappers without pulling in the larger Stage2Output convenience layer.
- Refactor TrackCStage2 to import TrackCStage2Light + TrackCStage2Output so consumers can choose a smaller compilation surface when they do not need the full convenience library.
