### PR TITLE
Track C: simplify witness positivity contradiction

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/Tao2015.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/Tao2015.lean
@@ -613,9 +613,7 @@ theorem exists_witness_pos {g : ℕ → ℤ} {d C : ℕ} (h : HasDiscrepancyAtLe
   have hn0 : n ≠ 0 := by
     intro h0
     subst h0
-    have : False := by
-      simpa [discrepancy_zero] using hn
-    exact this
+    simp [discrepancy_zero] at hn
   exact ⟨n, Nat.pos_of_ne_zero hn0, hn⟩
 
 end HasDiscrepancyAtLeastAlong


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- In Tao2015.exists_witness_pos, simplify the n = 0 contradiction by simplifying the witness inequality in-place.
- Removes a small unnecessary simpa block while keeping the statement and downstream API unchanged.
