### PR TITLE
Discrepancy: wrapper discOffset ≤ discOffsetUpTo

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -23,6 +23,7 @@ The goal is to pair verified artifacts with learning scaffolding.
 - **Proof sketch pattern:** normalize definitions first, then prove small local inequalities and compose.
 - **Common pitfalls:** jumping into advanced lemmas before reducing to canonical definitions.
 - **API note:** `discOffsetUpTo` is monotone in the cutoff. Use `discOffsetUpTo_mono` for an arbitrary `N ≤ N'`, or the convenience wrapper `discOffsetUpTo_le_add` for the common “extend by `K`” case `N ≤ N+K`.
+- **API note (bounding a fixed tail):** to bound a particular `discOffset f d m n` by the max cutoff at the *same* `n`, use `discOffset_le_discOffsetUpTo_self` (it’s just the `N = n` specialization, so you don’t have to write `le_rfl`).
 - **API note (max recursion):** when you need to peel the last case off a cutoff, rewrite `discOffsetUpTo f d m (N+1)` using `discOffsetUpTo_succ` to get a clean `max (discOffsetUpTo … N) (discOffset … (N+1))` normal form.
 - **API note (step positivity):** when extracting unboundedness witnesses, prefer the `Nat.succ` normal forms (`HasDiscrepancyAtLeast.exists_witness_succ(_pos)` and the affine analogue) so you can work with a concrete positive step without carrying a separate `d ≥ 1` side condition.
   The corner case `d = 0` has `simp` normal forms too, but those are now behind `import MoltResearch.Discrepancy.Deprecated` to keep the stable surface focused on the `d ≥ 1` workflow.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -647,6 +647,15 @@ lemma discOffset_le_discOffsetUpTo (f : ℕ → ℤ) (d m n N : ℕ) (hn : n ≤
     exact Finset.mem_range.2 (Nat.lt_succ_of_le hn)
   simpa using (Finset.le_sup (s := Finset.range (N + 1)) (f := fun t => discOffset f d m t) hn')
 
+/-- Convenience wrapper: a tail discrepancy is always bounded by the corresponding `UpTo` cutoff.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — `discOffset` ≤ `discOffsetUpTo` wrapper.
+-/
+lemma discOffset_le_discOffsetUpTo_self (f : ℕ → ℤ) (d m n : ℕ) :
+    discOffset f d m n ≤ discOffsetUpTo f d m n := by
+  simpa using
+    (discOffset_le_discOffsetUpTo (f := f) (d := d) (m := m) (n := n) (N := n) (le_rfl))
+
 /-- Monotonicity in the cutoff: increasing `N` can only increase `discOffsetUpTo`.
 
 Checklist item: Problems/erdos_discrepancy.md (Track B) — “Max discrepancy up to N” API.

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -268,6 +268,10 @@ example : discOffsetUpTo f 1 0 n = discUpTo f 1 n := by
 example (N : ℕ) (hn : n ≤ N) : discOffset f d 0 n ≤ discUpTo f d N := by
   simpa using (discOffset_le_discOffsetUpTo (f := f) (d := d) (m := 0) (n := n) (N := N) hn)
 
+-- Regression (Track B / `discOffset` ≤ `discOffsetUpTo` wrapper): the cutoff `N = n` is ergonomic.
+example : discOffset f d m n ≤ discOffsetUpTo f d m n := by
+  simpa using (discOffset_le_discOffsetUpTo_self (f := f) (d := d) (m := m) (n := n))
+
 -- Regression (Track B / homogeneous view of offsets): push the offset `m*d` into the summand.
 example : apSumOffset f d m n = apSum (fun k => f (k + m * d)) d n := by
   simpa using (apSumOffset_eq_apSum_shift_mul (f := f) (d := d) (m := m) (n := n))


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `discOffset` ≤ `discOffsetUpTo` wrapper: package a lemma of the form

Summary:
- Add `discOffset_le_discOffsetUpTo_self` as the ergonomic `N = n` specialization of `discOffset_le_discOffsetUpTo`.
- Add a stable-surface regression example under `import MoltResearch.Discrepancy`.

CI:
- `make ci`
