### PR TITLE
Track C: stage2_start modulo stage2_d

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Entry.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Entry.lean
@@ -79,6 +79,14 @@ theorem stage2_d_dvd_start (f : ℕ → ℤ) (hf : IsSignSequence f) :
   simpa [stage2_start] using
     (Nat.mul_comm (stage2_m (f := f) (hf := hf)) (stage2_d (f := f) (hf := hf)))
 
+/-- The affine-tail start index `stage2_start` has remainder `0` when reduced modulo `stage2_d`.
+
+This is often the most convenient form of `stage2_d_dvd_start` for arithmetic rewriting.
+-/
+theorem stage2_start_mod_d (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    stage2_start (f := f) (hf := hf) % stage2_d (f := f) (hf := hf) = 0 := by
+  exact Nat.mod_eq_zero_of_dvd (stage2_d_dvd_start (f := f) (hf := hf))
+
 /-- The reduced sequence produced by Stage 2 is a sign sequence. -/
 theorem stage2_hg (f : ℕ → ℤ) (hf : IsSignSequence f) :
     IsSignSequence (stage2_g (f := f) (hf := hf)) := by


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Added a small arithmetic convenience lemma: stage2_start mod stage2_d = 0.
- This packages the existing divisibility fact stage2_d_dvd_start into a form that is easy to rewrite with.
