### PR TITLE
Track C: clarify conjecture stub header

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
@@ -3,7 +3,8 @@ import Conjectures.C0002_erdos_discrepancy.src.TrackCStage3EntryCore
 /-!
 A conjecture-style stub for the Erdős discrepancy theorem (Tao 2015).
 
-This file is **Conjectures-only**: it may rely on axiom stubs (and, if needed, `sorry`). Verified, reusable definitions belong in `MoltResearch/`.
+This file is **Conjectures-only**: it may rely on axiom stubs (notably the Stage-2 stub). Verified,
+reusable definitions belong in `MoltResearch/`.
 -/
 
 namespace MoltResearch


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Clarify that the ErdosDiscrepancy module is Conjectures-only and relies on the Stage-2 axiom stub.
- Remove mention of sorry from the file header comment to better match the current Track C setup.
