### PR TITLE
Track C: Stage-3 witness wrappers in core

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Entry.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Entry.lean
@@ -154,30 +154,9 @@ Most of these are intentionally kept out of the hard-gate core module.
 `TrackCStage3EntryCore.lean` so hard-gate consumers can access it without importing this file.)
 -/
 
--- (moved to `TrackCStage3EntryCore.lean`)
-
-/-- Variant of `stage3_forall_exists_d_ge_one_witness_pos` with strict positivity for the step size.
-
-Normal form:
-`∀ C, ∃ d n, d > 0 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C`.
--/
-theorem stage3_forall_exists_d_pos_witness_pos (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    ∀ C : ℕ, ∃ d n : ℕ, d > 0 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C := by
-  intro C
-  rcases stage3_forall_exists_d_ge_one_witness_pos (f := f) (hf := hf) C with
-    ⟨d, n, hd, hn, hw⟩
-  refine ⟨d, n, ?_, hn, hw⟩
-  exact lt_of_lt_of_le Nat.zero_lt_one hd
-
-/-- Variant of `stage3_forall_exists_d_pos_witness_pos` with the step-size condition written as
-`d ≠ 0`.
--/
-theorem stage3_forall_exists_d_ne_zero_witness_pos (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    ∀ C : ℕ, ∃ d n : ℕ, d ≠ 0 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C := by
-  intro C
-  rcases stage3_forall_exists_d_pos_witness_pos (f := f) (hf := hf) C with
-    ⟨d, n, hd, hn, hw⟩
-  exact ⟨d, n, Nat.ne_of_gt hd, hn, hw⟩
+-- (moved to `TrackCStage3EntryCore.lean`): the nucleus witness normal forms
+-- `stage3_forall_exists_d_ge_one_witness_pos`, `stage3_forall_exists_d_pos_witness_pos`, and
+-- `stage3_forall_exists_d_ne_zero_witness_pos`.
 
 /-- Consumer-facing shortcut: Stage 3 yields the discrepancy witness form
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
@@ -76,6 +76,29 @@ theorem stage3_forall_exists_d_ge_one_witness_pos (f : ℕ → ℤ) (hf : IsSign
     (forall_hasDiscrepancyAtLeast_iff_forall_exists_d_ge_one_witness_pos f).1
       (stage3_forall_hasDiscrepancyAtLeast (f := f) (hf := hf))
 
+/-- Variant of `stage3_forall_exists_d_ge_one_witness_pos` with strict positivity for the step size.
+
+Normal form:
+`∀ C, ∃ d n, d > 0 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C`.
+-/
+theorem stage3_forall_exists_d_pos_witness_pos (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    ∀ C : ℕ, ∃ d n : ℕ, d > 0 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C := by
+  intro C
+  rcases stage3_forall_exists_d_ge_one_witness_pos (f := f) (hf := hf) C with
+    ⟨d, n, hd, hn, hw⟩
+  refine ⟨d, n, ?_, hn, hw⟩
+  exact lt_of_lt_of_le Nat.zero_lt_one hd
+
+/-- Variant of `stage3_forall_exists_d_pos_witness_pos` with the step-size condition written as
+`d ≠ 0`.
+-/
+theorem stage3_forall_exists_d_ne_zero_witness_pos (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    ∀ C : ℕ, ∃ d n : ℕ, d ≠ 0 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C := by
+  intro C
+  rcases stage3_forall_exists_d_pos_witness_pos (f := f) (hf := hf) C with
+    ⟨d, n, hd, hn, hw⟩
+  exact ⟨d, n, Nat.ne_of_gt hd, hn, hw⟩
+
 end Tao2015
 
 end MoltResearch


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Move the Stage-3 nucleus witness wrappers (d > 0 and d ≠ 0 variants) into the hard-gate core entry module.
- Keep TrackCStage3Entry lean by removing the duplicate definitions and leaving a pointer to the core location.
- No changes to the Stage-3 API names; this is a packaging-only refactor inside Conjectures/.
