### PR TITLE
Track B: boundedDiscOffset ↔ discOffsetUpTo bound

### DIFF
--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -808,6 +808,31 @@ theorem boundedDiscOffset_iff_forall_discOffset_le (f : ℕ → ℤ) (d m B : �
     BoundedDiscOffset f d m B ↔ ∀ n : ℕ, discOffset f d m n ≤ B :=
   Iff.rfl
 
+/-- `BoundedDiscOffset f d m B` is equivalent to a uniform bound on the finitary maxima
+`discOffsetUpTo f d m N`.
+
+This is the main bridge lemma that lets downstream code turn a “∀ n” boundedness hypothesis into
+an `UpTo` bound (and conversely) without unfolding definitions.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — Boundedness ↔ `discOffsetUpTo` growth bound.
+-/
+theorem boundedDiscOffset_iff_forall_discOffsetUpTo_le (f : ℕ → ℤ) (d m B : ℕ) :
+    BoundedDiscOffset f d m B ↔ ∀ N : ℕ, discOffsetUpTo f d m N ≤ B := by
+  constructor
+  · intro h N
+    classical
+    unfold discOffsetUpTo
+    refine Finset.sup_le ?_
+    intro n hn
+    -- Every term in the `sup` is bounded by `B`.
+    exact h n
+  · intro h n
+    -- Specialize the `UpTo` bound at `N = n` and use the pointwise ≤ max lemma.
+    have hUpTo : discOffsetUpTo f d m n ≤ B := h n
+    have hle : discOffset f d m n ≤ discOffsetUpTo f d m n :=
+      discOffset_le_discOffsetUpTo (f := f) (d := d) (m := m) (n := n) (N := n) (by rfl)
+    exact le_trans hle hUpTo
+
 /-!
 ### Exists-bound normal form
 

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -317,6 +317,12 @@ example (hf : IsSignSequence f) :
     discOffsetUpTo f d m (n₁ + n₂) ≤ discOffsetUpTo f d m n₁ + n₂ := by
   simpa using (discOffsetUpTo_add_le (f := f) (hf := hf) (d := d) (m := m) (N := n₁) (K := n₂))
 
+-- Regression (Track B / boundedness ↔ `discOffsetUpTo` growth bound):
+-- a uniform pointwise bound is equivalent to bounding all `UpTo` maxima.
+example (B : ℕ) :
+    BoundedDiscOffset f d m B ↔ ∀ N : ℕ, discOffsetUpTo f d m N ≤ B := by
+  simpa using (boundedDiscOffset_iff_forall_discOffsetUpTo_le (f := f) (d := d) (m := m) (B := B))
+
 -- Regression (Track B / concatenation inequality for `discOffsetUpTo`): a sharper bound that
 -- isolates the tail segment.
 example :


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Boundedness ↔ `discOffsetUpTo` growth bound

Adds a stable bridge lemma:
- `boundedDiscOffset_iff_forall_discOffsetUpTo_le`:
  `BoundedDiscOffset f d m B ↔ ∀ N, discOffsetUpTo f d m N ≤ B`

Also adds a compile-only stable-surface regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.

CI: `make ci`