### PR TITLE
Discrepancy: discOffsetUpTo monotonicity wrapper

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -22,4 +22,5 @@ The goal is to pair verified artifacts with learning scaffolding.
 - **Intuition:** foundational discrepancy definitions and small bounds let later modules reuse a common vocabulary.
 - **Proof sketch pattern:** normalize definitions first, then prove small local inequalities and compose.
 - **Common pitfalls:** jumping into advanced lemmas before reducing to canonical definitions.
+- **API note:** `discOffsetUpTo` is monotone in the cutoff. Use `discOffsetUpTo_mono` for an arbitrary `N ≤ N'`, or the convenience wrapper `discOffsetUpTo_le_add` for the common “extend by `K`” case `N ≤ N+K`.
 - **Related tasks:** `T1_01`, `T1_07`, `T1_12`.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -647,6 +647,14 @@ lemma discOffsetUpTo_mono (f : ℕ → ℤ) (d m : ℕ) {N N' : ℕ} (h : N ≤ 
   have hn' : n ∈ Finset.range (N' + 1) := Finset.mem_range.2 hnlt'
   exact Finset.le_sup (s := Finset.range (N' + 1)) (f := fun t => discOffset f d m t) hn'
 
+/-- A convenience wrapper: extending the cutoff by `K` can only increase `discOffsetUpTo`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — `discOffsetUpTo` monotone in length.
+-/
+lemma discOffsetUpTo_le_add (f : ℕ → ℤ) (d m N K : ℕ) :
+    discOffsetUpTo f d m N ≤ discOffsetUpTo f d m (N + K) := by
+  simpa using (discOffsetUpTo_mono (f := f) (d := d) (m := m) (N := N) (N' := N + K) (Nat.le_add_right N K))
+
 /-- The maximum in `discOffsetUpTo` is attained by some `n ≤ N`.
 
 Checklist item: Problems/erdos_discrepancy.md (Track B) — “Max discrepancy up to N” API.

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -358,6 +358,10 @@ example : ∃ t ≤ n, disc f d t = discUpTo f d n := by
 example (hn : n₁ ≤ n₂) : discOffsetUpTo f d m n₁ ≤ discOffsetUpTo f d m n₂ := by
   simpa using (discOffsetUpTo_mono (f := f) (d := d) (m := m) hn)
 
+-- Regression (Track B / monotonicity wrapper): `N ≤ N+K`.
+example : discOffsetUpTo f d m n₁ ≤ discOffsetUpTo f d m (n₁ + n₂) := by
+  simpa using (discOffsetUpTo_le_add (f := f) (d := d) (m := m) (N := n₁) (K := n₂))
+
 example : ∃ t ≤ n, discOffset f d m t = discOffsetUpTo f d m n := by
   simpa using (exists_discOffset_eq_discOffsetUpTo (f := f) (d := d) (m := m) (N := n))
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `discOffsetUpTo` monotone in length: prove a clean wrapper `discOffsetUpTo f d m N ≤ discOffsetUpTo f d m (N+K)` (and the `N ≤ N'` variant),

Adds `discOffsetUpTo_le_add` as a convenience wrapper around `discOffsetUpTo_mono`, plus a stable-surface regression example.
