### PR TITLE
Track B: checklist: UpTo degenerate-parameter coherence

### DIFF
--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -979,9 +979,12 @@ Definition of done:
   (Implemented as `discOffsetUpTo_blockLen_mul_succ_le_sum_range_sup_natAbs` in `MoltResearch/Discrepancy/Residue.lean`,
   with stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
-- [ ] API coherence for degenerate parameters at max-level: add simp-friendly lemmas for
+- [x] API coherence for degenerate parameters at max-level: add simp-friendly lemmas for
   `discOffsetUpTo f 1 m N`, `discOffsetUpTo f d 0 N`, and `discOffsetUpTo f d m 0`,
   normalizing statements to the preferred nucleus forms (without unfolding) and cover with a SurfaceAudit check.
+  (Implemented in `MoltResearch/Discrepancy/Basic.lean` as simp lemmas `discOffsetUpTo_zero`,
+  `discOffsetUpTo_zero_start`, `discOffsetUpTo_one_shift`; regression examples live in
+  `MoltResearch/Discrepancy/NormalFormExamples.lean`, and the stable surface audit includes `#check`s.)
 
 - [ ] Stable-surface regression mini-pipeline (max-level): add 1–2 compile-only examples under `import MoltResearch.Discrepancy` showing a typical flow
   paper endpoints → nucleus → residue split / cut → `discOffsetUpTo` bounds → conclude a clean inequality,


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: API coherence for degenerate parameters at max-level: add simp-friendly lemmas for

This PR marks the Track B checklist item as completed.

Notes:
- The simp-friendly coherence lemmas are already implemented in `MoltResearch/Discrepancy/Basic.lean`:
  - `discOffsetUpTo_zero`
  - `discOffsetUpTo_zero_start`
  - `discOffsetUpTo_one_shift`
- Compile-only regression examples live in `MoltResearch/Discrepancy/NormalFormExamples.lean`.
- The stable surface audit includes `#check` entries in `MoltResearch/Discrepancy/SurfaceAudit.lean`.

CI: `make ci`
