### PR TITLE
Discrepancy: checklist entry for one-shot normalization wrapper

### DIFF
--- a/MoltResearch/Discrepancy/SurfaceAudit.lean
+++ b/MoltResearch/Discrepancy/SurfaceAudit.lean
@@ -178,14 +178,17 @@ section
   -/
 
   -- Degenerate step (`d = 0`) simp normal forms.
+  --
+  -- We intentionally unfold the wrappers here, rather than requiring `simp` to unfold them by
+  -- default: the stable surface keeps `discOffset`/`discrepancy` as the normalization boundary.
   example : discOffset f 0 m n = Int.natAbs ((n : ℤ) * f 0) := by
-    simp
+    simp [discOffset, apSumOffset_zero_d, zsmul_eq_mul]
 
   example : discrepancy f 0 n = Int.natAbs ((n : ℤ) * f 0) := by
-    simp
+    simp [discrepancy, apSum_zero_d, zsmul_eq_mul]
 
   example : disc f 0 n = Int.natAbs ((n : ℤ) * f 0) := by
-    simp
+    simp [disc, apSum_zero_d, zsmul_eq_mul]
 
   /-!
   ### discOffset_* lemma exports (stable surface)

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -63,6 +63,15 @@ Goal: build a *directed* lemma scaffold (not lemma-sprawl). Each checkbox should
   `discOffset f d m n = discOffset g d m n` assuming pointwise agreement of summands on `Finset.range n`.
   (Implemented as `discOffset_congr_range` in `MoltResearch/Discrepancy/Offset.lean`; regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
+- [x] One-shot “normalization pipeline” wrapper lemma (paper affine endpoints → nucleus normal form):
+  rewrite
+  `Int.natAbs (∑ i ∈ Icc (m+1) n, f (a + i*d))`
+  directly into the nucleus wrapper
+  `discOffset (fun k => f (a + k)) d m (n-m)`
+  in a single `rw`/`simpa` step.
+  (Implemented as `natAbs_sum_Icc_of_le_affineEndpoints_eq_discOffset` (+ specializations/bound-level wrappers)
+  in `MoltResearch/Discrepancy/AffineTail.lean`; regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
+
 #### Auto-generated backlog (needs triage)
 
 - [x] Canonical homogeneous view of offsets: prove `apSumOffset f d m n = apSum (fun k => f (k + m*d)) d n`


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: One-shot “normalization pipeline” wrapper lemma (paper affine endpoints → nucleus normal form)

Summary:
- Mark the new one-shot normalization wrapper as completed in the Track B checklist (implemented in `MoltResearch/Discrepancy/AffineTail.lean`, with regression in `NormalFormExamples`).
- Fix `MoltResearch.Discrepancy.SurfaceAudit` degenerate-step (`d = 0`) regression examples by unfolding the wrappers explicitly (avoids relying on `simp` unfolding `discOffset`/`discrepancy` by default).

CI:
- `make ci`