### PR TITLE
Track C: simplify stage2_add_start_mod_d

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Entry.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Entry.lean
@@ -107,16 +107,7 @@ theorem stage2_add_start_mod_d (f : ℕ → ℤ) (hf : IsSignSequence f) (n : �
       n % stage2_d (f := f) (hf := hf) := by
   have hstart : stage2_start (f := f) (hf := hf) % stage2_d (f := f) (hf := hf) = 0 :=
     stage2_start_mod_d (f := f) (hf := hf)
-  calc
-    (n + stage2_start (f := f) (hf := hf)) % stage2_d (f := f) (hf := hf) =
-        ((n % stage2_d (f := f) (hf := hf)) +
-            (stage2_start (f := f) (hf := hf) % stage2_d (f := f) (hf := hf))) %
-          stage2_d (f := f) (hf := hf) := by
-        simpa [Nat.add_mod]
-    _ = ((n % stage2_d (f := f) (hf := hf)) + 0) % stage2_d (f := f) (hf := hf) := by
-        simp [hstart]
-    _ = n % stage2_d (f := f) (hf := hf) := by
-        simp
+  simp [Nat.add_mod, hstart]
 
 /-- Recover the offset parameter `stage2_m` by dividing the Stage-2 start index `stage2_start`
 by the reduced step size `stage2_d`.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Simplify the proof of stage2_add_start_mod_d using simp and Nat.add_mod.
- Removes an unnecessary simpa step, cleaning up linter output for the Track C hard-gate build.
