### PR TITLE
SurfaceAudit: export-check apSumFrom paper-notation add variants

### DIFF
--- a/MoltResearch/Discrepancy/SurfaceAudit.lean
+++ b/MoltResearch/Discrepancy/SurfaceAudit.lean
@@ -57,7 +57,9 @@ section
   #check sum_Icc_eq_apSumOffset_mul_left
 
   #check apSumFrom_eq_sum_Icc
+  #check apSumFrom_eq_sum_Icc_add
   #check sum_Icc_eq_apSumFrom
+  #check sum_Icc_eq_apSumFrom_add
   #check apSumFrom_tail_eq_sum_Icc_add
   #check sum_Icc_eq_apSumFrom_tail_of_le_add
   #check sum_Icc_eq_apSumFrom_tail


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Stable-surface export audit for paper-notation lemmas: ensure the preferred paper↔nucleus lemmas for `apSumFrom`/`apSumOffset`/`discOffset`

Summary:
- Extend the stable-surface audit to `#check` the translation-friendly `apSumFrom` paper-notation bridge
  (`apSumFrom_eq_sum_Icc_add`) and its inverse (`sum_Icc_eq_apSumFrom_add`).

Notes:
- No lemma changes; this is an API regression guard under `import MoltResearch.Discrepancy`.
- `make ci` passes locally.
