### PR TITLE
Track C: lighten Stage-3 entry wrappers

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Entry.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Entry.lean
@@ -1,5 +1,4 @@
 import Conjectures.C0002_erdos_discrepancy.src.TrackCStage3EntryCore
-import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Output
 
 /-!
 # Track C: Stage 3 entry point (Tao 2015 plane)
@@ -11,6 +10,10 @@ This file is **Conjectures-only** glue.
 - This file keeps additional Stage-3 convenience wrappers available under the traditional import
   `...TrackCStage3Entry` without forcing the hard-gate target to compile them.
 
+Design note: this module is intentionally lightweight. Most witness-form corollaries can be
+obtained from the hard-gate lemma `stage3_forall_hasDiscrepancyAtLeast` together with global
+normal-form equivalences, so we avoid importing the larger Stage-2 convenience-lemma library.
+
 Additional convenience lemmas and witness-form wrappers also live in
 `Conjectures.C0002_erdos_discrepancy.src.TrackCStage3Proof`.
 -/
@@ -21,67 +24,64 @@ namespace Tao2015
 
 -- (core API lives in `TrackCStage3EntryCore.lean`)
 
--- Note: `stage3_g_eq_fun` now lives in `TrackCStage3EntryCore.lean` so hard-gate consumers
+-- Note: `stage3_g_eq_fun` lives in `TrackCStage3EntryCore.lean` so hard-gate consumers
 -- can use it without importing this larger convenience-lemma module.
 
 /-- Consumer-facing shortcut: Stage 3 yields the nucleus witness form
 
 `∀ C, ∃ d n, d ≥ 1 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C`.
 
-This is a thin wrapper around the proved Stage-2 lemma
-`Stage2Output.forall_exists_d_ge_one_witness_pos`.
+This is a thin wrapper around the hard-gate lemma `stage3_forall_hasDiscrepancyAtLeast` via the
+global normal form lemma `forall_hasDiscrepancyAtLeast_iff_forall_exists_d_ge_one_witness_pos`.
 -/
 theorem stage3_forall_exists_d_ge_one_witness_pos (f : ℕ → ℤ) (hf : IsSignSequence f) :
     ∀ C : ℕ, ∃ d n : ℕ, d ≥ 1 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C := by
-  -- Stage 3 is just glue on top of Stage 2, so route through the Stage-2 lemma.
   exact
-    Stage2Output.forall_exists_d_ge_one_witness_pos (f := f) (stage2Out (f := f) (hf := hf))
+    (forall_hasDiscrepancyAtLeast_iff_forall_exists_d_ge_one_witness_pos f).1
+      (stage3_forall_hasDiscrepancyAtLeast (f := f) (hf := hf))
 
-/-- Consumer-facing shortcut: Stage 3 yields the nucleus witness form with strict positivity
-for the step size:
+/-- Variant of `stage3_forall_exists_d_ge_one_witness_pos` with strict positivity for the step size.
 
+Normal form:
 `∀ C, ∃ d n, d > 0 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C`.
-
-This is a thin wrapper around the proved Stage-2 lemma
-`Stage2Output.forall_exists_d_pos_witness_pos`.
 -/
 theorem stage3_forall_exists_d_pos_witness_pos (f : ℕ → ℤ) (hf : IsSignSequence f) :
     ∀ C : ℕ, ∃ d n : ℕ, d > 0 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C := by
-  -- Stage 3 is just glue on top of Stage 2, so route through the Stage-2 lemma.
-  exact Stage2Output.forall_exists_d_pos_witness_pos (f := f) (stage2Out (f := f) (hf := hf))
+  intro C
+  rcases stage3_forall_exists_d_ge_one_witness_pos (f := f) (hf := hf) C with
+    ⟨d, n, hd, hn, hw⟩
+  refine ⟨d, n, ?_, hn, hw⟩
+  exact lt_of_lt_of_le Nat.zero_lt_one hd
 
-/-- Consumer-facing shortcut: Stage 3 yields the nucleus witness form with the step-size condition
-written as `d ≠ 0`:
-
-`∀ C, ∃ d n, d ≠ 0 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C`.
-
-This is a thin wrapper around the proved Stage-2 lemma
-`Stage2Output.forall_exists_d_ne_zero_witness_pos`.
+/-- Variant of `stage3_forall_exists_d_pos_witness_pos` with the step-size condition written as
+`d ≠ 0`.
 -/
 theorem stage3_forall_exists_d_ne_zero_witness_pos (f : ℕ → ℤ) (hf : IsSignSequence f) :
     ∀ C : ℕ, ∃ d n : ℕ, d ≠ 0 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C := by
-  -- Stage 3 is just glue on top of Stage 2, so route through the Stage-2 lemma.
-  exact
-    Stage2Output.forall_exists_d_ne_zero_witness_pos (f := f) (stage2Out (f := f) (hf := hf))
+  intro C
+  rcases stage3_forall_exists_d_pos_witness_pos (f := f) (hf := hf) C with
+    ⟨d, n, hd, hn, hw⟩
+  exact ⟨d, n, Nat.ne_of_gt hd, hn, hw⟩
 
 /-- Consumer-facing shortcut: Stage 3 yields the discrepancy witness form
 
 `∀ C, ∃ d n, d > 0 ∧ discrepancy f d n > C`.
 
-This is a thin wrapper around the proved Stage-2 lemma
-`Stage2Output.forall_exists_discrepancy_gt_original`.
+This is obtained from `stage3_forall_hasDiscrepancyAtLeast` via
+`HasDiscrepancyAtLeast_iff_exists_discrepancy`.
 -/
 theorem stage3_forall_exists_discrepancy_gt (f : ℕ → ℤ) (hf : IsSignSequence f) :
     ∀ C : ℕ, ∃ d n : ℕ, d > 0 ∧ discrepancy f d n > C := by
+  intro C
   exact
-    Stage2Output.forall_exists_discrepancy_gt_original (f := f) (stage2Out (f := f) (hf := hf))
+    (HasDiscrepancyAtLeast_iff_exists_discrepancy (f := f) (C := C)).1
+      ((stage3_forall_hasDiscrepancyAtLeast (f := f) (hf := hf)) C)
 
 /-- Consumer-facing shortcut: Stage 3 yields unboundedness of the bundled offset discrepancy family
 `discOffset f d m` at the deterministic parameters produced by the pipeline.
 
-We keep this lemma in the `...TrackCStage3Entry` import path (rather than in the proof-heavy
-wrapper module) so consumers can access the offset witness without importing
-`TrackCStage3Proof`.
+We keep this lemma in the `...TrackCStage3Entry` import path so consumers can access the offset
+witness without importing `TrackCStage3Proof`.
 -/
 theorem stage3_unboundedDiscOffset (f : ℕ → ℤ) (hf : IsSignSequence f) :
     UnboundedDiscOffset f (stage3_d (f := f) (hf := hf)) (stage3_m (f := f) (hf := hf)) := by
@@ -96,16 +96,20 @@ witness.
 Normal form:
 `∀ B, ∃ n, n > 0 ∧ discOffset f (stage3_d ...) (stage3_m ...) n > B`.
 
-This is a thin wrapper around the proved Stage-2 lemma
-`Stage2Output.forall_exists_discOffset_gt'_witness_pos`.
+This is a thin wrapper around the generic normal-form lemma
+`UnboundedDiscOffset.forall_exists_discOffset_gt'_witness_pos`.
 -/
 theorem stage3_forall_exists_discOffset_gt'_witness_pos (f : ℕ → ℤ) (hf : IsSignSequence f) :
     ∀ B : ℕ,
       ∃ n : ℕ,
         n > 0 ∧
           discOffset f (stage3_d (f := f) (hf := hf)) (stage3_m (f := f) (hf := hf)) n > B := by
-  simpa [stage3_d, stage3_m, stage2_d, stage2_m] using
-    (Stage2Output.forall_exists_discOffset_gt'_witness_pos (f := f) (stage2Out (f := f) (hf := hf)))
+  have hunb :
+      UnboundedDiscOffset f (stage3_d (f := f) (hf := hf)) (stage3_m (f := f) (hf := hf)) :=
+    stage3_unboundedDiscOffset (f := f) (hf := hf)
+  exact
+    UnboundedDiscOffset.forall_exists_discOffset_gt'_witness_pos (f := f)
+      (d := stage3_d (f := f) (hf := hf)) (m := stage3_m (f := f) (hf := hf)) hunb
 
 /-- Existential packaging: Stage 3 yields concrete parameters `d, m` with `d > 0` such that the
 bundled offset discrepancy family `discOffset f d m` is unbounded.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Make TrackCStage3Entry leaner by dropping the large Stage-2 convenience import and deriving witness-form wrappers from the hard-gate Stage-3 statement plus global normal-form lemmas.
- Reprove the offset discOffset witness-pos wrapper directly from stage3_unboundedDiscOffset via generic UnboundedDiscOffset normal forms.
- Keeps the hard-gate surface unchanged while tightening the Stage-3 convenience layer dependencies.
