### PR TITLE
Track C: Stage2Output notBoundedOriginal

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
@@ -127,6 +127,10 @@ theorem notBoundedReducedAlong (out : Stage2Output f) : ¬ BoundedDiscrepancyAlo
   exact (Tao2015.UnboundedDiscrepancyAlong.iff_not_boundedDiscrepancyAlong
     (g := out.g) (d := out.d)).1 out.unbounded
 
+/-- Stage 2 implies the original sequence is not globally discrepancy-bounded. -/
+theorem notBoundedOriginal (out : Stage2Output f) : ¬ BoundedDiscrepancy f := by
+  exact out.out1.not_boundedDiscrepancy_of_unboundedDiscrepancyAlong (f := f) out.unbounded
+
 /-- Consumer-facing form: Stage 2 unboundedness transferred back to the original sequence as an
 unbounded **offset discrepancy** witness.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add Stage2Output.notBoundedOriginal: a small wrapper transporting stage-2 unboundedness back to the original sequence as ¬ BoundedDiscrepancy f.
- This reduces downstream boilerplate when consuming Stage2Output, aligning the record-level API with the existing stage2Out convenience lemma.
