### PR TITLE
Track C: use Stage-3 surface lemma

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
@@ -34,10 +34,8 @@ Track-C output `¬ BoundedDiscrepancy f`.
 -/
 theorem erdos_discrepancy (f : ℕ → ℤ) (hf : IsSignSequence f) :
     ∀ C : ℕ, HasDiscrepancyAtLeast f C := by
-  -- Route the surface statement through the verified equivalence
-  -- `∀ C, HasDiscrepancyAtLeast f C ↔ ¬ BoundedDiscrepancy f`.
-  refine (forall_hasDiscrepancyAtLeast_iff_not_boundedDiscrepancy f).2 ?_
-  exact erdos_discrepancy_notBounded (f := f) (hf := hf)
+  -- Prefer consuming the Stage-3 entry-point API directly.
+  exact Tao2015.stage3_forall_hasDiscrepancyAtLeast (f := f) (hf := hf)
 
 /-!
 Additional witness-form corollaries live in


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Simplify erdos_discrepancy to consume the Stage-3 entry-point surface lemma directly.
- Keeps the hard-gate ErdosDiscrepancy module focused on API wiring rather than restating the Stage-3 derivation.
