### PR TITLE
Discrepancy: simp coherence for discOffsetUpTo degenerate params

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -29,4 +29,8 @@ The goal is to pair verified artifacts with learning scaffolding.
 - **API note (max recursion):** when you need to peel the last case off a cutoff, rewrite `discOffsetUpTo f d m (N+1)` using `discOffsetUpTo_succ` to get a clean `max (discOffsetUpTo … N) (discOffset … (N+1))` normal form.
 - **API note (step positivity):** when extracting unboundedness witnesses, prefer the `Nat.succ` normal forms (`HasDiscrepancyAtLeast.exists_witness_succ(_pos)` and the affine analogue) so you can work with a concrete positive step without carrying a separate `d ≥ 1` side condition.
   The corner case `d = 0` has `simp` normal forms too, but those are now behind `import MoltResearch.Discrepancy.Deprecated` to keep the stable surface focused on the `d ≥ 1` workflow.
+- **API note (degenerate parameters for `UpTo`):** in downstream goals, you often want to normalize away “spurious” degenerate parameters without unfolding the finitary `Finset.sup` definition. The stable surface exports simp lemmas for:
+  - `discOffsetUpTo f d m 0 = 0`
+  - `discOffsetUpTo f d 0 N = discUpTo f d N`
+  - step-one shift: `discOffsetUpTo f 1 m N = discUpTo (fun k => f (k + m)) 1 N`
 - **Related tasks:** `T1_01`, `T1_07`, `T1_12`.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -574,6 +574,36 @@ We are conservative here: these lemmas should be obviously terminating and orien
   -- `discOffset f d 0 n` is definitionally `disc f d n`.
   simp [discOffset, disc, apSumOffset, apSum]
 
+/-!
+### Step-one (`d = 1`) coherence simp lemmas
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) —
+“API coherence for degenerate parameters at max-level”.
+
+When the step is `1`, an offset progression is just a shift of the underlying sequence.
+These lemmas expose that shift at the wrapper level, in `simp`-friendly normal form.
+-/
+
+/-- Step-one coherence: absorb the offset into a shift of the underlying sequence. -/
+@[simp] lemma apSumOffset_one_shift (f : ℕ → ℤ) (m n : ℕ) :
+    apSumOffset f 1 m n = apSum (fun k => f (k + m)) 1 n := by
+  unfold apSumOffset apSum
+  -- Both sides are `Finset.range n` sums; normalize arithmetic and `* 1`.
+  simp [Nat.mul_one, Nat.add_assoc, Nat.add_left_comm, Nat.add_comm]
+
+/-- Step-one coherence: `discOffset` is just `disc` on the shifted sequence. -/
+@[simp] lemma discOffset_one_shift (f : ℕ → ℤ) (m n : ℕ) :
+    discOffset f 1 m n = disc (fun k => f (k + m)) 1 n := by
+  unfold discOffset disc
+  simp [apSumOffset_one_shift]
+
+/-- Step-one coherence: `discOffsetUpTo` is `discUpTo` on the shifted sequence. -/
+@[simp] lemma discOffsetUpTo_one_shift (f : ℕ → ℤ) (m N : ℕ) :
+    discOffsetUpTo f 1 m N = discUpTo (fun k => f (k + m)) 1 N := by
+  classical
+  unfold discOffsetUpTo discUpTo
+  simp [discOffset_one_shift]
+
 /-- Max-recursion normal form for `discOffsetUpTo`.
 
 This is the finitary analogue of “the max up to `N+1` is either the max up to `N` or the new value

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -50,6 +50,21 @@ example : discOffset (fun _ => (1 : ℤ)) d m n = n := by
   simpa [discOffset_const_one]
 
 /-!
+### NEW (Track B): `discOffsetUpTo` degenerate-parameter simp coherence
+
+Compile-only regression tests ensuring the “degenerate parameter” simp lemmas stay one-liners.
+-/
+
+example : discOffsetUpTo f d m 0 = 0 := by
+  simp
+
+example : discOffsetUpTo f d 0 n = discUpTo f d n := by
+  simp
+
+example : discOffsetUpTo f 1 m n = discUpTo (fun k => f (k + m)) 1 n := by
+  simp
+
+/-!
 ### NEW (Track B): `discOffsetUpTo` Lipschitz-by-1 in `N`
 
 Compile-only regression tests ensuring the “extend the cutoff by 1” inequalities stay one-liners.

--- a/MoltResearch/Discrepancy/SurfaceAudit.lean
+++ b/MoltResearch/Discrepancy/SurfaceAudit.lean
@@ -191,6 +191,28 @@ section
     simp [disc, apSum_zero_d, zsmul_eq_mul]
 
   /-!
+  ### `UpTo` degenerate-parameter simp coherence (stable surface)
+
+  These ensure the stable surface exports the simp lemmas that normalize the `UpTo` wrappers in
+  the key degenerate cases, without users having to unfold into finset `sup`s.
+  -/
+
+  #check discUpTo
+  #check discOffsetUpTo
+  #check discOffsetUpTo_zero
+  #check discOffsetUpTo_zero_start
+  #check discOffsetUpTo_one_shift
+
+  example : discOffsetUpTo f d m 0 = 0 := by
+    simp
+
+  example : discOffsetUpTo f d 0 n = discUpTo f d n := by
+    simp
+
+  example : discOffsetUpTo f 1 m n = discUpTo (fun k => f (k + m)) 1 n := by
+    simp
+
+  /-!
   ### discOffset_* lemma exports (stable surface)
 
   These are high-leverage `discOffset` rewrite/transport lemmas used throughout Track B.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: API coherence for degenerate parameters at max-level: add simp-friendly lemmas for

What this PR does
- Adds step-one coherence simp lemmas in `MoltResearch/Discrepancy/Basic.lean`:
  - `apSumOffset_one_shift`: `apSumOffset f 1 m n = apSum (fun k => f (k + m)) 1 n`
  - `discOffset_one_shift`: `discOffset f 1 m n = disc (fun k => f (k + m)) 1 n`
  - `discOffsetUpTo_one_shift`: `discOffsetUpTo f 1 m N = discUpTo (fun k => f (k + m)) 1 N`
- Adds stable-surface regression examples under `import MoltResearch.Discrepancy`:
  - `NormalFormExamples.lean`: one-line `simp` examples for `N=0`, `m=0`, and `d=1`.
  - `SurfaceAudit.lean`: presence checks + compile-only `simp` examples to guard the stable surface.

Why
- Makes the max-level (`UpTo`) API behave coherently in the obvious degenerate cases without forcing downstream proofs to unfold into `Finset.sup`.

CI
- `make ci`