### PR TITLE
Discrepancy: paper-interval normal form for discOffset

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -100,6 +100,10 @@ example : (Finset.Icc (m + 1) (m + n)).sum (fun i => f (a + i * d)) = apSumFrom 
 example : Int.natAbs ((Finset.Icc (m + 1) (m + n)).sum (fun i => f (i * d))) = discOffset f d m n := by
   simp
 
+-- nucleus `discOffset` → paper discrepancy object (Track B item: paper-interval discrepancy normal form)
+example : discOffset f d m n = Int.natAbs ((Finset.Icc (m + 1) (m + n)).sum (fun i => f (i * d))) := by
+  simpa using (discOffset_eq_natAbs_sum_Icc (f := f) (d := d) (m := m) (n := n))
+
 /-!
 ### Regression: index-arithmetic simp polish (Track B)
 

--- a/MoltResearch/Discrepancy/Offset.lean
+++ b/MoltResearch/Discrepancy/Offset.lean
@@ -316,6 +316,19 @@ lemma apSumOffset_eq_sum_Icc (f : ℕ → ℤ) (d m n : ℕ) :
                   (Finset.Ico_add_one_right_eq_Icc (a := m + 1) (b := m + n))
             simpa [hend] using hsum
 
+/-- Paper-interval discrepancy normal form: rewrite `discOffset` directly as an `Icc`-sum.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — Paper-interval discrepancy normal form.
+
+This is the stable bridge lemma for surface statements written in paper notation.
+-/
+lemma discOffset_eq_natAbs_sum_Icc (f : ℕ → ℤ) (d m n : ℕ) :
+    discOffset f d m n =
+      Int.natAbs ((Finset.Icc (m + 1) (m + n)).sum (fun i => f (i * d))) := by
+  unfold discOffset
+  -- `discOffset` is definitional `Int.natAbs (apSumOffset ...)`.
+  -- Rewrite `apSumOffset` into paper notation.
+  simpa [apSumOffset_eq_sum_Icc]
 /-!
 ## “One-cut in paper notation” bridge
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Paper-interval discrepancy normal form: add a stable lemma rewriting `discOffset f d m n` directly into a paper-style `Icc` sum,

Summary:
- Add `discOffset_eq_natAbs_sum_Icc` as the stable bridge lemma (discOffset → paper `Icc` tail sum).
- Add a regression example under `MoltResearch.Discrepancy.NormalFormExamples`.

Notes:
- No new simp attributes were added; the lemma is an explicit normal-form bridge for surface statements.
