### PR TITLE
Track C: Stage 4 carries Stage 3 output

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage4.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage4.lean
@@ -3,14 +3,18 @@ import Conjectures.C0002_erdos_discrepancy.src.TrackCStage3EntryCore
 /-!
 # Track C — Stage 4 (stub)
 
-Stage 4 is the first place we want to carry a *real proof obligation* (not just packaging).
+Stage 4 is the first place we want to carry a real proof obligation (not just packaging).
 
 Policy:
 - This file should stay API + wiring.
 - Put any substantial arguments in `TrackCStage4Proof.lean`.
-- Stage 4 should consume Stage 3 only through the **hard-gate core** import above.
+- Stage 4 should consume Stage 3 only through the hard-gate core import above.
 
 Current status: stub interface.
+
+Design tweak (2026-04): Stage 4 output now *carries* the Stage-3 output record.
+This keeps traceability (and access to Stage-2 witnesses) without forcing Stage 4 consumers to
+re-run earlier stages.
 -/
 
 namespace MoltResearch
@@ -21,19 +25,19 @@ namespace Tao2015
 We keep this abstract for now: Stage 4 will eventually package whatever additional structure
 (or additional witnesses) the next Tao2015 step requires.
 
-For now, it only records that the Stage-3 core conclusion is available.
+For now, it records the full Stage-3 output.
 -/
 structure Stage4Output (f : ℕ → ℤ) : Type where
-  /-- The Stage-3 core conclusion, carried forward as the input to Stage 4. -/
-  stage3_notBounded : ¬ BoundedDiscrepancy f
+  /-- The Stage-3 output, carried forward as the input to Stage 4. -/
+  out3 : Tao2015.Stage3Output f
 
 namespace Stage4Output
 
 variable {f : ℕ → ℤ}
 
-/-- Stage 4 output already carries the core Track-C conclusion `¬ BoundedDiscrepancy f`. -/
+/-- Stage 4 output already carries the Stage-3 conclusion `¬ BoundedDiscrepancy f`. -/
 theorem notBounded (out : Stage4Output f) : ¬ BoundedDiscrepancy f :=
-  out.stage3_notBounded
+  out.out3.notBounded
 
 /-- Stage 4 output implies the usual surface statement `∀ C, HasDiscrepancyAtLeast f C`.
 
@@ -42,21 +46,21 @@ later stages can consume Stage 4 without re-proving it.
 -/
 theorem forall_hasDiscrepancyAtLeast (out : Stage4Output f) :
     ∀ C : ℕ, HasDiscrepancyAtLeast f C := by
-  -- Route through the verified equivalence rather than unfolding any definitions.
-  exact (forall_hasDiscrepancyAtLeast_iff_not_boundedDiscrepancy f).2 out.stage3_notBounded
+  -- Reuse the Stage-3 surface lemma rather than unfolding any definitions.
+  exact out.out3.forall_hasDiscrepancyAtLeast (f := f)
 
 end Stage4Output
 
 /-- Stage 4 main constructor (stub).
 
 Implementation idea:
-- obtain `stage3_notBounded` from `Tao2015.stage3_notBounded` (Stage 3 hard-gate core theorem),
+- obtain `out3` from `Tao2015.stage3Out` (Stage 3 hard-gate core definition),
 - then package any additional structure needed for later stages.
 
-The *real obligation* will live in `TrackCStage4Proof.lean`.
+The real obligation will live in `TrackCStage4Proof.lean`.
 -/
 noncomputable def stage4 (f : ℕ → ℤ) (hf : IsSignSequence f) : Stage4Output f :=
-  ⟨Tao2015.stage3_notBounded (f := f) (hf := hf)⟩
+  ⟨Tao2015.stage3Out (f := f) (hf := hf)⟩
 
 /-- Deterministic name for the Stage-4 output (useful to keep later statements readable). -/
 noncomputable abbrev stage4Out (f : ℕ → ℤ) (hf : IsSignSequence f) : Stage4Output f :=


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Stage 4 output now stores the Stage 3 output record, keeping traceability and future access to Stage 2 witnesses.
- Stage 4 boundary lemmas now route through the stored Stage 3 output instead of re-deriving the surface statement.
