### PR TITLE
Track C: Stage 3 reuses Stage-2 bridge lemmas

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
@@ -1,4 +1,4 @@
-import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Boundary
+import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Core
 
 /-!
 # Track C: Stage 3 boundary (Tao 2015 plane)
@@ -41,8 +41,8 @@ output (via `ReductionOutput.not_boundedDiscrepancy_of_unboundedDiscrepancyAlong
 does not need to import the larger Stage-2 convenience-lemma layer.
 -/
 theorem notBounded (out : Stage3Output f) : ¬ BoundedDiscrepancy f := by
-  exact
-    out.out2.out1.not_boundedDiscrepancy_of_unboundedDiscrepancyAlong (f := f) out.out2.unbounded
+  -- Delegate to the canonical Stage-2 “bridge back to the global statement” lemma.
+  exact out.out2.notBoundedOriginal (f := f)
 
 /-- Deterministic Stage-3 completion: a Stage-2 output already contains enough information to
 contradict any global boundedness hypothesis.
@@ -58,9 +58,8 @@ We keep this lemma in the hard-gate module so `ErdosDiscrepancy.lean` can remain
 -/
 theorem forall_hasDiscrepancyAtLeast (out : Stage3Output f) :
     ∀ C : ℕ, HasDiscrepancyAtLeast f C := by
-  -- Route through the global normal form lemma from `MoltResearch.Discrepancy.Unbounded`.
-  refine (forall_hasDiscrepancyAtLeast_iff_not_boundedDiscrepancy f).2 ?_
-  exact out.notBounded (f := f)
+  -- Reuse the Stage-2 surface lemma rather than re-proving it.
+  exact out.out2.forall_hasDiscrepancyAtLeast (f := f)
 
 end Stage3Output
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Stage 3 now imports the minimal Stage-2 core module instead of the Stage-2 boundary record alone.
- Reuse the canonical Stage-2 bridge lemmas for the global conclusion (not bounded discrepancy) and for the surface statement forall C, HasDiscrepancyAtLeast f C.
