### PR TITLE
Discrepancy: one-shot paper→discOffset bound rewrite

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -145,6 +145,13 @@ example : (Finset.Icc (m + 1) (m + n)).sum (fun i => f (a + i * d)) = apSumFrom 
 example : Int.natAbs ((Finset.Icc (m + 1) (m + n)).sum (fun i => f (i * d))) = discOffset f d m n := by
   simpa using (natAbs_sum_Icc_eq_discOffset (f := f) (d := d) (m := m) (n := n))
 
+-- NEW (Track B): one-shot goal rewrite for paper-style discrepancy bounds.
+example :
+    (Int.natAbs ((Finset.Icc (m + 1) (m + n)).sum (fun i => f (i * d))) ≤ C) ↔
+      (discOffset f d m n ≤ C) := by
+  simpa using
+    (natAbs_sum_Icc_le_iff_discOffset_le (f := f) (d := d) (m := m) (n := n) (C := C))
+
 -- mul-left paper discrepancy object → nucleus `discOffset` (named bridge lemma)
 example : Int.natAbs ((Finset.Icc (m + 1) (m + n)).sum (fun i => f (d * i))) = discOffset f d m n := by
   simpa using (natAbs_sum_Icc_mul_left_eq_discOffset (f := f) (d := d) (m := m) (n := n))

--- a/MoltResearch/Discrepancy/Offset.lean
+++ b/MoltResearch/Discrepancy/Offset.lean
@@ -343,6 +343,17 @@ lemma natAbs_sum_Icc_eq_discOffset (f : ℕ → ℤ) (d m n : ℕ) :
   simpa using
     (discOffset_eq_natAbs_sum_Icc (f := f) (d := d) (m := m) (n := n)).symm
 
+/-- One-shot goal rewrite: a paper-style bound on `Int.natAbs (∑ i ∈ Icc …, f (i*d))`
+can be rewritten into the nucleus form `discOffset f d m n ≤ C` in a single `simp`/`simpa` step.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — One-shot “normalization pipeline” wrapper.
+-/
+lemma natAbs_sum_Icc_le_iff_discOffset_le (f : ℕ → ℤ) (d m n C : ℕ) :
+    Int.natAbs ((Finset.Icc (m + 1) (m + n)).sum (fun i => f (i * d))) ≤ C ↔
+      discOffset f d m n ≤ C := by
+  -- Just rewrite the `Int.natAbs` expression to `discOffset`.
+  simpa [natAbs_sum_Icc_eq_discOffset (f := f) (d := d) (m := m) (n := n)]
+
 
 /-!
 ## `discOffsetUpTo` paper↔nucleus bridge


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: One-shot “normalization pipeline” tactic lemma

Adds a small wrapper lemma:
- `natAbs_sum_Icc_le_iff_discOffset_le`: rewrite paper-style bounds on `Int.natAbs (∑ i ∈ Icc (m+1) (m+n), f (i*d))` into nucleus form `discOffset f d m n ≤ C` in one `simp`/`simpa`.

Also adds a stable-surface regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.
