### PR TITLE
Track C: discrepancy witness with d ≥ 1

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancyWitnesses.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancyWitnesses.lean
@@ -103,6 +103,16 @@ theorem erdos_discrepancy_discrepancy (f : ℕ → ℤ) (hf : IsSignSequence f) 
     (Tao2015.Stage3Output.forall_exists_discrepancy_gt (f := f)
       (Tao2015.stage3Out (f := f) (hf := hf)))
 
+/-- Variant of `erdos_discrepancy_discrepancy` writing the step-size side condition as `d ≥ 1`.
+
+Many later analytic stages prefer `d ≥ 1` rather than `d > 0` when working with `Nat` step sizes.
+-/
+theorem erdos_discrepancy_discrepancy_d_ge_one (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    ∀ C : ℕ, ∃ d n : ℕ, d ≥ 1 ∧ discrepancy f d n > C := by
+  simpa using
+    (Tao2015.Stage3Output.forall_exists_discrepancy_gt_d_ge_one (f := f)
+      (Tao2015.stage3Out (f := f) (hf := hf)))
+
 /-- Strengthened witness form of `erdos_discrepancy_discrepancy` with a positive-length witness.
 
 This is sometimes convenient when downstream stages want to rule out the degenerate case `n = 0`.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a d ≥ 1 version of the discrepancy witness corollary in ErdosDiscrepancyWitnesses.
- Route it through the existing Stage3Output packaging lemma to keep the Stage-3 boundary surface stable.
