### PR TITLE
Track C: stage3Out_out2 in hard-gate core

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Entry.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Entry.lean
@@ -28,17 +28,11 @@ namespace Tao2015
 These are just re-exports of the Stage-2 deterministic projections, since Stage 3 is definitional
 glue on top of the Stage-2 output.
 
-We keep them out of `TrackCStage3EntryCore.lean` to minimize the hard-gate compilation surface.
--/
+Most of them live outside `TrackCStage3EntryCore.lean` to minimize the hard-gate compilation surface.
 
-/-- The Stage-2 output stored inside `stage3Out` is definitionally the Stage-2 output produced by
-Stage 2.
-
-This lemma is tiny but useful for rewriting when shuttling statements between Stage 2 and Stage 3.
+(One tiny definitional rewrite lemma, `stage3Out_out2`, lives in the core module so consumers can
+access it without importing this larger convenience layer.)
 -/
-theorem stage3Out_out2 (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    (stage3Out (f := f) (hf := hf)).out2 = stage2Out (f := f) (hf := hf) := by
-  rfl
 
 /-- Convenience projection: the reduced step size produced by Stage 3. -/
 noncomputable abbrev stage3_d (f : ℕ → ℤ) (hf : IsSignSequence f) : ℕ :=

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
@@ -33,6 +33,18 @@ noncomputable def stage3 (f : ℕ → ℤ) (hf : IsSignSequence f) : Stage3Outpu
 noncomputable abbrev stage3Out (f : ℕ → ℤ) (hf : IsSignSequence f) : Stage3Output f :=
   stage3 (f := f) (hf := hf)
 
+/-- The Stage-2 output stored inside `stage3Out` is definitionally the Stage-2 output produced by
+Stage 2.
+
+This lemma is tiny but useful for rewriting when shuttling statements between Stage 2 and Stage 3.
+
+We keep it in the hard-gate core so consumers don't need to import the larger Stage-3 convenience
+layer `TrackCStage3Entry` just to access this definitional rewrite.
+-/
+theorem stage3Out_out2 (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    (stage3Out (f := f) (hf := hf)).out2 = stage2Out (f := f) (hf := hf) := by
+  rfl
+
 /-- Consumer-facing shortcut: the Stage-3 pipeline closes the core goal `¬ BoundedDiscrepancy f`.
 
 We keep this lemma in the hard-gate core so `ErdosDiscrepancy.lean` can remain minimal.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Move the tiny definitional rewrite lemma stage3Out_out2 into the hard-gate Stage 3 entry core.
- Keep the larger Stage 3 convenience layer unchanged, just removing the duplicate definition and updating the surrounding comment.
