### PR TITLE
Track C: add Stage4 out3 rewrite

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage4.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage4.lean
@@ -66,6 +66,15 @@ noncomputable def stage4 (f : ℕ → ℤ) (hf : IsSignSequence f) : Stage4Outpu
 noncomputable abbrev stage4Out (f : ℕ → ℤ) (hf : IsSignSequence f) : Stage4Output f :=
   stage4 (f := f) (hf := hf)
 
+/-- The Stage-3 output stored inside `stage4Out` is definitionally the Stage-3 output produced by
+Stage 3.
+
+This lemma is tiny but useful for rewriting when shuttling statements between Stage 3 and Stage 4.
+-/
+theorem stage4Out_out3 (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    (stage4Out (f := f) (hf := hf)).out3 = Tao2015.stage3Out (f := f) (hf := hf) := by
+  rfl
+
 /-- Consumer-facing shortcut: Stage 4 closes the core goal `¬ BoundedDiscrepancy f`. -/
 theorem stage4_notBounded (f : ℕ → ℤ) (hf : IsSignSequence f) : ¬ BoundedDiscrepancy f := by
   exact (stage4Out (f := f) (hf := hf)).notBounded

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage4Proof.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage4Proof.lean
@@ -10,6 +10,7 @@ Guideline: keep Stage 4 boundary API small; put proofs here.
 
 namespace Conjectures.C0002.EDP.TrackC
 
--- TODO(Stage4): pick one concrete obligation and start burning down the `sorry` footprint here.
+-- TODO(Stage4): pick one concrete obligation and start turning the Stage-4 stub into an actual
+-- proof boundary (Stage 4 is the first place we want to carry nontrivial arguments).
 
 end Conjectures.C0002.EDP.TrackC


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Added a tiny definitional rewrite lemma stage4Out_out3 to make it easy to rewrite Stage-4 outputs back to the Stage-3 output they carry.
- Updated the Stage-4 proof placeholder TODO comment to reflect that Stage 4 is currently a stub boundary.
