### PR TITLE
Track B: stable-surface mini-pipeline (max-level) regression

### DIFF
--- a/MoltResearch/Discrepancy/MiniPipelineMaxExample.lean
+++ b/MoltResearch/Discrepancy/MiniPipelineMaxExample.lean
@@ -1,0 +1,52 @@
+import MoltResearch.Discrepancy
+
+/-!
+# Discrepancy: stable-surface mini-pipeline (max-level) regression examples
+
+Checklist item: `Problems/erdos_discrepancy.md` (Track B)
+
+These are intentionally **compile-only** examples that exercise a typical flow under the *stable*
+import surface:
+
+```lean
+import MoltResearch.Discrepancy
+```
+
+Goal: keep a couple of high-leverage “pipeline steps” from regressing without importing any opt-in
+simp bundles.
+-/
+
+namespace MoltResearch
+
+section
+  variable (f : ℕ → ℤ) (d m q N C : ℕ)
+
+  /-!
+  ## Paper endpoints → nucleus `discOffsetUpTo` (endpoint-style rewrite)
+
+  This is the “paper form” (finite `sup` over `t ≤ N`) in the endpoint conventions used downstream.
+  -/
+  example :
+      discOffsetUpTo f d m N =
+        (Finset.Icc 0 N).sup
+          (fun t =>
+            Int.natAbs ((Finset.Icc (m + 1) (m + t)).sum (fun i => f (i * d)))) := by
+    simpa using (discOffsetUpTo_eq_sup_Icc_lengths (f := f) (d := d) (m := m) (N := N))
+
+  /-!
+  ## Residue split / cut (max-level) → clean inequality
+
+  This packages the residue-class split bound for block lengths `q*(n+1)`.
+  -/
+  example (hq : q > 0) :
+      discOffsetUpTo_blockLen_mul_succ f d m q N ≤
+        (Finset.range q).sum (fun r =>
+          (Finset.range (N + 1)).sup (fun n =>
+            Int.natAbs (f ((m + r + 1) * d) + apSumFrom f ((m + r + 1) * d) (q * d) n))) := by
+    simpa using
+      (discOffsetUpTo_blockLen_mul_succ_le_sum_range_sup_natAbs (f := f) (d := d) (m := m)
+        (q := q) (N := N) hq)
+
+end
+
+end MoltResearch

--- a/MoltResearch/Discrepancy/SurfaceAudit.lean
+++ b/MoltResearch/Discrepancy/SurfaceAudit.lean
@@ -1,5 +1,6 @@
 import MoltResearch.Discrepancy
 import MoltResearch.Discrepancy.NormalFormPipelineExample
+import MoltResearch.Discrepancy.MiniPipelineMaxExample
 
 /-!
 # Discrepancy: stable surface audit (compile-time regression tests)

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -989,7 +989,8 @@ Definition of done:
 - [x] Stable-surface regression mini-pipeline (max-level): add 1–2 compile-only examples under `import MoltResearch.Discrepancy` showing a typical flow
   paper endpoints → nucleus → residue split / cut → `discOffsetUpTo` bounds → conclude a clean inequality,
   and wire into `SurfaceAudit`.
-  (Implemented in `MoltResearch/Discrepancy/NormalFormPipelineExample.lean`; wired via `MoltResearch/Discrepancy/SurfaceAudit.lean`.)
+  (Pipeline example lives in `MoltResearch/Discrepancy/NormalFormPipelineExample.lean`; additional max-level smoke examples live in
+  `MoltResearch/Discrepancy/MiniPipelineMaxExample.lean`; both are wired via `MoltResearch/Discrepancy/SurfaceAudit.lean`.)
 
 ### Track C - Conjecture stub + equivalences (backlog)
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Stable-surface regression mini-pipeline (max-level): add 1–2 compile-only examples under `import MoltResearch.Discrepancy` showing a typical flow

What changed
- Added `MoltResearch/Discrepancy/MiniPipelineMaxExample.lean`: compile-only examples under the stable surface that exercise:
  - paper-endpoint rewrite for `discOffsetUpTo`
  - max-level residue split bound for `discOffsetUpTo_blockLen_mul_succ`
- Wired it into `MoltResearch/Discrepancy/SurfaceAudit.lean` so CI enforces the pipeline stays intact.
- Marked the corresponding Track B checklist item as done in `Problems/erdos_discrepancy.md`.

Why
- This provides a small “smoke test” for the intended downstream workflow without importing any opt-in simp bundles.
