### PR TITLE
Discrepancy: one-shot Icc→apSumOffset wrapper

### DIFF
--- a/MoltResearch/Discrepancy/AffineTail.lean
+++ b/MoltResearch/Discrepancy/AffineTail.lean
@@ -1725,6 +1725,30 @@ lemma natAbs_sum_Icc_add_affineEndpoints_eq_discOffset
     (natAbs_sum_Icc_of_le_affineEndpoints_eq_discOffset (f := f) (a := a) (d := d)
       (m := m) (n := m + n) (Nat.le_add_right m n))
 
+/-- One-shot normalization pipeline wrapper (paper affine endpoints `Icc (m+1) (m+n)` → nucleus `apSumOffset`).
+
+This is the sum-level companion to `natAbs_sum_Icc_add_affineEndpoints_eq_discOffset`.
+
+It lets you rewrite the common paper-shaped interval sum
+
+`∑ i ∈ Icc (m+1) (m+n), f (a + i*d)`
+
+directly into the nucleus tail normal form
+
+`apSumOffset (fun k => f (a + k)) d m n`
+
+in a single `rw`/`simpa` step (no side conditions).
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — One-shot “normalization pipeline” wrapper.
+-/
+lemma sum_Icc_add_affineEndpoints_eq_apSumOffset
+    (f : ℕ → ℤ) (a d m n : ℕ) :
+    (Finset.Icc (m + 1) (m + n)).sum (fun i => f (a + i * d)) =
+        apSumOffset (fun k => f (a + k)) d m n := by
+  simpa [Nat.add_sub_cancel_left] using
+    (sum_Icc_eq_apSumOffset_of_le_affineEndpoints (f := f) (a := a) (d := d)
+      (m := m) (n := m + n) (Nat.le_add_right m n))
+
 /-- One-shot normalization pipeline wrapper (paper affine endpoint `natAbs` bound → `discOffset` bound).
 
 This is the inequality-level convenience lemma corresponding to

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -1618,6 +1618,13 @@ example (hmn : m ≤ n) :
   simpa using
     (sum_Icc_eq_apSumOffset_of_le_affineEndpoints (f := f) (a := a) (d := d) (m := m) (n := n) hmn)
 
+-- One-shot normalization wrapper for the common endpoint form `Icc (m+1) (m+n)` (no side conditions).
+example :
+    (Finset.Icc (m + 1) (m + n)).sum (fun i => f (a + i * d)) =
+      apSumOffset (fun k => f (a + k)) d m n := by
+  simpa using
+    (sum_Icc_add_affineEndpoints_eq_apSumOffset (f := f) (a := a) (d := d) (m := m) (n := n))
+
 -- Paper difference of two affine-endpoint tails → normalize to a later tail in `apSumOffset` normal form.
 example (hmn : m ≤ n) (hmn₁ : m + n₁ ≤ n) :
     (Finset.Icc (m + 1) n).sum (fun i => f (a + i * d)) -

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -938,7 +938,7 @@ Definition of done:
   (Implemented via `HasDiscrepancyAtLeast.exists_witness_succ(_pos)` / `HasAffineDiscrepancyAtLeast.exists_witness_succ(_pos)` on the stable surface,
   and by moving `d = 0` simp normal forms to `MoltResearch/Discrepancy/Deprecated.lean`.)
 
-- [ ] One-shot “normalization pipeline” tactic lemma: a small wrapper lemma (not a tactic) that takes a paper-style goal about `∑ i in Icc …` and rewrites it into the nucleus normal form (`apSumFrom`/`apSumOffset`/`discOffset`) in one `simp`/`rw` step,
+- [x] One-shot “normalization pipeline” wrapper lemma: a small wrapper lemma (not a tactic) that takes a paper-style goal about `∑ i in Icc …` and rewrites it into the nucleus normal form (`apSumFrom`/`apSumOffset`/`discOffset`) in one `simp`/`rw` step,
   and lock it in with a stable-surface regression example.
 
 ### Track C - Conjecture stub + equivalences (backlog)


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: One-shot “normalization pipeline” wrapper lemma: a small wrapper lemma (not a tactic) that takes a paper-style goal about `∑ i in Icc …` and rewrites it into the nucleus normal form (`apSumFrom`/`apSumOffset`/`discOffset`) in one `simp`/`rw` step,

What changed
- Added `sum_Icc_add_affineEndpoints_eq_apSumOffset` (paper `Icc (m+1) (m+n)` affine-endpoint tail sum → nucleus `apSumOffset`), as a one-step `rw`/`simpa` normalization wrapper.
- Added a stable-surface regression `example` in `MoltResearch.Discrepancy.NormalFormExamples` exercising the one-shot rewrite.
- Marked the Track B checklist item complete.

Notes
- Kept the lemma off the global simp set to avoid paper↔nucleus simp loops; intended use is `rw`/`simpa` at the call site.