### PR TITLE
Discrepancy: constant-sequence computed sanity checks

### DIFF
--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -491,6 +491,16 @@ It is defined as the natural absolute value of `apSumOffset f d m n`.
 def discOffset (f : ℕ → ℤ) (d m n : ℕ) : ℕ :=
   Int.natAbs (apSumOffset f d m n)
 
+/-- `discOffset` on a constant sequence computes to `|n * c|` (independent of the offset `m` and step `d`).
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) —
+“Constant/periodic sequence sanity checks: explicit computed examples for `apSum`/`discOffset`”.
+-/
+lemma discOffset_const (c : ℤ) (d m n : ℕ) :
+    discOffset (fun _ => c) d m n = Int.natAbs ((n : ℤ) * c) := by
+  unfold discOffset apSumOffset
+  simp [mul_comm, mul_left_comm, mul_assoc]
+
 /-!
 ### Discrepancy up to a finite length
 

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -25,6 +25,19 @@ section NormalFormExamples
 variable (f : ℕ → ℤ) (a b d k m n n₁ n₂ p C : ℕ)
 
 /-!
+### NEW (Track B): constant-sequence sanity checks (`apSum`/`discOffset`)
+
+These are explicit computed examples that should remain one-line `simp`/`simpa` proofs under the
+stable surface `import MoltResearch.Discrepancy`.
+-/
+
+example : apSum (fun _ => (1 : ℤ)) d n = (n : ℤ) := by
+  simp
+
+example : discOffset (fun _ => (1 : ℤ)) d m n = n := by
+  simpa [discOffset_const] 
+
+/-!
 ### NEW (Track B): micro-pipeline “starter scripts”
 
 These are 2–3 minimal compile-only examples showing the common workflow:


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Constant/periodic sequence sanity checks: add one or two explicit computed examples (as lemmas) for `apSum`/`discOffset`

Adds a small computed sanity-check lemma for offset discrepancy on constant sequences:
- `discOffset_const`: `discOffset (fun _ => c) d m n = |(n:ℤ) * c|`

Also adds stable-surface regression examples (under `import MoltResearch.Discrepancy`) showing that:
- `apSum (fun _ => 1) d n` simplifies to `n`
- `discOffset (fun _ => 1) d m n` simplifies to `n`

CI: `make ci`