### PR TITLE
Discrepancy: endpoint congruence wrapper for discOffset

### DIFF
--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -1143,6 +1143,25 @@ lemma apSumOffset_congr_finset_Icc (f g : ℕ → ℤ) (d m n : ℕ)
     exact Finset.mem_Icc.2 hi
   exact h i this
 
+/-- Endpoint-form congruence wrapper for `discOffset` (paper notation).
+
+This packages a very common hypothesis shape in discrepancy arguments:
+
+`∀ i, m < i ∧ i ≤ m+n → f (i*d) = g (i*d)`
+
+into the normal-form congruence statement
+`discOffset f d m n = discOffset g d m n`,
+without mentioning `Finset.range` or `Set.Icc` in the statement.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — Endpoint-congruence wrapper (disc-level, paper notation).
+-/
+lemma discOffset_congr_endpoints (f g : ℕ → ℤ) (d m n : ℕ)
+    (h : ∀ i, (m < i ∧ i ≤ m + n) → f (i * d) = g (i * d)) :
+    discOffset f d m n = discOffset g d m n := by
+  unfold discOffset
+  refine congrArg Int.natAbs ?_
+  exact apSumOffset_congr_endpoints (f := f) (g := g) (d := d) (m := m) (n := n) (h := h)
+
 /-- Range-form congruence lemma for `discOffset`.
 
 If `f` and `g` agree on every summation index `i ∈ Finset.range n` in the `range`-expanded normal

--- a/MoltResearch/Discrepancy/CastSimp.lean
+++ b/MoltResearch/Discrepancy/CastSimp.lean
@@ -47,7 +47,7 @@ This shows up frequently when normalizing `(i + 1 : ℕ)` endpoints after rewrit
 We include both orientations to avoid commutativity noise without enabling `Nat` commutativity.
 -/
 @[simp] lemma one_add_natCast (n : ℕ) : 1 + (n : ℤ) = ((1 + n : ℕ) : ℤ) := by
-  -- Keep this lemma separate to avoid pulling in commutativity simp rules.
-  simp [Nat.add_comm]
+  -- Use the non-commutative contraction lemma directly (avoid simp loops).
+  simpa using (natCast_add_natCast 1 n)
 
 end MoltResearch

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -1735,6 +1735,13 @@ example (g : ℕ → ℤ)
   simpa using
     (apSumOffset_congr_endpoints (f := f) (g := g) (d := d) (m := m) (n := n) (h := h))
 
+-- Regression: endpoint-form congruence wrapper (disc-level) is usable from the stable surface.
+example (g : ℕ → ℤ)
+    (h : ∀ i, (m < i ∧ i ≤ m + n) → f (i * d) = g (i * d)) :
+    discOffset f d m n = discOffset g d m n := by
+  simpa using
+    (discOffset_congr_endpoints (f := f) (g := g) (d := d) (m := m) (n := n) (h := h))
+
 -- Regression: support-form congruence lemmas are usable from the stable surface.
 example (g : ℕ → ℤ)
     (h : ∀ x ∈ apSupport d m n, f x = g x) :


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Endpoint-congruence wrapper (disc-level, paper notation)

Summary:
- Add `discOffset_congr_endpoints`, mirroring `apSumOffset_congr_endpoints`, so paper-style endpoint hypotheses rewrite `discOffset` without `Finset.range`/`Set.Icc` bookkeeping.
- Add stable-surface regression example under `import MoltResearch.Discrepancy`.
- Fix a simp recursion issue in `CastSimp.one_add_natCast` (previous proof could hit max recursion depth).

Local validation:
- `make ci`
