### PR TITLE
Require educational overlay updates for canonical module changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,19 @@ jobs:
             NUCLEUS=0
           fi
 
+          OVERLAY_PATH="Learning/EDUCATIONAL_OVERLAYS.md"
+          CANONICAL_REGEX='^(MoltResearch/Basics\.lean|MoltResearch/Logic\.lean|MoltResearch/Discrepancy/Basic\.lean)$'
+          if printf "%s\n" "$CHANGED" | grep -qE "$CANONICAL_REGEX"; then
+            CANONICAL_CHANGED=1
+          else
+            CANONICAL_CHANGED=0
+          fi
+          if printf "%s\n" "$CHANGED" | grep -qE "^${OVERLAY_PATH}$"; then
+            OVERLAY_CHANGED=1
+          else
+            OVERLAY_CHANGED=0
+          fi
+
           BODY=$(jq -r '.pull_request.body // ""' "$GITHUB_EVENT_PATH")
 
           CARD=$(printf "%s\n" "$BODY" | sed -n 's/^Card:[[:space:]]*//Ip' | head -n 1 | tr -d '\r')
@@ -54,6 +67,13 @@ jobs:
           # Hard gate for nucleus work.
           if [[ "$NUCLEUS" == "1" && "$MISSING" == "1" ]]; then
             echo "::error::This PR touches MoltResearch/ (verified nucleus). Please add Card/Track/Checklist item lines to the PR body (N/A allowed)."
+            exit 1
+          fi
+
+          # Canonical-module overlay hygiene.
+          if [[ "$CANONICAL_CHANGED" == "1" && "$OVERLAY_CHANGED" == "0" ]]; then
+            echo "::error::This PR changes designated canonical MoltResearch modules but does not update $OVERLAY_PATH."
+            echo "::error::Please add a concise overlay update (intuition/proof pattern/common pitfalls), or include a no-op clarification entry."
             exit 1
           fi
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,18 @@ If your PR adds/changes a lemma intended for the **stable import surface** (anyt
 
 This is our regression test for rewrite pipelines: it keeps later refactors from silently breaking the intended normal forms.
 
+### Overlay maintenance rule (canonical module changes)
+
+If your PR introduces a **significant change** to canonical material in `MoltResearch/` (new concepts, major API shifts, renamed core lemmas, or meaningfully changed proof ergonomics), update:
+- `Learning/EDUCATIONAL_OVERLAYS.md`
+
+At minimum, add/edit a short note covering intuition, proof pattern, and common pitfalls for the affected canonical module.
+
+Designated canonical modules currently checked in CI:
+- `MoltResearch/Basics.lean`
+- `MoltResearch/Logic.lean`
+- `MoltResearch/Discrepancy/Basic.lean`
+
 ## House style
 - Write short comments when the proof is non-obvious.
 - Avoid huge `simp` explosions; extract helper lemmas.


### PR DESCRIPTION
### Motivation
- Keep learning scaffolding in sync with important changes to canonical `MoltResearch/` modules to avoid documentation drift. 
- Make overlay updates a lightweight, enforced part of PR hygiene for significant API/concept shifts in core modules. 
- Provide a minimal automated guard in CI to ensure the overlay maintenance rule is followed for designated canonical modules. 

### Description
- Add an "Overlay maintenance rule" to `CONTRIBUTING.md` requiring updates to `Learning/EDUCATIONAL_OVERLAYS.md` when a PR makes significant changes to canonical `MoltResearch/` material. 
- Add a CI check in `.github/workflows/ci.yml` that detects changes to designated canonical files and requires a corresponding update to `Learning/EDUCATIONAL_OVERLAYS.md`, failing with a clear error message if missing. 
- Declare the initially designated canonical modules checked by CI as `MoltResearch/Basics.lean`, `MoltResearch/Logic.lean`, and `MoltResearch/Discrepancy/Basic.lean`, and specify the minimal overlay content expected (intuition, proof pattern, common pitfalls). 

### Testing
- Verified the workflow contains the new overlay-check markers using a small `python3` probe that looked for the `CANONICAL_REGEX`/`OVERLAY_PATH` markers, which succeeded. 
- Attempted local `lake` build with `~/.elan/bin/lake build` and `lake build`, but both failed in this environment because `lake` is not installed. 
- Ran lightweight textual checks to confirm the new guidance appears in `CONTRIBUTING.md` and the overlay-gate logic is present in `.github/workflows/ci.yml`, and those files contain the expected checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db214b2730832bb83998e8be0228fe)