### PR TITLE
Discrepancy: UpTo simp/coherence (degenerate params)

### DIFF
--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -513,6 +513,39 @@ This is packaged in a finitary form (a `Finset.sup` over `range (N+1)`) so it is
 def discOffsetUpTo (f : ℕ → ℤ) (d m N : ℕ) : ℕ :=
   (Finset.range (N + 1)).sup (fun n => discOffset f d m n)
 
+/-!
+### `UpTo` API coherence simp lemmas (degenerate parameters)
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — Stable surface coherence for `UpTo` API.
+
+These are deliberately small and oriented for `simp`:
+- normalize away a spurious `m = 0` offset
+- compute the degenerate cutoff `N = 0`
+
+We are conservative here: these lemmas should be obviously terminating and orientation-safe.
+-/
+
+/-- `discUpTo` at cutoff `N = 0` is just `disc f d 0 = 0`. -/
+@[simp] lemma discUpTo_zero (f : ℕ → ℤ) (d : ℕ) : discUpTo f d 0 = 0 := by
+  classical
+  simp [discUpTo]
+
+/-- `discOffsetUpTo` at cutoff `N = 0` is just `discOffset f d m 0 = 0`. -/
+@[simp] lemma discOffsetUpTo_zero (f : ℕ → ℤ) (d m : ℕ) : discOffsetUpTo f d m 0 = 0 := by
+  classical
+  -- `range (0+1)` is the singleton `{0}`.
+  unfold discOffsetUpTo
+  -- Reduce to `discOffset f d m 0 = 0` by computation.
+  simp [discOffset, apSumOffset]
+
+/-- Coherence: a spurious `m = 0` offset in `discOffsetUpTo` normalizes to `discUpTo`. -/
+@[simp] lemma discOffsetUpTo_zero_start (f : ℕ → ℤ) (d N : ℕ) :
+    discOffsetUpTo f d 0 N = discUpTo f d N := by
+  classical
+  unfold discOffsetUpTo discUpTo
+  -- `discOffset f d 0 n` is definitionally `disc f d n`.
+  simp [discOffset, disc, apSumOffset, apSum]
+
 /-- Any particular `disc f d n` with `n ≤ N` is bounded by `discUpTo f d N`.
 
 Checklist item: Problems/erdos_discrepancy.md (Track B) — “Max discrepancy up to N” API.

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -199,6 +199,10 @@ example : discUpTo f d 0 = 0 := by
 example : discOffsetUpTo f d 0 n = discUpTo f d n := by
   simp
 
+-- Common special case: `d = 1`.
+example : discOffsetUpTo f 1 0 n = discUpTo f 1 n := by
+  simp
+
 -- Micro-pipeline: bound a particular tail discrepancy by an `UpTo` bound.
 example (N : ℕ) (hn : n ≤ N) : discOffset f d 0 n ≤ discUpTo f d N := by
   simpa using (discOffset_le_discOffsetUpTo (f := f) (d := d) (m := 0) (n := n) (N := N) hn)

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -185,6 +185,24 @@ example (q : ℕ) (hq : q > 0) (hd : q ∣ d) :
 example : apSumOffset f d 0 n = apSum f d n := by
   simp
 
+/-!
+### NEW (Track B): `UpTo` API coherence (degenerate parameters + micro-pipeline)
+
+These compile-only examples ensure the stable-surface `UpTo` wrappers stay easy to use.
+-/
+
+-- Degenerate cutoff: `N = 0`.
+example : discUpTo f d 0 = 0 := by
+  simp
+
+-- Coherence: `m = 0` offset normalizes away under `UpTo`.
+example : discOffsetUpTo f d 0 n = discUpTo f d n := by
+  simp
+
+-- Micro-pipeline: bound a particular tail discrepancy by an `UpTo` bound.
+example (N : ℕ) (hn : n ≤ N) : discOffset f d 0 n ≤ discUpTo f d N := by
+  simpa using (discOffset_le_discOffsetUpTo (f := f) (d := d) (m := 0) (n := n) (N := N) hn)
+
 -- Regression (Track B / homogeneous view of offsets): push the offset `m*d` into the summand.
 example : apSumOffset f d m n = apSum (fun k => f (k + m * d)) d n := by
   simpa using (apSumOffset_eq_apSum_shift_mul (f := f) (d := d) (m := m) (n := n))


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Stable surface coherence for `UpTo` API: add a minimal simp lemma set normalizing degenerate parameters for

What this PR does
- Adds small `[simp]`/coherence lemmas for `discUpTo` / `discOffsetUpTo`:
  - `discUpTo f d 0 = 0`
  - `discOffsetUpTo f d m 0 = 0`
  - `discOffsetUpTo f d 0 N = discUpTo f d N`
- Adds stable-surface compile-only regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean` exercising:
  - degenerate cutoff `N=0`
  - `m=0` coherence under `UpTo`
  - bounding a particular `discOffset` by an `UpTo` bound

Notes
- This implements the Track B checkbox whose text is line-wrapped in the card file; CI expects the first-line checkbox text verbatim.
- No new opportunistic lemmas outside the Track B item; `[simp]` additions are conservative and orientation-safe.