### PR TITLE
Add CI check enforcing Task metadata coverage for Tier0/Tier1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,9 @@ jobs:
             fi
           fi
 
+      - name: Check task metadata coverage
+        run: python3 scripts/check_task_metadata_coverage.py
+
       - uses: leanprover/lean-action@v1
         with:
           build: true

--- a/scripts/check_task_metadata_coverage.py
+++ b/scripts/check_task_metadata_coverage.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Validate Learning/task_metadata.json covers all Tier0/Tier1 task files."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+METADATA_PATH = REPO_ROOT / "Learning" / "task_metadata.json"
+REQUIRED_FIELDS = {
+    "id",
+    "file",
+    "tier",
+    "hint",
+    "prerequisites",
+    "difficulty",
+    "expected_minutes",
+    "downstream_relevance",
+    "concepts",
+}
+
+
+def main() -> int:
+    data = json.loads(METADATA_PATH.read_text(encoding="utf-8"))
+    tasks = data.get("tasks")
+
+    if not isinstance(tasks, list):
+        print("ERROR: Learning/task_metadata.json must contain a top-level 'tasks' array.")
+        return 1
+
+    metadata_files: set[str] = set()
+    errors: list[str] = []
+
+    for i, entry in enumerate(tasks):
+        if not isinstance(entry, dict):
+            errors.append(f"tasks[{i}] is not an object")
+            continue
+
+        missing_fields = sorted(REQUIRED_FIELDS - set(entry.keys()))
+        if missing_fields:
+            errors.append(
+                f"tasks[{i}] missing required fields: {', '.join(missing_fields)}"
+            )
+
+        file_value = entry.get("file")
+        if isinstance(file_value, str):
+            metadata_files.add(file_value)
+        else:
+            errors.append(f"tasks[{i}].file must be a string")
+
+    task_files = {
+        p.relative_to(REPO_ROOT).as_posix()
+        for tier in ("Tier0", "Tier1")
+        for p in (REPO_ROOT / "Tasks" / tier).glob("T*_*.lean")
+    }
+
+    missing_metadata = sorted(task_files - metadata_files)
+    stale_metadata = sorted(metadata_files - task_files)
+
+    if missing_metadata:
+        errors.append(
+            "missing metadata entries for task files: " + ", ".join(missing_metadata)
+        )
+
+    if stale_metadata:
+        errors.append(
+            "metadata entries reference non-existent task files: " + ", ".join(stale_metadata)
+        )
+
+    if errors:
+        print("Task metadata coverage check failed:")
+        for err in errors:
+            print(f"- {err}")
+        return 1
+
+    print(
+        f"Task metadata coverage OK: {len(task_files)} task files with matching metadata entries."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation

- Prevent drift between task files under `Tasks/Tier0`/`Tasks/Tier1` and the canonical `Learning/task_metadata.json` by enforcing a minimal, consistent metadata schema. 
- Fail early in CI when task files are added/removed without updating metadata so downstream tooling and dashboards remain truthful.

### Description

- Add `scripts/check_task_metadata_coverage.py` which validates that every `Tasks/Tier0/T*_*.lean` and `Tasks/Tier1/T*_*.lean` file has a matching metadata entry and that each entry contains the required fields `id`, `file`, `tier`, `hint`, `prerequisites`, `difficulty`, `expected_minutes`, `downstream_relevance`, and `concepts`.
- The script reports missing metadata entries and stale metadata references and exits non-zero on failures.
- Wire the coverage check into CI by adding a `Check task metadata coverage` step in `.github/workflows/ci.yml` before the Lean build.
- No changes to `Learning/task_metadata.json` were necessary because the existing metadata already matched the current task files.

### Testing

- Ran `python3 scripts/check_task_metadata_coverage.py` which completed successfully and printed a coverage summary. 
- Regenerated metadata with `python3 scripts/generate_task_metadata.py > /tmp/task_metadata.generated.json` and verified `diff -u Learning/task_metadata.json /tmp/task_metadata.generated.json` produced no differences. 
- Confirmed the CI workflow file contains the new `Check task metadata coverage` step and the repository-level runs complete the new check locally without error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db2132c488832b93909624cb25dd3c)