### PR TITLE
Track C: slim Stage-2 entry surface

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Entry.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Entry.lean
@@ -97,17 +97,7 @@ theorem stage2_start_mod_d (f : ℕ → ℤ) (hf : IsSignSequence f) :
     stage2_start (f := f) (hf := hf) % stage2_d (f := f) (hf := hf) = 0 := by
   exact Nat.mod_eq_zero_of_dvd (stage2_d_dvd_start (f := f) (hf := hf))
 
-/-- Recover the bundled offset parameter `stage2_m` by dividing the start index `stage2_start`
-by the step size `stage2_d`.
-
-This is a tiny arithmetic convenience lemma: `stage2_start = stage2_m * stage2_d` by definition.
--/
-theorem stage2_start_div_d (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    stage2_start (f := f) (hf := hf) / stage2_d (f := f) (hf := hf) =
-      stage2_m (f := f) (hf := hf) := by
-  -- `stage2_d_pos` is the only side condition needed for `Nat.mul_div_left`.
-  simpa [stage2_start] using
-    (Nat.mul_div_left (stage2_m (f := f) (hf := hf)) (stage2_d_pos (f := f) (hf := hf)))
+-- (moved to `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2ProofCore`)
 
 /-- The reduced sequence produced by Stage 2 is a sign sequence. -/
 theorem stage2_hg (f : ℕ → ℤ) (hf : IsSignSequence f) :

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2ProofCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2ProofCore.lean
@@ -27,6 +27,18 @@ The Stage-2 conjecture stub (axiom) and the deterministic name `stage2Out` live 
 This file keeps only the core convenience wrappers.
 -/
 
+/-- Recover the bundled offset parameter `stage2_m` by dividing the start index `stage2_start`
+by the step size `stage2_d`.
+
+This is a tiny arithmetic convenience lemma: `stage2_start = stage2_m * stage2_d` by definition.
+-/
+theorem stage2_start_div_d (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    stage2_start (f := f) (hf := hf) / stage2_d (f := f) (hf := hf) =
+      stage2_m (f := f) (hf := hf) := by
+  -- `stage2_d_pos` is the only side condition needed for `Nat.mul_div_left`.
+  simpa [stage2_start] using
+    (Nat.mul_div_left (stage2_m (f := f) (hf := hf)) (stage2_d_pos (f := f) (hf := hf)))
+
 /-- Minimal consumer-facing Stage-2 consequence: the original sequence cannot have globally bounded
 (discrepancy) once Stage 2 produces an unbounded fixed-step witness along the reduced sequence. -/
 theorem stage2_notBounded (f : ℕ → ℤ) (hf : IsSignSequence f) : ¬ BoundedDiscrepancy f := by

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Entry.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Entry.lean
@@ -97,7 +97,9 @@ This is a tiny arithmetic convenience lemma: `stage3_start = stage3_m * stage3_d
 theorem stage3_start_div_d (f : ℕ → ℤ) (hf : IsSignSequence f) :
     stage3_start (f := f) (hf := hf) / stage3_d (f := f) (hf := hf) =
       stage3_m (f := f) (hf := hf) := by
-  simpa [stage3_start, stage3_d, stage3_m] using stage2_start_div_d (f := f) (hf := hf)
+  -- `stage3_d_pos` is the only side condition needed for `Nat.mul_div_left`.
+  simpa [stage3_start, stage3_m, stage3_d, stage2_start] using
+    (Nat.mul_div_left (stage3_m (f := f) (hf := hf)) (stage3_d_pos (f := f) (hf := hf)))
 
 /-- The reduced sequence produced by Stage 3 is a sign sequence. -/
 theorem stage3_hg (f : ℕ → ℤ) (hf : IsSignSequence f) :


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Moved the arithmetic helper stage2_start_div_d out of TrackCStage2Entry and into TrackCStage2ProofCore to keep the hard-gate Stage-2 entry surface thinner.
- Updated the Stage-3 convenience lemma stage3_start_div_d to prove the division identity directly, so Stage 3 no longer depends on that moved Stage-2 helper.
