### PR TITLE
Discrepancy: discOffsetUpTo Lipschitz-by-1 in N

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -23,6 +23,8 @@ The goal is to pair verified artifacts with learning scaffolding.
 - **Proof sketch pattern:** normalize definitions first, then prove small local inequalities and compose.
 - **Common pitfalls:** jumping into advanced lemmas before reducing to canonical definitions.
 - **API note:** `discOffsetUpTo` is monotone in the cutoff. Use `discOffsetUpTo_mono` for an arbitrary `N ≤ N'`, or the convenience wrapper `discOffsetUpTo_le_add` for the common “extend by `K`” case `N ≤ N+K`.
+- **API note (Lipschitz step):** for sign sequences, the one-step cutoff bound is `discOffsetUpTo_succ_le_add_one`:
+  `discOffsetUpTo f d m (N+1) ≤ discOffsetUpTo f d m N + 1`. The reverse direction (monotonicity) is `discOffsetUpTo_le_succ`.
 - **API note (bounding a fixed tail):** to bound a particular `discOffset f d m n` by the max cutoff at the *same* `n`, use `discOffset_le_discOffsetUpTo_self` (it’s just the `N = n` specialization, so you don’t have to write `le_rfl`).
 - **API note (max recursion):** when you need to peel the last case off a cutoff, rewrite `discOffsetUpTo f d m (N+1)` using `discOffsetUpTo_succ` to get a clean `max (discOffsetUpTo … N) (discOffset … (N+1))` normal form.
 - **API note (step positivity):** when extracting unboundedness witnesses, prefer the `Nat.succ` normal forms (`HasDiscrepancyAtLeast.exists_witness_succ(_pos)` and the affine analogue) so you can work with a concrete positive step without carrying a separate `d ≥ 1` side condition.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -678,7 +678,17 @@ Checklist item: Problems/erdos_discrepancy.md (Track B) — `discOffsetUpTo` mon
 -/
 lemma discOffsetUpTo_le_add (f : ℕ → ℤ) (d m N K : ℕ) :
     discOffsetUpTo f d m N ≤ discOffsetUpTo f d m (N + K) := by
-  simpa using (discOffsetUpTo_mono (f := f) (d := d) (m := m) (N := N) (N' := N + K) (Nat.le_add_right N K))
+  simpa using
+    (discOffsetUpTo_mono (f := f) (d := d) (m := m) (N := N) (N' := N + K) (Nat.le_add_right N K))
+
+/-- Convenience: `discOffsetUpTo` is monotone under `N ↦ N+1`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — `discOffsetUpTo` Lipschitz-by-1 in `N`
+(reverse inequality direction).
+-/
+lemma discOffsetUpTo_le_succ (f : ℕ → ℤ) (d m N : ℕ) :
+    discOffsetUpTo f d m N ≤ discOffsetUpTo f d m (N + 1) := by
+  simpa using (discOffsetUpTo_le_add (f := f) (d := d) (m := m) (N := N) (K := 1))
 
 /-- The maximum in `discOffsetUpTo` is attained by some `n ≤ N`.
 
@@ -3005,6 +3015,17 @@ lemma discOffsetUpTo_add_le {f : ℕ → ℤ} (hf : IsSignSequence f) (d m N K :
     have hNt : discOffset f d m (N + t) ≤ discOffsetUpTo f d m N + t := by
       exact le_trans hsplit (Nat.add_le_add h1 h2)
     exact le_trans hNt (Nat.add_le_add_left ht _)
+
+
+/-- Lipschitz-by-1 in the cutoff parameter: extending from `N` to `N+1` increases the maximum by at
+most `1` (for sign sequences).
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — `discOffsetUpTo` Lipschitz-by-1 in `N`
+(forward inequality direction).
+-/
+lemma discOffsetUpTo_succ_le_add_one {f : ℕ → ℤ} (hf : IsSignSequence f) (d m N : ℕ) :
+    discOffsetUpTo f d m (N + 1) ≤ discOffsetUpTo f d m N + 1 := by
+  simpa using (discOffsetUpTo_add_le (f := f) (hf := hf) (d := d) (m := m) (N := N) (K := 1))
 
 
 /-- Concatenation inequality for `discOffsetUpTo`: extending the cutoff from `N` to `N + K` is

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -50,6 +50,19 @@ example : discOffset (fun _ => (1 : ℤ)) d m n = n := by
   simpa [discOffset_const_one]
 
 /-!
+### NEW (Track B): `discOffsetUpTo` Lipschitz-by-1 in `N`
+
+Compile-only regression tests ensuring the “extend the cutoff by 1” inequalities stay one-liners.
+-/
+
+example (hf : IsSignSequence f) :
+    discOffsetUpTo f d m (n + 1) ≤ discOffsetUpTo f d m n + 1 := by
+  simpa using (discOffsetUpTo_succ_le_add_one (f := f) (hf := hf) (d := d) (m := m) (N := n))
+
+example : discOffsetUpTo f d m n ≤ discOffsetUpTo f d m (n + 1) := by
+  simpa using (discOffsetUpTo_le_succ (f := f) (d := d) (m := m) (N := n))
+
+/-!
 Periodic (non-constant) sanity check: the alternating sign sequence has period 2.
 
 When the step `d` is even, the sampled indices are all even, so the sequence restricts to the


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `discOffsetUpTo` Lipschitz-by-1 in N

Adds one-step cutoff inequalities for `discOffsetUpTo`:
- monotonicity `N ≤ N+1` wrapper (`discOffsetUpTo_le_succ`)
- Lipschitz forward step for sign sequences (`discOffsetUpTo_succ_le_add_one`)

Also adds stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean`.
