### PR TITLE
Track C: simp for d_dvd_start

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
@@ -53,7 +53,7 @@ abbrev start (out : Stage2Output f) : ℕ := out.m * out.d
 /-- The affine-tail start index `out.start` is a multiple of the reduced step size `out.d`. -/
 theorem d_dvd_start (out : Stage2Output f) : out.d ∣ out.start := by
   -- `out.start` is definitionally `m*d`.
-  simpa [Stage2Output.start] using (Nat.dvd_mul_left out.d out.m)
+  simp [Stage2Output.start]
 
 /-- The affine-tail start index `out.start` has remainder `0` when reduced modulo `out.d`.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- In TrackCStage2Core, replace simpa with simp in Stage2Output.d_dvd_start.
- Same statement, smaller proof term, and removes the unnecessarySimpa linter warning in Conjectures.
