### PR TITLE
Track C: derive surface statement from notBounded

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
@@ -29,13 +29,15 @@ theorem erdos_discrepancy_notBounded (f : ℕ → ℤ) (hf : IsSignSequence f) :
 
 Every ±1 sequence has unbounded discrepancy on homogeneous arithmetic progressions.
 
-This is the usual surface statement `∀ C, HasDiscrepancyAtLeast f C` exposed directly from the
-Track-C Stage-3 pipeline.
+This is the usual surface statement `∀ C, HasDiscrepancyAtLeast f C` derived from the core
+Track-C output `¬ BoundedDiscrepancy f`.
 -/
 theorem erdos_discrepancy (f : ℕ → ℤ) (hf : IsSignSequence f) :
     ∀ C : ℕ, HasDiscrepancyAtLeast f C := by
-  -- Prefer consuming the Stage-3 entry-point API.
-  exact Tao2015.stage3_forall_hasDiscrepancyAtLeast (f := f) (hf := hf)
+  -- Route the surface statement through the verified equivalence
+  -- `∀ C, HasDiscrepancyAtLeast f C ↔ ¬ BoundedDiscrepancy f`.
+  refine (forall_hasDiscrepancyAtLeast_iff_not_boundedDiscrepancy f).2 ?_
+  exact erdos_discrepancy_notBounded (f := f) (hf := hf)
 
 /-!
 Additional witness-form corollaries live in


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Prove erdos_discrepancy via the core Track-C statement erdos_discrepancy_notBounded using the standard equivalence with global bounded discrepancy.
- Keeps the surface theorem downstream of the not-bounded normal form, so the core output remains the single source of truth.
