### PR TITLE
Refactor solved-task detection into shared Tier0/Tier1 helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,16 @@ The repo now includes a lightweight learning graph + recommender loop:
 - `Learning/task_metadata.json` — task metadata (currently generated from Tasks/ + hints; safe defaults)
 - `scripts/next_task_recommender.py` — picks next unlocked tasks by easiest/impact/blended strategy
 - `scripts/learning_dashboard.py` — prints tier progress and concept coverage
+- `scripts/task_solved_state.py` — shared solved-state helper used by dashboard/recommender
 - `Learning/EDUCATIONAL_OVERLAYS.md` — concise intuition/proof-pattern notes for canonical modules
 - `scripts/generate_task_metadata.py` — regenerates baseline metadata from the repo
+
+
+Solved-state contract used by these tools:
+
+- A task is treated as solved if a matching Lean file exists in one configured solution source.
+- Current sources are `Solutions/Tier0/T0_*.lean` and `Solutions/Tier1/T1_*.lean`.
+- The canonical solved task id is the file stem (for example, `T0_07` from `Solutions/Tier0/T0_07.lean`).
 
 Run:
 

--- a/scripts/learning_dashboard.py
+++ b/scripts/learning_dashboard.py
@@ -7,22 +7,16 @@ import json
 from collections import Counter
 from pathlib import Path
 
+from task_solved_state import solved_task_ids
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 METADATA_PATH = REPO_ROOT / "Learning" / "task_metadata.json"
-SOLUTIONS_TIER0 = REPO_ROOT / "Solutions" / "Tier0"
 
 
 def load_tasks() -> list[dict]:
     with METADATA_PATH.open() as f:
         return json.load(f)["tasks"]
 
-
-def solved_task_ids() -> set[str]:
-    solved = set()
-    if SOLUTIONS_TIER0.exists():
-        for p in SOLUTIONS_TIER0.glob("T0_*.lean"):
-            solved.add(p.stem)
-    return solved
 
 
 def main() -> None:

--- a/scripts/next_task_recommender.py
+++ b/scripts/next_task_recommender.py
@@ -13,22 +13,16 @@ import argparse
 import json
 from pathlib import Path
 
+from task_solved_state import solved_task_ids
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 METADATA_PATH = REPO_ROOT / "Learning" / "task_metadata.json"
-SOLUTIONS_TIER0 = REPO_ROOT / "Solutions" / "Tier0"
 
 
 def load_tasks() -> list[dict]:
     with METADATA_PATH.open() as f:
         return json.load(f)["tasks"]
 
-
-def solved_task_ids() -> set[str]:
-    solved = set()
-    if SOLUTIONS_TIER0.exists():
-        for p in SOLUTIONS_TIER0.glob("T0_*.lean"):
-            solved.add(p.stem)
-    return solved
 
 
 def unlocked(task: dict, solved: set[str]) -> bool:

--- a/scripts/task_solved_state.py
+++ b/scripts/task_solved_state.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Shared solved-task detection for metadata-driven tooling.
+
+Solved state is inferred from solution files committed under Solutions/.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# (relative directory, filename glob)
+SOLVED_SOURCES: tuple[tuple[str, str], ...] = (
+    ("Solutions/Tier0", "T0_*.lean"),
+    ("Solutions/Tier1", "T1_*.lean"),
+)
+
+
+def solved_task_ids(repo_root: Path = REPO_ROOT) -> set[str]:
+    """Return solved task IDs inferred from solution source files.
+
+    Contract:
+    - each source file's stem is the canonical task id (e.g. ``T0_07``), and
+    - a task is considered solved when such a file exists in one configured source.
+    """
+
+    solved: set[str] = set()
+    for relative_dir, pattern in SOLVED_SOURCES:
+        source_dir = repo_root / relative_dir
+        if not source_dir.exists():
+            continue
+        for solution_file in source_dir.glob(pattern):
+            solved.add(solution_file.stem)
+    return solved


### PR DESCRIPTION
### Motivation

- Centralize solved-task detection used by metadata-driven tools to avoid duplicated logic across scripts.
- Extend solved-state coverage to include both Tier‑0 and Tier‑1 solution sources so tooling can reason about more solution locations.
- Make the solved-state behavior explicit in docs so downstream tools have a clear contract to rely on.

### Description

- Add `scripts/task_solved_state.py` which exposes `solved_task_ids()` and enumerates configured solution sources (`Solutions/Tier0/T0_*.lean` and `Solutions/Tier1/T1_*.lean`).
- Update `scripts/next_task_recommender.py` to import and call `solved_task_ids()` instead of using a local Tier‑0-only implementation.
- Update `scripts/learning_dashboard.py` to import and call `solved_task_ids()` instead of duplicating solved-state logic.
- Document the solved-state contract in `README.md`, describing source globs and canonical id derivation (file stem).

### Testing

- Ran `python3 scripts/next_task_recommender.py --top 3` and it executed successfully, listing detected solved tasks and top recommendations.
- Ran `python3 scripts/learning_dashboard.py` and it executed successfully, printing tier progress and readiness signal.
- No automated test failures were observed when exercising the modified scripts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db2142e3ac832bb2a684cd6b0b8cfd)