### PR TITLE
Discrepancy: strengthen stable-surface paper-lemma audit

### DIFF
--- a/MoltResearch/Discrepancy/SurfaceAudit.lean
+++ b/MoltResearch/Discrepancy/SurfaceAudit.lean
@@ -53,11 +53,15 @@ section
   #check apSumOffset_eq_sum_Icc_length_mul_left
   #check sum_Icc_eq_apSumOffset_length
   #check sum_Icc_eq_apSumOffset_length_mul_left
+  #check sum_Icc_eq_apSumOffset
+  #check sum_Icc_eq_apSumOffset_mul_left
 
   #check apSumFrom_eq_sum_Icc
   #check sum_Icc_eq_apSumFrom
   #check apSumFrom_tail_eq_sum_Icc_add
   #check sum_Icc_eq_apSumFrom_tail_of_le_add
+  #check sum_Icc_eq_apSumFrom_tail
+  #check sum_Icc_eq_apSumFrom_tail_of_le
 
   -- Paper-notation ↔ nucleus bridge for affine tails with `d * i` summand convention.
   #check apSumFrom_tail_eq_sum_Icc_mul_left


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Stable-surface export audit for paper-notation lemmas: ensure the preferred paper↔nucleus lemmas for `apSumFrom`/`apSumOffset`/`discOffset`

What changed
- Strengthened `MoltResearch.Discrepancy.SurfaceAudit` so the stable surface `import MoltResearch.Discrepancy` is compile-time checked to export the base paper↔nucleus bridge lemmas:
  - `sum_Icc_eq_apSumOffset`, `sum_Icc_eq_apSumOffset_mul_left`
  - `sum_Icc_eq_apSumFrom_tail`, `sum_Icc_eq_apSumFrom_tail_of_le`

Why
- These lemmas are part of the intended "paper notation ↔ nucleus API" rewrite toolkit; keeping them in the audit reduces future "mystery import" regressions.

CI
- `make ci`
