### PR TITLE
Track C: isolate Stage-2 axiom stub

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/Tao2015.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/Tao2015.lean
@@ -7,7 +7,7 @@ import MoltResearch.Discrepancy.AffineTail
 This module is **Conjectures-only**: it may contain axiom stubs (and, if needed, `sorry`).
 
 At present, the only non-verified assumption is the Stage-2 axiom in
-`Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Entry`.
+`Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Stub`.
 
 Hard goal for Track C automation: make
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2.lean
@@ -11,7 +11,8 @@ This file is intentionally thin: it re-exports
 keeping `TrackCStage2.lean` as “API + wiring”.
 
 The conjecture stub itself lives in
-`Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Entry` (imported via
+`Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Stub` (imported via
+`Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Entry` and re-exported by
 `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Light`) so consumers can just
 `import ...TrackCStage2`.
 -/

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Boundary.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Boundary.lean
@@ -55,7 +55,7 @@ The `Stage2Output` record is defined in this file. The bulk of the convenience l
 ## Stage 2 conjecture stub
 
 The Stage-2 conjecture/axiom stub lives in
-`Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Entry` so that this file remains mostly
+`Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Stub` so that this file remains mostly
 “API + wiring”.
 -/
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Entry.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Entry.lean
@@ -1,4 +1,4 @@
-import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Boundary
+import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Stub
 
 /-!
 # Track C: Stage 2 entry point (Tao 2015 plane)
@@ -6,12 +6,13 @@ import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Boundary
 This file is **Conjectures-only** glue.
 
 It contains only:
-- the Stage-2 conjecture stub (axiom) `stage2`,
-- the deterministic name `stage2Out`,
 - the lightweight projections `stage2_d`, `stage2_g`, `stage2_m`, `stage2_start`, and
 - the tiny projection lemmas `stage2_d_pos`, `stage2_one_le_d`, `stage2_d_ne_zero`,
   `stage2_start_eq_m_mul_d`, `stage2_d_dvd_start`, `stage2_start_mod_d`, `stage2_hg`,
   `stage2_g_eq`, `stage2_g_eq_fun`.
+
+The conjecture stub itself (`stage2` and the deterministic name `stage2Out`) lives in
+`Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Stub`.
 
 All other proved convenience lemmas about `stage2Out` live in
 `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Proof`.
@@ -23,17 +24,6 @@ wrapper lemmas when it only needs the Stage-2 stub.
 namespace MoltResearch
 
 namespace Tao2015
-
-/-- **Conjecture stub:** Stage 2 of Tao 2015.
-
-Given a sign sequence `f`, produce a Stage-1 reduction output and show that the reduced sequence
-has unbounded discrepancy along its associated fixed step.
--/
-axiom stage2 (f : ℕ → ℤ) (hf : IsSignSequence f) : Stage2Output f
-
-/-- Deterministic name for the Stage-2 output (useful to keep later statements readable). -/
-noncomputable abbrev stage2Out (f : ℕ → ℤ) (hf : IsSignSequence f) : Stage2Output f :=
-  stage2 (f := f) (hf := hf)
 
 /-- Convenience projection: the reduced step size produced by Stage 2. -/
 noncomputable abbrev stage2_d (f : ℕ → ℤ) (hf : IsSignSequence f) : ℕ :=

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2ProofCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2ProofCore.lean
@@ -13,7 +13,7 @@ The larger collection of witness-form wrappers lives in
 `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2ProofWitnesses`.
 
 The Stage-2 conjecture stub (axiom) itself lives in
-`Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Entry`.
+`Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Stub`.
 -/
 
 namespace MoltResearch
@@ -22,7 +22,7 @@ namespace Tao2015
 
 /-!
 The Stage-2 conjecture stub (axiom) and the deterministic name `stage2Out` live in
-`Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Entry`.
+`Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Stub`.
 
 This file keeps only the core convenience wrappers.
 -/

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Stub.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Stub.lean
@@ -1,0 +1,32 @@
+import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Boundary
+
+/-!
+# Track C: Stage 2 conjecture stub (Tao 2015 plane)
+
+This file is **Conjectures-only** glue.
+
+It isolates the single non-verified assumption of Track C: the Stage-2 boundary axiom.
+
+Design goal: downstream hard-gate consumers (Stage 3, `ErdosDiscrepancy.lean`) should only need to
+import this stub to access `stage2Out`, avoiding compilation of additional Stage-2 convenience
+lemmas.
+-/
+
+namespace MoltResearch
+
+namespace Tao2015
+
+/-- **Conjecture stub:** Stage 2 of Tao 2015.
+
+Given a sign sequence `f`, produce a Stage-2 output consisting of a Stage-1 reduction output and an
+unbounded fixed-step discrepancy witness along the reduced sequence.
+-/
+axiom stage2 (f : ℕ → ℤ) (hf : IsSignSequence f) : Stage2Output f
+
+/-- Deterministic name for the Stage-2 output (useful to keep later statements readable). -/
+noncomputable abbrev stage2Out (f : ℕ → ℤ) (hf : IsSignSequence f) : Stage2Output f :=
+  stage2 (f := f) (hf := hf)
+
+end Tao2015
+
+end MoltResearch

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
@@ -1,5 +1,5 @@
 import Conjectures.C0002_erdos_discrepancy.src.TrackCStage3
-import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Entry
+import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Stub
 
 /-!
 # Track C: Stage 3 entry point (hard-gate core)


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add TrackCStage2Stub to isolate the single Stage-2 axiom stub (stage2) and the deterministic name stage2Out.
- Switch TrackCStage3EntryCore to import the stub directly, keeping the ErdosDiscrepancy hard-gate surface smaller.
- Update TrackCStage2Entry and related docs to reflect the new split (entry point now focuses on projections/lemmas).
