### PR TITLE
Track C: stage2_start_div_d lemma

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Entry.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Entry.lean
@@ -97,6 +97,18 @@ theorem stage2_start_mod_d (f : ℕ → ℤ) (hf : IsSignSequence f) :
     stage2_start (f := f) (hf := hf) % stage2_d (f := f) (hf := hf) = 0 := by
   exact Nat.mod_eq_zero_of_dvd (stage2_d_dvd_start (f := f) (hf := hf))
 
+/-- Recover the bundled offset parameter `stage2_m` by dividing the start index `stage2_start`
+by the step size `stage2_d`.
+
+This is a tiny arithmetic convenience lemma: `stage2_start = stage2_m * stage2_d` by definition.
+-/
+theorem stage2_start_div_d (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    stage2_start (f := f) (hf := hf) / stage2_d (f := f) (hf := hf) =
+      stage2_m (f := f) (hf := hf) := by
+  -- `stage2_d_pos` is the only side condition needed for `Nat.mul_div_left`.
+  simpa [stage2_start] using
+    (Nat.mul_div_left (stage2_m (f := f) (hf := hf)) (stage2_d_pos (f := f) (hf := hf)))
+
 /-- The reduced sequence produced by Stage 2 is a sign sequence. -/
 theorem stage2_hg (f : ℕ → ℤ) (hf : IsSignSequence f) :
     IsSignSequence (stage2_g (f := f) (hf := hf)) := by


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a tiny arithmetic convenience lemma stage2_start_div_d: stage2_start / stage2_d = stage2_m.
- This keeps Stage 2 entry-point glue self-contained while making downstream rewrites around the m*d start index cleaner.
