### PR TITLE
Track C: stage2_g_eq_fun in entry module

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Entry.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Entry.lean
@@ -10,7 +10,7 @@ It contains only:
 - the deterministic name `stage2Out`,
 - the lightweight projections `stage2_d`, `stage2_g`, `stage2_m`, `stage2_start`, and
 - the tiny projection lemmas `stage2_d_pos`, `stage2_one_le_d`, `stage2_d_ne_zero`, `stage2_hg`,
-  `stage2_g_eq`.
+  `stage2_g_eq`, `stage2_g_eq_fun`.
 
 All other proved convenience lemmas about `stage2Out` live in
 `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Proof`.
@@ -90,6 +90,13 @@ theorem stage2_g_eq (f : ℕ → ℤ) (hf : IsSignSequence f) (k : ℕ) :
   -- This is just the Stage-1 reduction contract carried by the Stage-2 output.
   simpa [stage2_g, stage2_start, stage2_m, stage2_d] using
     (stage2Out (f := f) (hf := hf)).out1.g_eq k
+
+/-- Function-level rewrite for `stage2_g`: it is the shifted sequence `fun k => f (k + m*d)`. -/
+theorem stage2_g_eq_fun (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    stage2_g (f := f) (hf := hf) =
+      fun k => f (k + stage2_start (f := f) (hf := hf)) := by
+  funext k
+  simpa using stage2_g_eq (f := f) (hf := hf) k
 
 end Tao2015
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Proof.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Proof.lean
@@ -88,13 +88,6 @@ theorem stage2_exists_params_one_le_unboundedDiscOffset (f : ℕ → ℤ) (hf : 
     stage2_one_le_d (f := f) (hf := hf), ?_⟩
   exact stage2_unboundedDiscOffset (f := f) (hf := hf)
 
-/-- Function-level rewrite for `stage2_g`: it is the shifted sequence `fun k => f (k + m*d)`. -/
-theorem stage2_g_eq_fun (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    stage2_g (f := f) (hf := hf) =
-      fun k => f (k + stage2_start (f := f) (hf := hf)) := by
-  funext k
-  simpa using stage2_g_eq (f := f) (hf := hf) k
-
 /-!
 ## Additional witness-form wrappers
 -/


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Moved the function-level rewrite lemma stage2_g_eq_fun into the Stage 2 entry module so lightweight consumers can use it without importing the larger proof wrapper layer.
- Removed the now-duplicated lemma from TrackCStage2Proof.
