### PR TITLE
Discrepancy: paper-endpoint normal form for discOffsetUpTo

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -348,7 +348,15 @@ example : discUpTo f d n = (Finset.range (n + 1)).sup (fun t => disc f d t) := b
 example : discOffsetUpTo f d m n = (Finset.range (n + 1)).sup (fun t => discOffset f d m t) := by
   rfl
 
--- Regression: monotonicity + witness attainment for `discUpTo` / `discOffsetUpTo`.
+-- Regression (Track B / paper-endpoint normalization for `discOffsetUpTo`): rewrite into a `sup`
+-- of paper-interval expressions with the repo's preferred endpoints.
+example :
+    discOffsetUpTo f d m n =
+      (Finset.range (n + 1)).sup
+        (fun t => Int.natAbs ((Finset.Icc (m + 1) (m + t)).sum (fun i => f (i * d)))) := by
+  simpa using (discOffsetUpTo_eq_sup_range_Icc (f := f) (d := d) (m := m) (N := n))
+
+-- Regression: monotonicity + witness attainment for `discUpTo` / `discOffsetUpTo`. 
 example (hn : n₁ ≤ n₂) : discUpTo f d n₁ ≤ discUpTo f d n₂ := by
   simpa using (discUpTo_mono (f := f) (d := d) hn)
 

--- a/MoltResearch/Discrepancy/Offset.lean
+++ b/MoltResearch/Discrepancy/Offset.lean
@@ -407,6 +407,22 @@ lemma discOffsetUpTo_eq_sup_Icc_endpoints (f : ℕ → ℤ) (d m N : ℕ) :
     simpa [hrewrite] using
       (Finset.le_sup (s := Finset.range (N + 1)) (f := fun n => discOffset f d m n) hnmem)
 
+
+/-- Paper-endpoint normalization for `discOffsetUpTo`: rewrite directly into a `sup` of paper-interval
+expressions indexed by the length parameter `n ≤ N`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — Paper-endpoint normalization for
+`discOffsetUpTo`.
+-/
+lemma discOffsetUpTo_eq_sup_range_Icc (f : ℕ → ℤ) (d m N : ℕ) :
+    discOffsetUpTo f d m N =
+      (Finset.range (N + 1)).sup
+        (fun n => Int.natAbs ((Finset.Icc (m + 1) (m + n)).sum (fun i => f (i * d)))) := by
+  classical
+  unfold discOffsetUpTo
+  -- Rewrite each `discOffset` term into paper notation.
+  simpa [discOffset_eq_natAbs_sum_Icc, Nat.add_assoc, Nat.add_left_comm, Nat.add_comm]
+
 /-!
 ## “One-cut in paper notation” bridge
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Paper-endpoint normalization for `discOffsetUpTo`: add a lemma rewriting `discOffsetUpTo f d m N` into a `sup` over paper intervals

What changed:
- Added `discOffsetUpTo_eq_sup_range_Icc` in `MoltResearch/Discrepancy/Offset.lean`, rewriting `discOffsetUpTo` into a finitary `Finset.sup` of the paper-interval discrepancy expression.
- Added a stable-surface regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean` (under `import MoltResearch.Discrepancy`).

Notes:
- This is a pure rewrite lemma; no new simp lemmas were added.
