### PR TITLE
Track C: core Stage-3 apSum witness

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Entry.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Entry.lean
@@ -148,21 +148,13 @@ theorem stage3_unboundedDiscrepancyAlong_core (f : ℕ → ℤ) (hf : IsSignSequ
 /-!
 ## Witness-form corollaries
 
-These are intentionally kept out of the hard-gate core module.
+Most of these are intentionally kept out of the hard-gate core module.
+
+(The most pipeline-friendly variant `stage3_forall_exists_d_ge_one_witness_pos` lives in
+`TrackCStage3EntryCore.lean` so hard-gate consumers can access it without importing this file.)
 -/
 
-/-- Consumer-facing shortcut: Stage 3 yields the nucleus witness form
-
-`∀ C, ∃ d n, d ≥ 1 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C`.
-
-This is a thin wrapper around the hard-gate lemma `stage3_forall_hasDiscrepancyAtLeast` via the
-global normal form lemma `forall_hasDiscrepancyAtLeast_iff_forall_exists_d_ge_one_witness_pos`.
--/
-theorem stage3_forall_exists_d_ge_one_witness_pos (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    ∀ C : ℕ, ∃ d n : ℕ, d ≥ 1 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C := by
-  exact
-    (forall_hasDiscrepancyAtLeast_iff_forall_exists_d_ge_one_witness_pos f).1
-      (stage3_forall_hasDiscrepancyAtLeast (f := f) (hf := hf))
+-- (moved to `TrackCStage3EntryCore.lean`)
 
 /-- Variant of `stage3_forall_exists_d_ge_one_witness_pos` with strict positivity for the step size.
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
@@ -12,6 +12,8 @@ It provides the minimal Stage-3 entry point API needed by the Track-C hard-gate 
 - `stage3` / `stage3Out` : produce a `Stage3Output f` from a sign sequence `f`
 - `stage3_notBounded` : close the core goal `¬ BoundedDiscrepancy f`
 - `stage3_forall_hasDiscrepancyAtLeast` : the usual surface statement `∀ C, HasDiscrepancyAtLeast f C`
+- `stage3_forall_exists_d_ge_one_witness_pos` : the pipeline-friendly nucleus witness normal form
+  `∀ C, ∃ d n, d ≥ 1 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C`
 
 All additional projections and rewrite lemmas (e.g. `stage3_d`, `stage3_g`, `stage3_start`,
 `stage3_g_eq`, ...) live in `Conjectures.C0002_erdos_discrepancy.src.TrackCStage3Entry`.
@@ -60,6 +62,19 @@ This is a thin wrapper around `Stage3Output.forall_hasDiscrepancyAtLeast`.
 theorem stage3_forall_hasDiscrepancyAtLeast (f : ℕ → ℤ) (hf : IsSignSequence f) :
     ∀ C : ℕ, HasDiscrepancyAtLeast f C := by
   exact Stage3Output.forall_hasDiscrepancyAtLeast (f := f) (stage3Out (f := f) (hf := hf))
+
+/-- Consumer-facing shortcut: Stage 3 yields the nucleus witness form
+
+`∀ C, ∃ d n, d ≥ 1 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C`.
+
+This is the most pipeline-friendly surface statement for consuming Stage 3 without importing the
+larger Stage-3 output-lemma layer.
+-/
+theorem stage3_forall_exists_d_ge_one_witness_pos (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    ∀ C : ℕ, ∃ d n : ℕ, d ≥ 1 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C := by
+  exact
+    (forall_hasDiscrepancyAtLeast_iff_forall_exists_d_ge_one_witness_pos f).1
+      (stage3_forall_hasDiscrepancyAtLeast (f := f) (hf := hf))
 
 end Tao2015
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Expose the pipeline-friendly Stage-3 nucleus witness normal form (apSum) in the Stage-3 hard-gate core entry module.
- Remove the duplicate wrapper from TrackCStage3Entry and update the witness-corollary docs accordingly.
- Keep Stage-3 imports minimal: this is derived from stage3_forall_hasDiscrepancyAtLeast via a global normal-form equivalence.
