### PR TITLE
Track C: stage3 discrepancy witness wrapper

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Entry.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Entry.lean
@@ -70,6 +70,18 @@ theorem stage3_forall_exists_d_ne_zero_witness_pos (f : ℕ → ℤ) (hf : IsSig
   exact
     Stage2Output.forall_exists_d_ne_zero_witness_pos (f := f) (stage2Out (f := f) (hf := hf))
 
+/-- Consumer-facing shortcut: Stage 3 yields the discrepancy witness form
+
+`∀ C, ∃ d n, d > 0 ∧ discrepancy f d n > C`.
+
+This is a thin wrapper around the proved Stage-2 lemma
+`Stage2Output.forall_exists_discrepancy_gt_original`.
+-/
+theorem stage3_forall_exists_discrepancy_gt (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    ∀ C : ℕ, ∃ d n : ℕ, d > 0 ∧ discrepancy f d n > C := by
+  exact
+    Stage2Output.forall_exists_discrepancy_gt_original (f := f) (stage2Out (f := f) (hf := hf))
+
 /-- Consumer-facing shortcut: Stage 3 yields unboundedness of the bundled offset discrepancy family
 `discOffset f d m` at the deterministic parameters produced by the pipeline.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Added a Stage 3 entry-point wrapper stage3_forall_exists_discrepancy_gt so consumers can get the discrepancy witness normal form directly.
- Implemented as a thin wrapper over the proved Stage 2 lemma Stage2Output.forall_exists_discrepancy_gt_original.
