### PR TITLE
Track B: discOffsetUpTo endpoint-style sup rewrite (Icc 0 N)

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -292,6 +292,13 @@ example (N C : ℕ) :
         Int.natAbs ((Finset.Icc (m + 1) (m + n)).sum (fun i => f (i * d))) ≤ C := by
   simpa using (discOffsetUpTo_le_iff_forall_range_Icc (f := f) (d := d) (m := m) (N := N) (C := C))
 
+-- Regression (Track B / paper↔nucleus bridge, endpoint style): rewrite into an `Icc 0 N` supremum.
+example (N : ℕ) :
+    discOffsetUpTo f d m N =
+      (Finset.Icc 0 N).sup
+        (fun n => Int.natAbs ((Finset.Icc (m + 1) (m + n)).sum (fun i => f (i * d)))) := by
+  simpa using (discOffsetUpTo_eq_sup_Icc_lengths (f := f) (d := d) (m := m) (N := N))
+
 -- Regression (Track B / homogeneous view of offsets): push the offset `m*d` into the summand.
 example : apSumOffset f d m n = apSum (fun k => f (k + m * d)) d n := by
   simpa using (apSumOffset_eq_apSum_shift_mul (f := f) (d := d) (m := m) (n := n))

--- a/MoltResearch/Discrepancy/Offset.lean
+++ b/MoltResearch/Discrepancy/Offset.lean
@@ -454,6 +454,23 @@ lemma discOffsetUpTo_eq_sup_range_Icc (f : ℕ → ℤ) (d m N : ℕ) :
   -- Rewrite each `discOffset` term into paper notation.
   simpa [discOffset_eq_natAbs_sum_Icc, Nat.add_assoc, Nat.add_left_comm, Nat.add_comm]
 
+/-- Paper↔nucleus bridge for `discOffsetUpTo` (endpoint style): rewrite the `Finset.range (N+1)`
+supremum in `discOffsetUpTo_eq_sup_range_Icc` as a supremum over `Finset.Icc 0 N`.
+
+This matches the common “witness `n ≤ N`” convention used in later Tao2015 stages.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — Paper↔nucleus bridge for
+`discOffsetUpTo` (endpoint style).
+-/
+lemma discOffsetUpTo_eq_sup_Icc_lengths (f : ℕ → ℤ) (d m N : ℕ) :
+    discOffsetUpTo f d m N =
+      (Finset.Icc 0 N).sup
+        (fun n => Int.natAbs ((Finset.Icc (m + 1) (m + n)).sum (fun i => f (i * d)))) := by
+  classical
+  have hrange : (Finset.range (N + 1)) = Finset.Icc 0 N := by
+    simpa using (Nat.range_eq_Icc_zero_sub_one (N + 1) (Nat.add_one_ne_zero N))
+  simpa [hrange] using (discOffsetUpTo_eq_sup_range_Icc (f := f) (d := d) (m := m) (N := N))
+
 /-- One-shot goal rewrite: a bound on `discOffsetUpTo` is equivalent to a uniform bound on the
 paper-interval discrepancy expressions `Int.natAbs (∑ i ∈ Icc (m+1) (m+n), f (i*d))` for all
 lengths `n ≤ N`.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Paper↔nucleus bridge for `discOffsetUpTo` (endpoint style): add a one-shot lemma rewriting

## What
- Add `discOffsetUpTo_eq_sup_Icc_lengths` in `MoltResearch/Discrepancy/Offset.lean`, rewriting the existing paper-endpoint `sup` form from `Finset.range (N+1)` to `Finset.Icc 0 N` (matches the `n ≤ N` witness convention).
- Add a compile-only regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean` using the new lemma.

## Why
Downstream Tao2015-style arguments frequently quantify over a length witness `n ≤ N`; having the `Icc 0 N` supremum form avoids endpoint-convention friction while staying in the same paper-endpoint expression `Int.natAbs (∑ i ∈ Icc (m+1) (m+n), f (i*d))`.

## CI
- `make ci`
