### PR TITLE
Track C: Icc-sum unboundedness normal form

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/Tao2015.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/Tao2015.lean
@@ -449,6 +449,40 @@ theorem iff_not_exists_forall_natAbs_apSumOffset_le (f : ℕ → ℤ) (d m : ℕ
       exact hle'
     exact hnb ⟨B, hB⟩
 
+/-- Paper-notation normal form: unbounded offset discrepancy means there is no uniform bound on the
+shifted progression sums
+`∑ i ∈ Icc (m+1) (m+n), f (i*d)`.
+
+Negation-normal form:
+`¬ ∃ B, ∀ n, Int.natAbs ((Icc (m+1) (m+n)).sum (fun i => f (i*d))) ≤ B`.
+
+This is `iff_not_exists_forall_natAbs_apSumOffset_le` rewritten using
+`natAbs_apSumOffset_eq_natAbs_sum_Icc`.
+-/
+theorem iff_not_exists_forall_natAbs_sum_Icc_offset_le (f : ℕ → ℤ) (d m : ℕ) :
+    UnboundedDiscOffset f d m ↔
+      (¬ ∃ B : ℕ,
+        ∀ n : ℕ,
+          Int.natAbs ((Finset.Icc (m + 1) (m + n)).sum (fun i => f (i * d))) ≤ B) := by
+  have hiff :
+      (∃ B : ℕ, ∀ n : ℕ, Int.natAbs (apSumOffset f d m n) ≤ B) ↔
+        (∃ B : ℕ,
+          ∀ n : ℕ,
+            Int.natAbs ((Finset.Icc (m + 1) (m + n)).sum (fun i => f (i * d))) ≤ B) := by
+    constructor
+    · rintro ⟨B, hB⟩
+      refine ⟨B, ?_⟩
+      intro n
+      simpa [natAbs_apSumOffset_eq_natAbs_sum_Icc (f := f) (d := d) (m := m) (n := n)] using hB n
+    · rintro ⟨B, hB⟩
+      refine ⟨B, ?_⟩
+      intro n
+      simpa [natAbs_apSumOffset_eq_natAbs_sum_Icc (f := f) (d := d) (m := m) (n := n)] using hB n
+
+  exact
+    (iff_not_exists_forall_natAbs_apSumOffset_le (f := f) (d := d) (m := m)).trans
+      (not_congr hiff)
+
 end UnboundedDiscOffset
 
 /-- Normal form: unbounded offset discrepancy means there is no uniform `discOffset` bound.

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
@@ -209,18 +209,11 @@ theorem not_exists_forall_natAbs_sum_Icc_offset_le (out : Stage2Output f) :
     ¬ ∃ B : ℕ,
         ∀ n : ℕ,
           Int.natAbs ((Finset.Icc (out.m + 1) (out.m + n)).sum (fun i => f (i * out.d))) ≤ B := by
-  intro h
-  have hOffset :
-      ∃ B : ℕ, ∀ n : ℕ, Int.natAbs (apSumOffset f out.d out.m n) ≤ B := by
-    rcases h with ⟨B, hB⟩
-    refine ⟨B, ?_⟩
-    intro n
-    have hIcc :
-        Int.natAbs ((Finset.Icc (out.m + 1) (out.m + n)).sum (fun i => f (i * out.d))) ≤ B :=
-      hB n
-    simpa [Tao2015.natAbs_apSumOffset_eq_natAbs_sum_Icc (f := f) (d := out.d) (m := out.m) (n := n)] using
-      hIcc
-  exact (out.not_exists_forall_natAbs_apSumOffset_le (f := f)) hOffset
+  have hunb : UnboundedDiscOffset f out.d out.m := out.unboundedDiscOffset (f := f)
+  exact
+    (Tao2015.UnboundedDiscOffset.iff_not_exists_forall_natAbs_sum_Icc_offset_le (f := f)
+        (d := out.d) (m := out.m)).1
+      hunb
 
 /-- Existential packaging: Stage 2 already yields concrete parameters `d, m` such that the bundled
 offset discrepancy family `discOffset f d m` is unbounded.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Added a paper-notation negation-normal-form lemma: unbounded discOffset is equivalent to no uniform bound on Icc progression sums.
- Simplified Stage2Output.not_exists_forall_natAbs_sum_Icc_offset_le to use the new core lemma.
