### PR TITLE
Discrepancy: computed discOffset lemmas for constant ±1

### DIFF
--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -501,6 +501,24 @@ lemma discOffset_const (c : ℤ) (d m n : ℕ) :
   unfold discOffset apSumOffset
   simp [mul_comm, mul_left_comm, mul_assoc]
 
+/-- `discOffset` on the constant sequence `1` computes to `n`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) —
+“Constant/periodic sequence sanity checks: explicit computed examples for `apSum`/`discOffset`”.
+-/
+@[simp] lemma discOffset_const_one (d m n : ℕ) :
+    discOffset (fun _ => (1 : ℤ)) d m n = n := by
+  simpa [discOffset_const]
+
+/-- `discOffset` on the constant sequence `-1` also computes to `n`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) —
+“Constant/periodic sequence sanity checks: explicit computed examples for `apSum`/`discOffset`”.
+-/
+@[simp] lemma discOffset_const_neg_one (d m n : ℕ) :
+    discOffset (fun _ => (-1 : ℤ)) d m n = n := by
+  simpa [discOffset_const]
+
 /-!
 ### Discrepancy up to a finite length
 

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -35,7 +35,7 @@ example : apSum (fun _ => (1 : ℤ)) d n = (n : ℤ) := by
   simp
 
 example : discOffset (fun _ => (1 : ℤ)) d m n = n := by
-  simpa [discOffset_const] 
+  simpa [discOffset_const_one]
 
 /-!
 ### NEW (Track B): micro-pipeline “starter scripts”


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Constant/periodic sequence sanity checks: add one or two explicit computed examples (as lemmas) for `apSum`/`discOffset`

This PR adds stable-surface computed lemmas:
- `discOffset_const_one` (`discOffset (fun _ => 1) ... = n`)
- `discOffset_const_neg_one` (`discOffset (fun _ => -1) ... = n`)

and updates `NormalFormExamples.lean` to use the new lemma (regression under `import MoltResearch.Discrepancy`).
