### PR TITLE
Track C: stage3_start_mod_d

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
@@ -73,6 +73,14 @@ theorem stage3_d_dvd_start (f : ℕ → ℤ) (hf : IsSignSequence f) :
   -- `stage3_start` is definitionally `m*d`.
   simp [stage3_d, stage3_start, stage2_start]
 
+/-- The affine-tail start index `stage3_start` has remainder `0` when reduced modulo `stage3_d`.
+
+This is often the most convenient form of `stage3_d_dvd_start` for arithmetic rewriting.
+-/
+theorem stage3_start_mod_d (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    stage3_start (f := f) (hf := hf) % stage3_d (f := f) (hf := hf) = 0 := by
+  exact Nat.mod_eq_zero_of_dvd (stage3_d_dvd_start (f := f) (hf := hf))
+
 /-- The reduced sequence produced by Stage 3 is a sign sequence. -/
 theorem stage3_hg (f : ℕ → ℤ) (hf : IsSignSequence f) :
     IsSignSequence (stage3_g (f := f) (hf := hf)) := by


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add lemma stage3_start_mod_d: stage3_start % stage3_d = 0.
- Mirrors the existing Stage-2 entry-point lemma (stage2_start_mod_d) to make Stage-3 arithmetic rewriting easier.
