### PR TITLE
Track B: stable-surface mini-pipeline example

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormPipelineExample.lean
+++ b/MoltResearch/Discrepancy/NormalFormPipelineExample.lean
@@ -113,6 +113,42 @@ section
         _ = discOffset g 1 0 3 + discOffset g 1 3 3 + 2 := by
               ac_rfl
 
+  /-!
+  ## `discOffsetUpTo` cut/concatenation inequality (compile-only)
+
+  A very common Track B move is: bound a long segment by cutting it into an initial prefix of
+  length `N` and a tail segment of length `K`.
+
+  This exercises the `discOffsetUpTo` “max up to length” wrapper *and* the cut/concatenation lemma,
+  under the stable surface:
+
+  ```lean
+  import MoltResearch.Discrepancy
+  ```
+  -/
+
+  section UpToCut
+
+  variable (f : ℕ → ℤ) (d m N K : ℕ)
+
+  -- Cut/concatenation inequality (stable surface):
+  --   max up to `N+K` ≤ (max up to `N`) + (max on tail length `K`).
+  example :
+      discOffsetUpTo f d m (N + K) ≤ discOffsetUpTo f d m N + discOffsetUpTo f d (m + N) K := by
+    simpa using (discOffsetUpTo_add_le_add_discOffsetUpTo (f := f) (d := d) (m := m) (N := N) (K := K))
+
+  -- A clean inequality for a *particular* tail length, chained through `discOffset ≤ discOffsetUpTo`.
+  example :
+      discOffset f d m (N + K) ≤ discOffsetUpTo f d m N + discOffsetUpTo f d (m + N) K := by
+    have h1 : discOffset f d m (N + K) ≤ discOffsetUpTo f d m (N + K) := by
+      simpa using (discOffset_le_discOffsetUpTo_self (f := f) (d := d) (m := m) (n := N + K))
+    have h2 :
+        discOffsetUpTo f d m (N + K) ≤ discOffsetUpTo f d m N + discOffsetUpTo f d (m + N) K := by
+      simpa using (discOffsetUpTo_add_le_add_discOffsetUpTo (f := f) (d := d) (m := m) (N := N) (K := K))
+    exact le_trans h1 h2
+
+  end UpToCut
+
 end
 
 end MoltResearch

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -986,9 +986,10 @@ Definition of done:
   `discOffsetUpTo_zero_start`, `discOffsetUpTo_one_shift`; regression examples live in
   `MoltResearch/Discrepancy/NormalFormExamples.lean`, and the stable surface audit includes `#check`s.)
 
-- [ ] Stable-surface regression mini-pipeline (max-level): add 1–2 compile-only examples under `import MoltResearch.Discrepancy` showing a typical flow
+- [x] Stable-surface regression mini-pipeline (max-level): add 1–2 compile-only examples under `import MoltResearch.Discrepancy` showing a typical flow
   paper endpoints → nucleus → residue split / cut → `discOffsetUpTo` bounds → conclude a clean inequality,
   and wire into `SurfaceAudit`.
+  (Implemented in `MoltResearch/Discrepancy/NormalFormPipelineExample.lean`; wired via `MoltResearch/Discrepancy/SurfaceAudit.lean`.)
 
 ### Track C - Conjecture stub + equivalences (backlog)
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Stable-surface regression mini-pipeline (max-level): add 1–2 compile-only examples under `import MoltResearch.Discrepancy` showing a typical flow

What changed
- Extended `MoltResearch/Discrepancy/NormalFormPipelineExample.lean` with a tiny compile-only example exercising the `discOffsetUpTo` cut/concatenation inequality (`discOffsetUpTo_add_le_add_discOffsetUpTo`) and a chained bound for a concrete `discOffset` length.
- Marked the checklist item as completed in `Problems/erdos_discrepancy.md` with pointers to the example + `SurfaceAudit` wiring.

Notes
- Example-only change (no new lemmas).
- `make ci` green locally.
