### PR TITLE
PaperSimp: one-line simp for Icc (m+1) (m+n) affine endpoints

### DIFF
--- a/MoltResearch/Discrepancy/PaperSimp.lean
+++ b/MoltResearch/Discrepancy/PaperSimp.lean
@@ -49,9 +49,20 @@ lemma natAbs_sum_Icc_of_le_affineEndpoints_eq_discOffset'
         hmn)
   simpa [hs]
 
+-- Common paper form: `∑_{i=m+1}^{m+n} f (a + i*d)`.
+-- This avoids having to manually provide the inequality `m ≤ m+n` and simplifies `(m+n) - m`.
+lemma natAbs_sum_Icc_add_affineEndpoints_eq_discOffset'
+    (f : ℕ → ℤ) (a d m n : ℕ) :
+    Int.natAbs ((Finset.Icc (m + 1) (m + n)).sum (fun i => f (a + i * d))) =
+        discOffset (fun k => f (a + k)) d m n := by
+  simpa [Nat.add_sub_cancel_left] using
+    (natAbs_sum_Icc_of_le_affineEndpoints_eq_discOffset' (f := f) (a := a) (d := d)
+      (m := m) (n := m + n) (Nat.le_add_right m n))
+
 attribute [simp]
   natAbs_sum_Icc_eq_discOffset'
   natAbs_sum_Icc_of_le_affineEndpoints_eq_discOffset'
+  natAbs_sum_Icc_add_affineEndpoints_eq_discOffset'
 
 /-!
 ## Disable nucleus → paper rewrites as simp rules (loop avoidance)

--- a/MoltResearch/Discrepancy/PaperSimpExamples.lean
+++ b/MoltResearch/Discrepancy/PaperSimpExamples.lean
@@ -1,0 +1,35 @@
+import MoltResearch.Discrepancy
+import MoltResearch.Discrepancy.PaperSimp
+
+/-!
+# Regression examples for `MoltResearch.Discrepancy.PaperSimp`
+
+Compile-only checks that the opt-in paper endpoint simp pipeline stays usable while
+importing the stable surface `MoltResearch.Discrepancy`.
+
+This file is intentionally **not** imported by `MoltResearch.Discrepancy`.
+-/
+
+namespace MoltResearch
+
+-- Homogeneous tail form: `∑_{i=m+1}^{m+n} f (i*d)`.
+example (f : ℕ → ℤ) (d m n : ℕ) :
+    Int.natAbs ((Finset.Icc (m + 1) (m + n)).sum (fun i => f (i * d))) = discOffset f d m n := by
+  simp
+
+-- Affine endpoint form: `∑_{i=m+1}^{m+n} f (a + i*d)`.
+example (f : ℕ → ℤ) (a d m n : ℕ) :
+    Int.natAbs ((Finset.Icc (m + 1) (m + n)).sum (fun i => f (a + i * d))) =
+        affineDiscrepancy f (a + m * d) d n := by
+  -- First, use the opt-in paper endpoint simp lemma (in `PaperSimp`) to land in `discOffset`.
+  have h :=
+    (natAbs_sum_Icc_add_affineEndpoints_eq_discOffset' (f := f) (a := a) (d := d) (m := m)
+      (n := n))
+  -- Then, rewrite the `discOffset` wrapper to the affine nucleus wrapper.
+  have h' : discOffset (fun k => f (a + k)) d m n = affineDiscrepancy f (a + m * d) d n := by
+    rw [discOffset_def, affineDiscrepancy_def]
+    -- Now it suffices to rewrite the underlying AP sum.
+    simpa [apSumOffset_shift_eq_apSumFrom_tail]
+  exact h.trans h'
+
+end MoltResearch


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: One-line `simp` pipeline for paper endpoints: add (or refine) an opt-in simp set so a typical goal involving

Summary:
- Extend `MoltResearch.Discrepancy.PaperSimp` with a dedicated lemma for the common affine paper form
  `∑_{i=m+1}^{m+n} f (a + i*d)`.
  This avoids having to supply `m ≤ m+n` manually and simplifies `(m+n) - m` to `n`.
- Add `MoltResearch.Discrepancy.PaperSimpExamples` (compile-only) to lock in the intended one-line simp behavior when importing the stable surface plus the opt-in simp module.

Notes:
- The new simp lemma is opt-in (lives in `PaperSimp`) and does not add global simp rules.