### PR TITLE
Discrepancy: one-shot paper→discOffset bound wrappers

### DIFF
--- a/MoltResearch/Discrepancy/AffineTail.lean
+++ b/MoltResearch/Discrepancy/AffineTail.lean
@@ -1725,6 +1725,45 @@ lemma natAbs_sum_Icc_add_affineEndpoints_eq_discOffset
     (natAbs_sum_Icc_of_le_affineEndpoints_eq_discOffset (f := f) (a := a) (d := d)
       (m := m) (n := m + n) (Nat.le_add_right m n))
 
+/-- One-shot normalization pipeline wrapper (paper affine endpoint `natAbs` bound → `discOffset` bound).
+
+This is the inequality-level convenience lemma corresponding to
+`natAbs_sum_Icc_of_le_affineEndpoints_eq_discOffset`.
+
+It lets you go from the paper-shaped hypothesis
+
+`Int.natAbs (∑ i ∈ Icc (m+1) n, f (a + i*d)) ≤ C`
+
+directly to the nucleus normal form
+
+`discOffset (fun k => f (a + k)) d m (n-m) ≤ C`
+
+in a single `exact`/`simpa` step.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — One-shot “normalization pipeline” wrapper.
+-/
+lemma natAbs_sum_Icc_of_le_affineEndpoints_le_discOffset
+    (f : ℕ → ℤ) (a d C : ℕ) {m n : ℕ} (hmn : m ≤ n)
+    (h : Int.natAbs ((Finset.Icc (m + 1) n).sum (fun i => f (a + i * d))) ≤ C) :
+    discOffset (fun k => f (a + k)) d m (n - m) ≤ C := by
+  -- Rewrite the paper expression to `discOffset` using the equality-level wrapper, then close.
+  simpa [natAbs_sum_Icc_of_le_affineEndpoints_eq_discOffset (f := f) (a := a) (d := d)
+    (m := m) (n := n) hmn] using h
+
+/-- Specialization of `natAbs_sum_Icc_of_le_affineEndpoints_le_discOffset` to the common endpoint form
+`Icc (m+1) (m+n)`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — One-shot “normalization pipeline” wrapper.
+-/
+lemma natAbs_sum_Icc_add_affineEndpoints_le_discOffset
+    (f : ℕ → ℤ) (a d m n C : ℕ)
+    (h : Int.natAbs ((Finset.Icc (m + 1) (m + n)).sum (fun i => f (a + i * d))) ≤ C) :
+    discOffset (fun k => f (a + k)) d m n ≤ C := by
+  -- Use the bound-level wrapper after normalizing the endpoints.
+  simpa [Nat.add_sub_cancel_left] using
+    (natAbs_sum_Icc_of_le_affineEndpoints_le_discOffset (f := f) (a := a) (d := d) (C := C)
+      (m := m) (n := m + n) (Nat.le_add_right m n) h)
+
 /-- Alias for `sum_Icc_eq_apSumOffset_shift_add_of_le` (same statement, naming aligned with
 `sum_Icc_eq_apSumOffset_of_le`). -/
 lemma sum_Icc_eq_apSumOffset_of_le_shift_add (f : ℕ → ℤ) (a d : ℕ) {m n : ℕ} (hmn : m ≤ n) :

--- a/MoltResearch/Discrepancy/UserScripts.lean
+++ b/MoltResearch/Discrepancy/UserScripts.lean
@@ -77,6 +77,13 @@ example (hmn : m ≤ n)
   simpa [
     sum_Icc_eq_apSumOffset_of_le_affineEndpoints (f := f) (a := a) (d := d) (m := m) (n := n) hmn] using h
 
+-- 5a) Same goal as (5), but using the one-shot paper→nucleus wrapper lemma.
+example (hmn : m ≤ n)
+    (h : Int.natAbs ((Finset.Icc (m + 1) n).sum (fun i => f (a + i * d))) ≤ C) :
+    discOffset (fun k => f (a + k)) d m (n - m) ≤ C := by
+  exact natAbs_sum_Icc_of_le_affineEndpoints_le_discOffset (f := f) (a := a) (d := d) (C := C)
+    (m := m) (n := n) hmn h
+
 -- 5b) Same as (5), but with the summand written as `a + d*i` (mul-left convention).
 example (hmn : m ≤ n)
     (h : Int.natAbs ((Finset.Icc (m + 1) n).sum (fun i => f (a + d * i))) ≤ C) :


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: One-shot “normalization pipeline” tactic lemma: a small wrapper lemma (not a tactic) that takes a paper-style goal about `∑ i in Icc …` and rewrites it into the nucleus normal form (`apSumFrom`/`apSumOffset`/`discOffset`) in one `simp`/`rw` step,

Summary:
- Adds inequality-level wrapper lemmas `natAbs_sum_Icc_of_le_affineEndpoints_le_discOffset` and `natAbs_sum_Icc_add_affineEndpoints_le_discOffset` in `MoltResearch/Discrepancy/AffineTail.lean`.
  These convert paper-shaped bounds on `Int.natAbs (Finset.Icc ...).sum ...` directly into `discOffset ... ≤ C` in a single step.
- Adds a stable-surface regression example in `MoltResearch/Discrepancy/UserScripts.lean` showing the one-shot pipeline under `import MoltResearch.Discrepancy`.

Notes:
- No new simp rules were added to the stable surface; these are explicit wrapper lemmas to avoid simp-loop risk.
