### PR TITLE
Discrepancy: discOffset as natAbs of apSum difference

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -78,6 +78,10 @@ example : apSumFrom f a d (m + n) - apSumFrom f a d m = apSumOffset (fun k => f 
 example : Int.natAbs (apSumOffset f d m n) = discOffset f d m n := by
   simp [discOffset]
 
+-- (3.5) Canonical “difference of partial sums” normal form (discOffset) (Track B backlog item).
+example : discOffset f d m n = Int.natAbs (apSum f d (m + n) - apSum f d m) := by
+  simpa using (discOffset_eq_natAbs_apSum_sub (f := f) (d := d) (m := m) (n := n))
+
 /-!
 ### Regression: paper↔nucleus endpoint bridge simp wrappers (Track B)
 

--- a/MoltResearch/Discrepancy/Offset.lean
+++ b/MoltResearch/Discrepancy/Offset.lean
@@ -1126,6 +1126,21 @@ lemma apSum_sub_eq_apSumOffset (f : ℕ → ℤ) (d m n : ℕ) :
     apSum f d (m + n) - apSum f d m = apSumOffset f d m n := by
   simpa using (apSumOffset_eq_sub (f := f) (d := d) (m := m) (n := n)).symm
 
+/-- Canonical “difference of partial sums” normal form for `discOffset`.
+
+This is the `discOffset` wrapper around `apSum_sub_eq_apSumOffset`, oriented so rewriting turns
+`discOffset` into the natural absolute value of a two-sum difference.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — “Canonical difference of partial sums
+normal form (discOffset)”.
+-/
+lemma discOffset_eq_natAbs_apSum_sub (f : ℕ → ℤ) (d m n : ℕ) :
+    discOffset f d m n = Int.natAbs (apSum f d (m + n) - apSum f d m) := by
+  unfold discOffset
+  have h : apSumOffset f d m n = apSum f d (m + n) - apSum f d m := by
+    simpa using (apSum_sub_eq_apSumOffset (f := f) (d := d) (m := m) (n := n)).symm
+  simpa [h]
+
 /-- Rewrite the normal-form difference `apSum f d (m+n) - apSum f d m` as an interval sum
 `∑ i ∈ Icc (m+1) (m+n), f (i*d)`.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Canonical “difference of partial sums” normal form (discOffset): add an exported lemma rewriting

Adds `discOffset_eq_natAbs_apSum_sub` (in `MoltResearch/Discrepancy/Offset.lean`), rewriting
`discOffset f d m n` into `Int.natAbs (apSum f d (m+n) - apSum f d m)` via `apSum_sub_eq_apSumOffset`.

Also adds a stable-surface regression example under `import MoltResearch.Discrepancy` in
`MoltResearch/Discrepancy/NormalFormExamples.lean`.
