### PR TITLE
Track C: move Stage3 reduced boundedness lemma to core

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Core.lean
@@ -65,6 +65,12 @@ theorem forall_hasDiscrepancyAtLeastAlong (out : Stage3Output f) :
   simpa [Tao2015.UnboundedDiscrepancyAlong, HasDiscrepancyAtLeastAlong, Stage3Output.g,
     Stage3Output.d] using out.out2.unbounded
 
+/-- Stage 3 implies the reduced sequence is not bounded along its fixed step size. -/
+theorem notBoundedReducedAlong (out : Stage3Output f) : ¬ BoundedDiscrepancyAlong out.g out.d := by
+  exact
+    (Tao2015.UnboundedDiscrepancyAlong.iff_not_boundedDiscrepancyAlong (g := out.g) (d := out.d)).1
+      out.unboundedReducedAlong
+
 /-- Stage 3 yields unbounded fixed-step discrepancy for the reduced sequence, expressed using the
 verified core predicate `MoltResearch.UnboundedDiscrepancyAlong`.
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Output.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Output.lean
@@ -117,11 +117,6 @@ theorem forall_exists_sum_Icc_d_ge_one_witness_pos (out : Stage3Output f) :
 
 -- (moved to `TrackCStage3Core.lean`)
 
-/-- Stage 3 implies the reduced sequence is not bounded along its fixed step size. -/
-theorem notBoundedReducedAlong (out : Stage3Output f) : ¬ BoundedDiscrepancyAlong out.g out.d := by
-  simpa [Stage3Output.g, Stage3Output.d] using
-    (Stage2Output.notBoundedReducedAlong (f := f) out.out2)
-
 /-- Stage 3 output yields unboundedness of the bundled offset discrepancy family
 `discOffset f d m` at the concrete parameters coming from Stage 1.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Moved Stage 3 lemma notBoundedReducedAlong into TrackCStage3Core so downstream stages can use it via the light core import.
- Removed the duplicate definition from TrackCStage3Output (it is still available there via the core import).
