### PR TITLE
Discrepancy: discOffsetUpTo successor max recursion

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -23,6 +23,7 @@ The goal is to pair verified artifacts with learning scaffolding.
 - **Proof sketch pattern:** normalize definitions first, then prove small local inequalities and compose.
 - **Common pitfalls:** jumping into advanced lemmas before reducing to canonical definitions.
 - **API note:** `discOffsetUpTo` is monotone in the cutoff. Use `discOffsetUpTo_mono` for an arbitrary `N ≤ N'`, or the convenience wrapper `discOffsetUpTo_le_add` for the common “extend by `K`” case `N ≤ N+K`.
+- **API note (max recursion):** when you need to peel the last case off a cutoff, rewrite `discOffsetUpTo f d m (N+1)` using `discOffsetUpTo_succ` to get a clean `max (discOffsetUpTo … N) (discOffset … (N+1))` normal form.
 - **API note (step positivity):** when extracting unboundedness witnesses, prefer the `Nat.succ` normal forms (`HasDiscrepancyAtLeast.exists_witness_succ(_pos)` and the affine analogue) so you can work with a concrete positive step without carrying a separate `d ≥ 1` side condition.
   The corner case `d = 0` has `simp` normal forms too, but those are now behind `import MoltResearch.Discrepancy.Deprecated` to keep the stable surface focused on the `d ≥ 1` workflow.
 - **Related tasks:** `T1_01`, `T1_07`, `T1_12`.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -574,6 +574,22 @@ We are conservative here: these lemmas should be obviously terminating and orien
   -- `discOffset f d 0 n` is definitionally `disc f d n`.
   simp [discOffset, disc, apSumOffset, apSum]
 
+/-- Max-recursion normal form for `discOffsetUpTo`.
+
+This is the finitary analogue of “the max up to `N+1` is either the max up to `N` or the new value
+at `N+1`”.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — `discOffsetUpTo` max-recursion normal form.
+-/
+lemma discOffsetUpTo_succ (f : ℕ → ℤ) (d m N : ℕ) :
+    discOffsetUpTo f d m (N + 1) =
+      max (discOffsetUpTo f d m N) (discOffset f d m (N + 1)) := by
+  classical
+  unfold discOffsetUpTo
+  -- `range ((N+1)+1) = insert (N+1) (range (N+1))`.
+  -- Then `Finset.sup_insert` computes the new supremum as a `max`.
+  simpa [Finset.range_add_one, max_comm, max_left_comm, max_assoc]
+
 /-- Any particular `disc f d n` with `n ≤ N` is bounded by `discUpTo f d N`.
 
 Checklist item: Problems/erdos_discrepancy.md (Track B) — “Max discrepancy up to N” API.

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -394,6 +394,12 @@ example : discUpTo f d n = (Finset.range (n + 1)).sup (fun t => disc f d t) := b
 example : discOffsetUpTo f d m n = (Finset.range (n + 1)).sup (fun t => discOffset f d m t) := by
   rfl
 
+-- Regression (Track B / `discOffsetUpTo` max-recursion normal form): the successor cutoff is a `max`.
+example :
+    discOffsetUpTo f d m (n + 1) =
+      max (discOffsetUpTo f d m n) (discOffset f d m (n + 1)) := by
+  simpa using (discOffsetUpTo_succ (f := f) (d := d) (m := m) (N := n))
+
 -- Regression (Track B / paper-endpoint normalization for `discOffsetUpTo`): rewrite into a `sup`
 -- of paper-interval expressions with the repo's preferred endpoints.
 example :

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -943,9 +943,11 @@ Definition of done:
 
 #### Auto-generated backlog (needs triage)
 
-- [ ] `discOffsetUpTo` max-recursion normal form: prove a finitary recursion lemma like
+- [x] `discOffsetUpTo` max-recursion normal form: prove a finitary recursion lemma like
   `discOffsetUpTo f d m (N+1) = max (discOffsetUpTo f d m N) (discOffset f d m (N+1))`,
   with a stable-surface regression example under `import MoltResearch.Discrepancy`.
+  (Implemented as `discOffsetUpTo_succ` in `MoltResearch/Discrepancy/Basic.lean`, with regression example in
+  `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
 - [ ] `discOffset` ≤ `discOffsetUpTo` wrapper: package a lemma of the form
   `n ≤ N → discOffset f d m n ≤ discOffsetUpTo f d m N` (and the homogeneous/along variants if relevant),


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `discOffsetUpTo` max-recursion normal form: prove a finitary recursion lemma like

Implements `discOffsetUpTo_succ`:
- `discOffsetUpTo f d m (N+1) = max (discOffsetUpTo f d m N) (discOffset f d m (N+1))`

Also adds a stable-surface regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean` and marks the checklist item complete on the card.

CI: `make ci`
