### PR TITLE
Track C: witness-pos packaging for sum_Icc offset

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancyWitnesses.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancyWitnesses.lean
@@ -202,6 +202,19 @@ theorem erdos_discrepancy_exists_params_forall_exists_natAbs_sum_Icc_offset_gt (
     (Tao2015.Stage2Output.exists_params_forall_exists_natAbs_sum_Icc_offset_gt (f := f)
       (Tao2015.stage3Out (f := f) (hf := hf)).out2)
 
+/-- Positive-length witness form of `erdos_discrepancy_exists_params_forall_exists_natAbs_sum_Icc_offset_gt`.
+
+The witness length `n` cannot be `0`, since the interval `Icc (m+1) (m+n)` is empty when `n = 0`.
+-/
+theorem erdos_discrepancy_exists_params_forall_exists_natAbs_sum_Icc_offset_gt_witness_pos
+    (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    ∃ d m : ℕ, d > 0 ∧
+      (∀ B : ℕ, ∃ n : ℕ, n > 0 ∧
+        Int.natAbs ((Finset.Icc (m + 1) (m + n)).sum (fun i => f (i * d))) > B) := by
+  simpa using
+    (Tao2015.Stage2Output.exists_params_forall_exists_natAbs_sum_Icc_offset_gt_witness_pos (f := f)
+      (Tao2015.stage3Out (f := f) (hf := hf)).out2)
+
 /-- Variant of `erdos_discrepancy_exists_params_forall_exists_natAbs_sum_Icc_offset_gt` packaging the
 step-size side condition as `1 ≤ d`.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add positive-length witness packaging lemma for paper-notation offset sums in ErdosDiscrepancyWitnesses.
- Delegates to the existing Stage-2 packaging lemma, so downstream consumers can demand n > 0.
