### PR TITLE
Track C: stage3_g_eq_fun in core

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Entry.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Entry.lean
@@ -21,14 +21,8 @@ namespace Tao2015
 
 -- (core API lives in `TrackCStage3EntryCore.lean`)
 
-/-- Function-level rewrite for `stage3_g`: it is the shifted sequence
-`fun k => f (k + stage3_start)`.
--/
-theorem stage3_g_eq_fun (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    stage3_g (f := f) (hf := hf) =
-      fun k => f (k + stage3_start (f := f) (hf := hf)) := by
-  funext k
-  simpa using stage3_g_eq (f := f) (hf := hf) k
+-- Note: `stage3_g_eq_fun` now lives in `TrackCStage3EntryCore.lean` so hard-gate consumers
+-- can use it without importing this larger convenience-lemma module.
 
 /-- Consumer-facing shortcut: Stage 3 yields the nucleus witness form
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
@@ -83,6 +83,15 @@ theorem stage3_g_eq (f : ℕ → ℤ) (hf : IsSignSequence f) (k : ℕ) :
     stage3_g (f := f) (hf := hf) k = f (k + stage3_start (f := f) (hf := hf)) := by
   simpa [stage3_g, stage3_start] using stage2_g_eq (f := f) (hf := hf) k
 
+/-- Function-level rewrite for `stage3_g`: it is the shifted sequence
+`fun k => f (k + stage3_start)`.
+-/
+theorem stage3_g_eq_fun (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    stage3_g (f := f) (hf := hf) =
+      fun k => f (k + stage3_start (f := f) (hf := hf)) := by
+  funext k
+  simpa using stage3_g_eq (f := f) (hf := hf) k
+
 /-- Consumer-facing shortcut: the Stage-3 pipeline closes the core goal `¬ BoundedDiscrepancy f`.
 
 We keep this lemma in the hard-gate core so `ErdosDiscrepancy.lean` can remain minimal.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Move stage3_g_eq_fun into the hard-gate Stage-3 entry core for symmetry with Stage 2.
- Remove the duplicate definition from TrackCStage3Entry so there is a single source of truth.
- Keeps the hard-gate import Conjectures.C0002_erdos_discrepancy.src.ErdosDiscrepancy unchanged while improving the core Stage-3 API.
