### PR TITLE
Track C: discrepancy witness wrapper

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
@@ -99,6 +99,20 @@ theorem stage3_forall_exists_d_ne_zero_witness_pos (f : ℕ → ℤ) (hf : IsSig
     ⟨d, n, hd, hn, hw⟩
   exact ⟨d, n, Nat.ne_of_gt hd, hn, hw⟩
 
+/-- Discrepancy witness form of `stage3_forall_exists_d_pos_witness_pos`.
+
+Normal form:
+`∀ C, ∃ d n, d > 0 ∧ n > 0 ∧ discrepancy f d n > C`.
+-/
+theorem stage3_forall_exists_discrepancy_gt_witness_pos (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    ∀ C : ℕ, ∃ d n : ℕ, d > 0 ∧ n > 0 ∧ discrepancy f d n > C := by
+  intro C
+  rcases stage3_forall_exists_d_pos_witness_pos (f := f) (hf := hf) C with ⟨d, n, hd, hn, hw⟩
+  refine ⟨d, n, hd, hn, ?_⟩
+  -- `discrepancy f d n` is definitionally `Int.natAbs (apSum f d n)`.
+  change Int.natAbs (apSum f d n) > C
+  exact hw
+
 /-- Consumer-facing shortcut: Stage 3 yields the paper-notation witness form
 
 `∀ C, ∃ d n, d > 0 ∧ n > 0 ∧ Int.natAbs (∑ i ∈ Icc 1 n, f (i*d)) > C`.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add Stage 3 entry-core wrapper stage3_forall_exists_discrepancy_gt_witness_pos.
- Exposes the common witness normal form with discrepancy f d n > C plus side conditions d > 0 and n > 0.
- Keeps the hard-gate Stage 3 entry API usable without importing the larger Stage 3 convenience layer.
