### PR TITLE
Discrepancy: regression for discOffset reindexing by range permutation

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -209,6 +209,12 @@ example (q : ℕ) (hq : q > 0) (hd : q ∣ d) :
   simpa using
     (apSumOffset_reindex_div_of_dvd (f := f) (q := q) (d := d) (m := m) (n := n) hq hd)
 
+-- Regression (Track B / range permutation): reindexing by a permutation of `Fin n`.
+example (σ : Equiv.Perm (Fin n)) :
+    discOffset f d m n =
+      Int.natAbs ((Finset.univ : Finset (Fin n)).sum (fun i => f ((m + (σ i).1 + 1) * d))) := by
+  simpa using (discOffset_reindex_fin_perm (f := f) (d := d) (m := m) (n := n) (σ := σ))
+
 -- Regression: `simp` should normalize away a spurious zero-offset tail.
 example : apSumOffset f d 0 n = apSum f d n := by
   simp


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `discOffset` congruence under affine reindexing: package a lemma that if `φ : ℕ → ℕ` is a bijection on `Finset.range n` (or an explicit `Nat` reindex like `i ↦ n-1-i` / `i ↦ i+k`), then the corresponding reindexed `apSumOffset` has identical `discOffset`.

What changed
- Added a stable-surface regression example (under `import MoltResearch.Discrepancy`) exercising the existing `discOffset_reindex_fin_perm` lemma.

Notes
- No new lemmas were introduced; this is compile-time coverage for the reindexing API.
