### PR TITLE
Discrepancy: named paper↔nucleus bridge for discOffset

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -96,9 +96,9 @@ example : (Finset.Icc (m + 1) (m + n)).sum (fun i => f (d * i)) = apSumOffset f 
 example : (Finset.Icc (m + 1) (m + n)).sum (fun i => f (a + i * d)) = apSumFrom f (a + m * d) d n := by
   simp
 
--- paper discrepancy object → nucleus `discOffset`
+-- paper discrepancy object → nucleus `discOffset` (named bridge lemma)
 example : Int.natAbs ((Finset.Icc (m + 1) (m + n)).sum (fun i => f (i * d))) = discOffset f d m n := by
-  simp
+  simpa using (natAbs_sum_Icc_eq_discOffset (f := f) (d := d) (m := m) (n := n))
 
 -- nucleus `discOffset` → paper discrepancy object (Track B item: paper-interval discrepancy normal form)
 example : discOffset f d m n = Int.natAbs ((Finset.Icc (m + 1) (m + n)).sum (fun i => f (i * d))) := by

--- a/MoltResearch/Discrepancy/Offset.lean
+++ b/MoltResearch/Discrepancy/Offset.lean
@@ -330,6 +330,19 @@ lemma discOffset_eq_natAbs_sum_Icc (f : ℕ → ℤ) (d m n : ℕ) :
   -- Rewrite `apSumOffset` into paper notation.
   simpa [apSumOffset_eq_sum_Icc]
 
+/-- Inverse orientation of `discOffset_eq_natAbs_sum_Icc`.
+
+This is useful when starting from a surface statement in paper notation and normalizing into the
+nucleus API.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — Stable-surface export audit for
+paper-notation lemmas.
+-/
+lemma natAbs_sum_Icc_eq_discOffset (f : ℕ → ℤ) (d m n : ℕ) :
+    Int.natAbs ((Finset.Icc (m + 1) (m + n)).sum (fun i => f (i * d))) = discOffset f d m n := by
+  simpa using
+    (discOffset_eq_natAbs_sum_Icc (f := f) (d := d) (m := m) (n := n)).symm
+
 /-!
 ## `discOffsetUpTo` paper↔nucleus bridge
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Stable-surface export audit for paper-notation lemmas: ensure the preferred paper↔nucleus lemmas for `apSumFrom`/`apSumOffset`/`discOffset`

What changed
- Added `natAbs_sum_Icc_eq_discOffset` (inverse orientation of `discOffset_eq_natAbs_sum_Icc`) so paper-notation discrepancy expressions can be rewritten into the nucleus API with a named lemma.
- Updated `MoltResearch/Discrepancy/NormalFormExamples.lean` to exercise the named bridge lemma.

Tests
- `make ci`
