### PR TITLE
Track C: stage3 no bounded discOffset

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Entry.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Entry.lean
@@ -205,6 +205,18 @@ theorem stage3_unboundedDiscOffset (f : ℕ → ℤ) (hf : IsSignSequence f) :
   simpa [stage3_d, stage3_m, stage2_d, stage2_m] using
     (Stage2Output.unboundedDiscOffset (f := f) (stage2Out (f := f) (hf := hf)))
 
+/-- Negation-normal-form: Stage 3 yields no uniform bound on the bundled offset discrepancy family
+`discOffset f d m` at the deterministic parameters produced by the pipeline.
+
+This is a thin wrapper around the Stage-2 core lemma
+`Stage2Output.not_exists_boundedDiscOffset`.
+-/
+theorem stage3_not_exists_boundedDiscOffset (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    ¬ ∃ B : ℕ,
+        BoundedDiscOffset f (stage3_d (f := f) (hf := hf)) (stage3_m (f := f) (hf := hf)) B := by
+  simpa [stage3_d, stage3_m, stage2_d, stage2_m, Stage2Output.d, Stage2Output.m] using
+    (Stage2Output.not_exists_boundedDiscOffset (f := f) (stage2Out (f := f) (hf := hf)))
+
 /-- Witness-family form of `stage3_unboundedDiscOffset` (inequality-direction), with a positive-length
 witness.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a Stage-3 convenience lemma giving the negation-normal-form no-uniform-bound statement for BoundedDiscOffset at the deterministic (d, m).
- Proof routes through the existing Stage-2 core lemma Stage2Output.not_exists_boundedDiscOffset, keeping the hard-gate surface unchanged.
