### PR TITLE
Discrepancy: periodic sanity-check examples

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -38,6 +38,21 @@ example : discOffset (fun _ => (1 : ℤ)) d m n = n := by
   simpa [discOffset_const_one]
 
 /-!
+Periodic (non-constant) sanity check: the alternating sign sequence has period 2.
+
+When the step `d` is even, the sampled indices are all even, so the sequence restricts to the
+constant `1` sequence and the discrepancy reduces to the constant-sequence computation.
+-/
+
+example : apSum (fun t : ℕ => if t % 2 = 0 then (1 : ℤ) else -1) 2 n = (n : ℤ) := by
+  -- Every sampled index is of the form `(i+1)*2`, hence even.
+  simp [apSum]
+
+example : discOffset (fun t : ℕ => if t % 2 = 0 then (1 : ℤ) else -1) 2 m n = n := by
+  -- Same idea for the offset progression: every sampled index is even.
+  simp [discOffset, apSumOffset]
+
+/-!
 ### NEW (Track B): micro-pipeline “starter scripts”
 
 These are 2–3 minimal compile-only examples showing the common workflow:


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Constant/periodic sequence sanity checks: add one or two explicit computed examples (as lemmas) for `apSum`/`discOffset`

Adds two compile-only regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean` for the alternating (period-2) sign sequence when sampling with even step `d = 2`:
- `apSum` computes to `(n : ℤ)`
- `discOffset` computes to `n`

These are meant to keep the stable-surface simp normal forms honest (periodic sequence reduces to constant-on-sampled-indices).
