### PR TITLE
Track B: mark discOffset partial-sum-difference normal form done

### DIFF
--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -300,9 +300,10 @@ Goal: build a *directed* lemma scaffold (not lemma-sprawl). Each checkbox should
 
 #### Auto-generated backlog (needs triage)
 
-- [ ] Canonical “difference of partial sums” normal form (discOffset): add an exported lemma rewriting
+- [x] Canonical “difference of partial sums” normal form (discOffset): add an exported lemma rewriting
   `discOffset f d m n` into `Int.natAbs (apSum f d (m+n) - apSum f d m)` (and/or the paper `∑ i ∈ Icc …` difference),
   so later stages can switch between nucleus `discOffset` and a plain two-sum form without unfolding definitions.
+  (Implemented as `discOffset_eq_natAbs_apSum_sub` in `MoltResearch/Discrepancy/Offset.lean`; stable-surface regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
 - [ ] `discOffsetUpTo` triangle/subadditivity (shift-aware): prove a packaged inequality like
   `discOffsetUpTo f d m (N+K) ≤ discOffsetUpTo f d m N + discOffsetUpTo f d (m+N) K`,


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Canonical “difference of partial sums” normal form (discOffset)

This PR marks the Track B checklist item complete, pointing to the existing exported lemma:
- `discOffset_eq_natAbs_apSum_sub` (in `MoltResearch/Discrepancy/Offset.lean`)

Regression coverage already exists in:
- `MoltResearch/Discrepancy/NormalFormExamples.lean`
