### PR TITLE
Track C: move discOffset NNF lemma to core

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/Tao2015.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/Tao2015.lean
@@ -426,6 +426,20 @@ theorem iff_not_exists_forall_natAbs_apSumOffset_le (f : ℕ → ℤ) (d m : ℕ
 
 end UnboundedDiscOffset
 
+/-- Normal form: unbounded offset discrepancy means there is no uniform `discOffset` bound.
+
+Negation-normal form:
+`¬ ∃ B, ∀ n, discOffset f d m n ≤ B`.
+
+This is the definitional `discOffset` rewrite of
+`UnboundedDiscOffset.iff_not_exists_forall_natAbs_apSumOffset_le`.
+-/
+theorem unboundedDiscOffset_iff_not_exists_forall_discOffset_le (f : ℕ → ℤ) (d m : ℕ) :
+    UnboundedDiscOffset f d m ↔ (¬ ∃ B : ℕ, ∀ n : ℕ, discOffset f d m n ≤ B) := by
+  -- Avoid simp loops: `discOffset` is definitional.
+  simpa [discOffset, -natAbs_apSumOffset_eq_discOffset] using
+    (UnboundedDiscOffset.iff_not_exists_forall_natAbs_apSumOffset_le (f := f) (d := d) (m := m))
+
 /-- Preferred naming for the core lemma
 `MoltResearch.not_exists_boundedDiscOffset_iff_forall_exists_discOffset_lt`.
 

--- a/Conjectures/C0002_erdos_discrepancy/src/Tao2015Extras.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/Tao2015Extras.lean
@@ -148,19 +148,7 @@ theorem unboundedDiscOffset_iff_not_exists_forall_natAbs_apSumOffset_le (f : ℕ
   simpa [BoundedDiscOffset, discOffset, -natAbs_apSumOffset_eq_discOffset] using
     (Tao2015.unboundedDiscOffset_iff_not_exists_boundedDiscOffset (f := f) (d := d) (m := m))
 
-/-- Normal form: unbounded offset discrepancy means there is no uniform `discOffset` bound.
-
-Negation-normal form:
-`¬ ∃ B, ∀ n, discOffset f d m n ≤ B`.
-
-This is `unboundedDiscOffset_iff_not_exists_forall_natAbs_apSumOffset_le` rewritten using the
-(definitional) equality `discOffset f d m n = Int.natAbs (apSumOffset f d m n)`.
--/
-theorem unboundedDiscOffset_iff_not_exists_forall_discOffset_le (f : ℕ → ℤ) (d m : ℕ) :
-    UnboundedDiscOffset f d m ↔ (¬ ∃ B : ℕ, ∀ n : ℕ, discOffset f d m n ≤ B) := by
-  -- Avoid simp loops: `discOffset` is definitional.
-  simpa [discOffset, -natAbs_apSumOffset_eq_discOffset] using
-    (unboundedDiscOffset_iff_not_exists_forall_natAbs_apSumOffset_le (f := f) (d := d) (m := m))
+-- moved to `Conjectures.C0002_erdos_discrepancy.src.Tao2015` (core interface)
 
 /-- Normal form: unbounded offset discrepancy means there is no uniform affine-tail nucleus bound.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Moved the unboundedDiscOffset negation-normal-form lemma for discOffset (no uniform bound) into the core Tao2015 interface file.
- Left Tao2015Extras as thin convenience glue, with a pointer to the core location.
