### PR TITLE
Track C: trim Stage2Light import

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Entry.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Entry.lean
@@ -9,8 +9,8 @@ It contains only:
 - the Stage-2 conjecture stub (axiom) `stage2`,
 - the deterministic name `stage2Out`,
 - the lightweight projections `stage2_d`, `stage2_g`, `stage2_m`, `stage2_start`, and
-- the tiny projection lemmas `stage2_d_pos`, `stage2_one_le_d`, `stage2_d_ne_zero`, `stage2_hg`,
-  `stage2_g_eq`, `stage2_g_eq_fun`.
+- the tiny projection lemmas `stage2_d_pos`, `stage2_one_le_d`, `stage2_d_ne_zero`,
+  `stage2_d_dvd_start`, `stage2_start_mod_d`, `stage2_hg`, `stage2_g_eq`, `stage2_g_eq_fun`.
 
 All other proved convenience lemmas about `stage2Out` live in
 `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Proof`.

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Light.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Light.lean
@@ -1,5 +1,4 @@
 import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Entry
-import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Boundary
 import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Proof
 
 /-!


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Trim a redundant Stage2Boundary import from TrackCStage2Light (still re-exported via TrackCStage2Entry).
- Update the TrackCStage2Entry module header to list the start-index lemmas now present in the file.
