### PR TITLE
EDP Track B: checklist mark discOffset ≤ discOffsetUpTo wrapper done

### DIFF
--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -949,9 +949,11 @@ Definition of done:
   (Implemented as `discOffsetUpTo_succ` in `MoltResearch/Discrepancy/Basic.lean`, with regression example in
   `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
-- [ ] `discOffset` ≤ `discOffsetUpTo` wrapper: package a lemma of the form
+- [x] `discOffset` ≤ `discOffsetUpTo` wrapper: package a lemma of the form
   `n ≤ N → discOffset f d m n ≤ discOffsetUpTo f d m N` (and the homogeneous/along variants if relevant),
   so later proofs can move freely between “a particular interval” and “the maximum up to N”.
+  (Implemented as `discOffset_le_discOffsetUpTo` and the ergonomic cutoff lemma `discOffset_le_discOffsetUpTo_self` in
+  `MoltResearch/Discrepancy/Basic.lean`, with stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
 - [ ] Triangle-inequality bound for `discOffsetUpTo`: prove a canonical inequality bounding
   `discOffsetUpTo f d m (N+K)` by `discOffsetUpTo f d m N + discOffsetUpTo f d (m+N) K` (or the repo’s preferred tail shape),


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `discOffset` ≤ `discOffsetUpTo` wrapper: package a lemma of the form

This updates the Erdos discrepancy Track B checklist to reflect that the wrapper lemmas already exist:
- `discOffset_le_discOffsetUpTo`
- `discOffset_le_discOffsetUpTo_self`

Regression examples already live in `MoltResearch/Discrepancy/NormalFormExamples.lean`.
