### PR TITLE
Discrepancy: step-positivity witness normal forms

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -23,4 +23,6 @@ The goal is to pair verified artifacts with learning scaffolding.
 - **Proof sketch pattern:** normalize definitions first, then prove small local inequalities and compose.
 - **Common pitfalls:** jumping into advanced lemmas before reducing to canonical definitions.
 - **API note:** `discOffsetUpTo` is monotone in the cutoff. Use `discOffsetUpTo_mono` for an arbitrary `N ≤ N'`, or the convenience wrapper `discOffsetUpTo_le_add` for the common “extend by `K`” case `N ≤ N+K`.
+- **API note (step positivity):** when extracting unboundedness witnesses, prefer the `Nat.succ` normal forms (`HasDiscrepancyAtLeast.exists_witness_succ(_pos)` and the affine analogue) so you can work with a concrete positive step without carrying a separate `d ≥ 1` side condition.
+  The corner case `d = 0` has `simp` normal forms too, but those are now behind `import MoltResearch.Discrepancy.Deprecated` to keep the stable surface focused on the `d ≥ 1` workflow.
 - **Related tasks:** `T1_01`, `T1_07`, `T1_12`.

--- a/MoltResearch/Discrepancy/Affine.lean
+++ b/MoltResearch/Discrepancy/Affine.lean
@@ -1177,6 +1177,33 @@ lemma HasAffineDiscrepancyAtLeast.exists_witness_d_ge_one {f : ℕ → ℤ} {C :
   refine ⟨a, d, n, ?_, hgt⟩
   exact Nat.succ_le_of_lt hd
 
+/-!
+### Step-positivity witness normal forms (`d = Nat.succ d'`)
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — Step-positivity normal form.
+-/
+
+/-- From an affine discrepancy witness obtain a witness whose step is written as `Nat.succ d`. -/
+lemma HasAffineDiscrepancyAtLeast.exists_witness_succ {f : ℕ → ℤ} {C : ℕ}
+    (h : HasAffineDiscrepancyAtLeast f C) :
+    ∃ a d n : ℕ, Int.natAbs (apSumFrom f a (Nat.succ d) n) > C := by
+  rcases HasAffineDiscrepancyAtLeast.exists_witness_d_ge_one (h := h) with ⟨a, d, n, hd, hgt⟩
+  have hdpos : 0 < d := lt_of_lt_of_le Nat.zero_lt_one hd
+  have hd0 : d ≠ 0 := Nat.ne_of_gt hdpos
+  rcases Nat.exists_eq_succ_of_ne_zero hd0 with ⟨d', rfl⟩
+  exact ⟨a, d', n, hgt⟩
+
+/-- Variant of `HasAffineDiscrepancyAtLeast.exists_witness_succ` also recording `n > 0`. -/
+lemma HasAffineDiscrepancyAtLeast.exists_witness_succ_pos {f : ℕ → ℤ} {C : ℕ}
+    (h : HasAffineDiscrepancyAtLeast f C) :
+    ∃ a d n : ℕ, n > 0 ∧ Int.natAbs (apSumFrom f a (Nat.succ d) n) > C := by
+  rcases h.exists_witness_pos with ⟨a, d, n, hd, hn, hgt⟩
+  have hd' : d ≥ 1 := Nat.succ_le_of_lt hd
+  have hdpos : 0 < d := lt_of_lt_of_le Nat.zero_lt_one hd'
+  have hd0 : d ≠ 0 := Nat.ne_of_gt hdpos
+  rcases Nat.exists_eq_succ_of_ne_zero hd0 with ⟨d', rfl⟩
+  exact ⟨a, d', n, hn, hgt⟩
+
 /-- Normal form: `HasAffineDiscrepancyAtLeast f C` has a witness with `d ≥ 1` and `n > 0`.
 
 The `n > 0` side condition is automatic from `Int.natAbs (apSumFrom …) > C`, but it is often

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -777,48 +777,18 @@ This direction avoids simp loops with `discOffset_def`.
   rfl
 
 
-/-- Degenerate step (`d = 0`): the sampled index is always `0`, so the sum is a constant sum. -/
-@[simp] lemma apSum_zero_step (f : ℕ → ℤ) (n : ℕ) :
-    apSum f 0 n = (n : ℤ) * f 0 := by
-  classical
-  unfold apSum
-  -- All sampled indices are `((i+1)*0) = 0`.
-  simp
-
-/-- Degenerate step (`d = 0`) at the homogeneous discrepancy wrapper `disc` level. -/
-@[simp] lemma disc_zero_step (f : ℕ → ℤ) (n : ℕ) :
-    disc f 0 n = Int.natAbs ((n : ℤ) * f 0) := by
-  unfold disc
-  simp [apSum_zero_step]
-
-/-- Degenerate step (`d = 0`) at the homogeneous discrepancy wrapper `discrepancy` level. -/
-@[simp] lemma discrepancy_zero_step (f : ℕ → ℤ) (n : ℕ) :
-    discrepancy f 0 n = Int.natAbs ((n : ℤ) * f 0) := by
-  unfold discrepancy
-  simp [apSum_zero_step]
-
 /-!
-### Degenerate-step (`d = 0`) normal forms
+### Degenerate-step (`d = 0`) normal forms (deprecated surface)
 
-Checklist item: Problems/erdos_discrepancy.md (Track B) — “Coherence lemma for `apSumOffset` under `d=0`”.
+The simp-oriented `d = 0` normal-form lemmas used to live in this file, but they are now
+considered *corner-case surface* and have been moved behind:
 
-These lemmas are oriented for `simp`: they prevent downstream goals from unfolding `apSumOffset`
-into a constant `Finset` sum when the step is `0`.
+```lean
+import MoltResearch.Discrepancy.Deprecated
+```
+
+This keeps the stable surface (`import MoltResearch.Discrepancy`) focused on the `d ≥ 1` workflow.
 -/
-
-/-- Degenerate step (`d = 0`): the sampled index is always `0`, so the sum is a constant sum. -/
-@[simp] lemma apSumOffset_zero_step (f : ℕ → ℤ) (m n : ℕ) :
-    apSumOffset f 0 m n = (n : ℤ) * f 0 := by
-  classical
-  unfold apSumOffset
-  -- All sampled indices are `((m+i+1)*0) = 0`.
-  simp
-
-/-- Degenerate step (`d = 0`) at the `discOffset` level. -/
-@[simp] lemma discOffset_zero_step (f : ℕ → ℤ) (m n : ℕ) :
-    discOffset f 0 m n = Int.natAbs ((n : ℤ) * f 0) := by
-  unfold discOffset
-  simp
 
 /-!
 ### `discAlong`: along-`d` API coherence (`m = 0` offset form)
@@ -2019,6 +1989,35 @@ lemma HasDiscrepancyAtLeast.exists_witness_d_ge_one_pos {f : ℕ → ℤ} {C : �
     ∃ d n, d ≥ 1 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C := by
   rcases HasDiscrepancyAtLeast.exists_witness_pos (h := h) with ⟨d, n, hd, hn, hgt⟩
   exact ⟨d, n, Nat.succ_le_of_lt hd, hn, hgt⟩
+
+/-!
+### Step-positivity witness normal forms (`d = Nat.succ d'`)
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — Step-positivity normal form.
+
+These lemmas package the (automatic) `d ≥ 1` side condition by writing the step as `Nat.succ d'`.
+This lets downstream code avoid carrying separate inequalities.
+-/
+
+/-- From a discrepancy witness obtain a witness whose step is written as `Nat.succ d`. -/
+lemma HasDiscrepancyAtLeast.exists_witness_succ {f : ℕ → ℤ} {C : ℕ}
+    (h : HasDiscrepancyAtLeast f C) :
+    ∃ d n : ℕ, Int.natAbs (apSum f (Nat.succ d) n) > C := by
+  rcases HasDiscrepancyAtLeast.exists_witness_d_ge_one (h := h) with ⟨d, n, hd, hgt⟩
+  have hdpos : 0 < d := lt_of_lt_of_le Nat.zero_lt_one hd
+  have hd0 : d ≠ 0 := Nat.ne_of_gt hdpos
+  rcases Nat.exists_eq_succ_of_ne_zero hd0 with ⟨d', rfl⟩
+  exact ⟨d', n, hgt⟩
+
+/-- Variant of `HasDiscrepancyAtLeast.exists_witness_succ` also recording `n > 0`. -/
+lemma HasDiscrepancyAtLeast.exists_witness_succ_pos {f : ℕ → ℤ} {C : ℕ}
+    (h : HasDiscrepancyAtLeast f C) :
+    ∃ d n : ℕ, n > 0 ∧ Int.natAbs (apSum f (Nat.succ d) n) > C := by
+  rcases HasDiscrepancyAtLeast.exists_witness_d_ge_one_pos (h := h) with ⟨d, n, hd, hn, hgt⟩
+  have hdpos : 0 < d := lt_of_lt_of_le Nat.zero_lt_one hd
+  have hd0 : d ≠ 0 := Nat.ne_of_gt hdpos
+  rcases Nat.exists_eq_succ_of_ne_zero hd0 with ⟨d', rfl⟩
+  exact ⟨d', n, hn, hgt⟩
 
 /-- `HasDiscrepancyAtLeast` can be stated with `d` and `n` both positive.
 

--- a/MoltResearch/Discrepancy/Deprecated.lean
+++ b/MoltResearch/Discrepancy/Deprecated.lean
@@ -18,6 +18,49 @@ If you need older names (e.g. `*_map_add` wrappers), import this file explicitly
 
 namespace MoltResearch
 
+/-!
+## Degenerate-step (`d = 0`) simp normal forms (corner-case surface)
+
+These lemmas are oriented for `simp` and keep the `d = 0` corner case from unfolding `apSum`/
+`apSumOffset` into `Finset` sums.
+
+They used to be part of the stable surface (`import MoltResearch.Discrepancy`) but are now behind
+this deprecated surface module.
+-/
+
+/-- Degenerate step (`d = 0`): the sampled index is always `0`, so the sum is a constant sum. -/
+@[simp] lemma apSum_zero_step (f : ℕ → ℤ) (n : ℕ) :
+    apSum f 0 n = (n : ℤ) * f 0 := by
+  classical
+  unfold apSum
+  simp
+
+/-- Degenerate step (`d = 0`) at the homogeneous discrepancy wrapper `disc` level. -/
+@[simp] lemma disc_zero_step (f : ℕ → ℤ) (n : ℕ) :
+    disc f 0 n = Int.natAbs ((n : ℤ) * f 0) := by
+  unfold disc
+  simp [apSum_zero_step]
+
+/-- Degenerate step (`d = 0`) at the homogeneous discrepancy wrapper `discrepancy` level. -/
+@[simp] lemma discrepancy_zero_step (f : ℕ → ℤ) (n : ℕ) :
+    discrepancy f 0 n = Int.natAbs ((n : ℤ) * f 0) := by
+  unfold discrepancy
+  simp [apSum_zero_step]
+
+/-- Degenerate step (`d = 0`): the sampled index is always `0`, so the offset sum is constant. -/
+@[simp] lemma apSumOffset_zero_step (f : ℕ → ℤ) (m n : ℕ) :
+    apSumOffset f 0 m n = (n : ℤ) * f 0 := by
+  classical
+  unfold apSumOffset
+  simp
+
+/-- Degenerate step (`d = 0`) at the `discOffset` level. -/
+@[simp] lemma discOffset_zero_step (f : ℕ → ℤ) (m n : ℕ) :
+    discOffset f 0 m n = Int.natAbs ((n : ℤ) * f 0) := by
+  unfold discOffset
+  simp
+
+
 /-- Deprecated name for `IsSignSequence.shift_add`. -/
 @[deprecated "Use `IsSignSequence.shift_add`." (since := "2026-02-28")]
 lemma IsSignSequence.map_add {f : ℕ → ℤ} (k : ℕ) (hf : IsSignSequence f) :

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -445,18 +445,11 @@ example : discOffset f d m 0 = 0 := by
 example : discOffset f d m 1 = Int.natAbs (f ((m + 1) * d)) := by
   simp
 
--- Regression (Track B / degenerate-step normal forms):
--- The `d = 0` case should simplify without unfolding into a `Finset` sum.
-example : discOffset f 0 m n = Int.natAbs ((n : ℤ) * f 0) := by
-  simp
-
--- Regression (Track B / degenerate-step normal forms):
-example : disc f 0 n = Int.natAbs ((n : ℤ) * f 0) := by
-  simp
-
--- Regression (Track B / degenerate-step normal forms):
-example : discrepancy f 0 n = Int.natAbs ((n : ℤ) * f 0) := by
-  simp
+-- Regression (Track B / step-positivity witness normal forms):
+-- The stable surface should make it easy to normalize to `d = Nat.succ d'`.
+example (C : ℕ) (h : HasDiscrepancyAtLeast f C) :
+    ∃ d n : ℕ, Int.natAbs (apSum f (Nat.succ d) n) > C := by
+  simpa using (HasDiscrepancyAtLeast.exists_witness_succ (h := h))
 
 -- Regression (Track B / negation invariance, disc-level):
 -- Sign flips should be a one-line `simp`.

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -924,8 +924,10 @@ Definition of done:
   (Implemented as `sum_Icc_eq_apSumOffset_cut` and `discOffset_eq_natAbs_sum_Icc_cut` in `MoltResearch/Discrepancy/Offset.lean`,
   with stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
-- [ ] Step-positivity normal form: add a consistent lemma suite that reduces all theorems to `d ≥ 1` (or `Nat.succ d`) hypotheses early,
+- [x] Step-positivity normal form: add a consistent lemma suite that reduces all theorems to `d ≥ 1` (or `Nat.succ d`) hypotheses early,
   with deprecated `d=0` corner-case variants behind `MoltResearch.Discrepancy.Deprecated`, to keep the stable surface clean.
+  (Implemented via `HasDiscrepancyAtLeast.exists_witness_succ(_pos)` / `HasAffineDiscrepancyAtLeast.exists_witness_succ(_pos)` on the stable surface,
+  and by moving `d = 0` simp normal forms to `MoltResearch/Discrepancy/Deprecated.lean`.)
 
 - [ ] One-shot “normalization pipeline” tactic lemma: a small wrapper lemma (not a tactic) that takes a paper-style goal about `∑ i in Icc …` and rewrites it into the nucleus normal form (`apSumFrom`/`apSumOffset`/`discOffset`) in one `simp`/`rw` step,
   and lock it in with a stable-surface regression example.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Step-positivity normal form: add a consistent lemma suite that reduces all theorems to `d ≥ 1` (or `Nat.succ d`) hypotheses early,

Summary:
- Added stable-surface witness normal forms:
  - `HasDiscrepancyAtLeast.exists_witness_succ` / `exists_witness_succ_pos`
  - `HasAffineDiscrepancyAtLeast.exists_witness_succ` / `exists_witness_succ_pos`
- Moved `d = 0` simp normal forms (`*_zero_step`) out of the stable surface and behind `import MoltResearch.Discrepancy.Deprecated`.
- Updated `NormalFormExamples.lean` to regression-test the new step-positivity normal form on the stable surface.
- Marked the Track B checklist item as complete.

Notes:
- The deprecated module still provides the `d = 0` simp lemmas for downstream code that wants the corner-case normalization.
