### PR TITLE
Discrepancy: one-shot paper-endpoint bound rewrite for discOffsetUpTo

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -285,6 +285,13 @@ example (N : ℕ) (hn : n ≤ N) : discOffset f d 0 n ≤ discUpTo f d N := by
 example : discOffset f d m n ≤ discOffsetUpTo f d m n := by
   simpa using (discOffset_le_discOffsetUpTo_self (f := f) (d := d) (m := m) (n := n))
 
+-- Regression (Track B / paper-endpoint bridge for `discOffsetUpTo`): a one-shot bound rewrite.
+example (N C : ℕ) :
+    discOffsetUpTo f d m N ≤ C ↔
+      ∀ n ∈ Finset.range (N + 1),
+        Int.natAbs ((Finset.Icc (m + 1) (m + n)).sum (fun i => f (i * d))) ≤ C := by
+  simpa using (discOffsetUpTo_le_iff_forall_range_Icc (f := f) (d := d) (m := m) (N := N) (C := C))
+
 -- Regression (Track B / homogeneous view of offsets): push the offset `m*d` into the summand.
 example : apSumOffset f d m n = apSum (fun k => f (k + m * d)) d n := by
   simpa using (apSumOffset_eq_apSum_shift_mul (f := f) (d := d) (m := m) (n := n))

--- a/MoltResearch/Discrepancy/Offset.lean
+++ b/MoltResearch/Discrepancy/Offset.lean
@@ -454,6 +454,27 @@ lemma discOffsetUpTo_eq_sup_range_Icc (f : ℕ → ℤ) (d m N : ℕ) :
   -- Rewrite each `discOffset` term into paper notation.
   simpa [discOffset_eq_natAbs_sum_Icc, Nat.add_assoc, Nat.add_left_comm, Nat.add_comm]
 
+/-- One-shot goal rewrite: a bound on `discOffsetUpTo` is equivalent to a uniform bound on the
+paper-interval discrepancy expressions `Int.natAbs (∑ i ∈ Icc (m+1) (m+n), f (i*d))` for all
+lengths `n ≤ N`.
+
+This packages `discOffsetUpTo_eq_sup_range_Icc` together with `Finset.sup_le_iff`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — `discOffsetUpTo` paper↔nucleus bridge
+(endpoint style): one-shot bound rewrite.
+-/
+lemma discOffsetUpTo_le_iff_forall_range_Icc (f : ℕ → ℤ) (d m N C : ℕ) :
+    discOffsetUpTo f d m N ≤ C ↔
+      ∀ n ∈ Finset.range (N + 1),
+        Int.natAbs ((Finset.Icc (m + 1) (m + n)).sum (fun i => f (i * d))) ≤ C := by
+  classical
+  -- Rewrite `discOffsetUpTo` to a `sup` over paper expressions.
+  -- Then `sup ≤ C` iff all entries are `≤ C`.
+  simpa [discOffsetUpTo_eq_sup_range_Icc] using
+    (Finset.sup_le_iff (s := Finset.range (N + 1))
+      (f := fun n => Int.natAbs ((Finset.Icc (m + 1) (m + n)).sum (fun i => f (i * d))))
+      (a := C))
+
 /-!
 ## “One-cut in paper notation” bridge
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Paper↔nucleus bridge for `discOffsetUpTo` (endpoint style): add a one-shot lemma rewriting

What this does
- Adds `discOffsetUpTo_le_iff_forall_range_Icc`, a one-shot rewrite:
  `discOffsetUpTo f d m N ≤ C` ↔ (for all `n ≤ N`) `Int.natAbs (∑ i ∈ Icc (m+1) (m+n), f (i*d)) ≤ C`.
- Adds a compile-only stable-surface regression example in `NormalFormExamples.lean`.

Notes
- Implemented via `discOffsetUpTo_eq_sup_range_Icc` + `Finset.sup_le_iff`.
- No new opportunistic lemmas beyond this checklist item.
