### PR TITLE
Track C: Stage-2 nucleus witness wrapper

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
@@ -494,6 +494,20 @@ through Stage 3).
 They live in this larger output-lemma module to keep `TrackCStage2Core.lean` minimal.
 -/
 
+/-- Nucleus witness form of the Stage-2 unboundedness hypothesis `out.unbounded`.
+
+Normal form:
+`∀ B, ∃ n, Int.natAbs (apSum out.g out.d n) > B`.
+
+This is a thin wrapper around
+`Tao2015.unboundedDiscrepancyAlong_iff_forall_exists_natAbs_apSum_gt'`.
+-/
+theorem forall_exists_natAbs_apSum_gt' (out : Stage2Output f) :
+    ∀ B : ℕ, ∃ n : ℕ, Int.natAbs (apSum out.g out.d n) > B := by
+  simpa using
+    (Tao2015.unboundedDiscrepancyAlong_iff_forall_exists_natAbs_apSum_gt' (g := out.g) (d := out.d)).1
+      out.unbounded
+
 /-- Positive-length nucleus witness form of the Stage-2 unboundedness hypothesis `out.unbounded`.
 
 Normal form:


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Added Stage2Output.forall_exists_natAbs_apSum_gt' as a small wrapper exposing Stage-2 unboundedness directly in the nucleus form Int.natAbs (apSum ...) > B.
- Implemented via the existing unboundedDiscrepancyAlong_iff_forall_exists_natAbs_apSum_gt' normal form, keeping the Stage-2 API surface tidy.
