### PR TITLE
Track C: Stage2 core exposes tail-nucleus unboundedness

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
@@ -147,6 +147,23 @@ theorem not_exists_boundedDiscOffset (out : Stage2Output f) :
         (d := out.d) (m := out.m)).1
       hunb
 
+/-- Negation-normal-form unboundedness statement for the affine-tail nuclei
+`Int.natAbs (apSumFrom f (out.m*d) out.d n)`.
+
+This is `unboundedDiscOffset` rewritten using the generic normal-form lemma
+`Tao2015.UnboundedDiscOffset.iff_not_exists_forall_natAbs_apSumFrom_mul_le`.
+
+We keep this lemma in `TrackCStage2Core.lean` so downstream stages can access it without importing
+the larger convenience-lemma library `TrackCStage2Output.lean`.
+-/
+theorem not_exists_forall_natAbs_apSumFrom_mul_le (out : Stage2Output f) :
+    ¬ ∃ B : ℕ, ∀ n : ℕ, Int.natAbs (apSumFrom f (out.m * out.d) out.d n) ≤ B := by
+  have hunb : UnboundedDiscOffset f out.d out.m := out.unboundedDiscOffset (f := f)
+  exact
+    (Tao2015.UnboundedDiscOffset.iff_not_exists_forall_natAbs_apSumFrom_mul_le
+        (f := f) (d := out.d) (m := out.m)).1
+      hunb
+
 /-- Stage 2 output implies the usual surface statement `∀ C, HasDiscrepancyAtLeast f C`.
 
 This is a thin wrapper around `notBoundedOriginal`.

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
@@ -110,17 +110,7 @@ theorem forall_exists_natAbs_apSumFrom_mul_gt_witness_pos (out : Stage2Output f)
     (UnboundedDiscOffset.forall_exists_natAbs_apSumFrom_mul_gt_witness_pos (f := f) (d := out.d)
       (m := out.m) hunb)
 
-/-- Negation-normal form of `forall_exists_natAbs_apSumFrom_mul_gt`: there is no uniform bound on
-the affine-tail nuclei at the concrete Stage-1 parameters produced by Stage 2. -/
-theorem not_exists_forall_natAbs_apSumFrom_mul_le (out : Stage2Output f) :
-    ¬ ∃ B : ℕ,
-        ∀ n : ℕ, Int.natAbs (apSumFrom f (out.m * out.d) out.d n) ≤ B := by
-  have hunb : UnboundedDiscOffset f out.d out.m :=
-    (out.out1.unboundedDiscrepancyAlong_iff_unboundedDiscOffset (f := f)).1 out.unbounded
-  exact
-    (Tao2015.UnboundedDiscOffset.iff_not_exists_forall_natAbs_apSumFrom_mul_le
-        (f := f) (d := out.d) (m := out.m)).1
-      hunb
+-- (moved to `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Core`)
 
 /-- Stage 2 implies the reduced sequence is not bounded along its fixed step size. -/
 theorem notBoundedReducedAlong (out : Stage2Output f) : ¬ BoundedDiscrepancyAlong out.g out.d := by


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Move the Stage-2 negation-normal-form affine-tail nucleus bound lemma into TrackCStage2Core so downstream stages can use it without importing the large output-lemma module.
- Keep TrackCStage2Output lean by removing the duplicate definition and leaving a moved-to note.
