### PR TITLE
Track C: simp rewrites for stage3/stage4 outputs

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
@@ -41,7 +41,7 @@ This lemma is tiny but useful for rewriting when shuttling statements between St
 We keep it in the hard-gate core so consumers don't need to import the larger Stage-3 convenience
 layer `TrackCStage3Entry` just to access this definitional rewrite.
 -/
-theorem stage3Out_out2 (f : ℕ → ℤ) (hf : IsSignSequence f) :
+@[simp] theorem stage3Out_out2 (f : ℕ → ℤ) (hf : IsSignSequence f) :
     (stage3Out (f := f) (hf := hf)).out2 = stage2Out (f := f) (hf := hf) := by
   rfl
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage4.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage4.lean
@@ -71,7 +71,7 @@ Stage 3.
 
 This lemma is tiny but useful for rewriting when shuttling statements between Stage 3 and Stage 4.
 -/
-theorem stage4Out_out3 (f : ℕ → ℤ) (hf : IsSignSequence f) :
+@[simp] theorem stage4Out_out3 (f : ℕ → ℤ) (hf : IsSignSequence f) :
     (stage4Out (f := f) (hf := hf)).out3 = Tao2015.stage3Out (f := f) (hf := hf) := by
   rfl
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Marked stage3Out_out2 as simp, so (stage3Out f hf).out2 rewrites directly to stage2Out f hf in hard-gate consumer proofs.
- Marked stage4Out_out3 as simp, so (stage4Out f hf).out3 rewrites directly to Tao2015.stage3Out f hf in downstream Stage-4 glue.
