### PR TITLE
Track C: discrepancy witness with d >= 1

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
@@ -113,6 +113,22 @@ theorem stage3_forall_exists_discrepancy_gt_witness_pos (f : ℕ → ℤ) (hf : 
   change Int.natAbs (apSum f d n) > C
   exact hw
 
+/-- Variant of `stage3_forall_exists_discrepancy_gt_witness_pos` with the step-size condition
+written as `d ≥ 1`.
+
+Normal form:
+`∀ C, ∃ d n, d ≥ 1 ∧ n > 0 ∧ discrepancy f d n > C`.
+-/
+theorem stage3_forall_exists_discrepancy_gt_d_ge_one_witness_pos (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    ∀ C : ℕ, ∃ d n : ℕ, d ≥ 1 ∧ n > 0 ∧ discrepancy f d n > C := by
+  intro C
+  rcases stage3_forall_exists_d_ge_one_witness_pos (f := f) (hf := hf) C with
+    ⟨d, n, hd, hn, hw⟩
+  refine ⟨d, n, hd, hn, ?_⟩
+  -- `discrepancy f d n` is definitionally `Int.natAbs (apSum f d n)`.
+  change Int.natAbs (apSum f d n) > C
+  exact hw
+
 /-- Consumer-facing shortcut: Stage 3 yields the paper-notation witness form
 
 `∀ C, ∃ d n, d > 0 ∧ n > 0 ∧ Int.natAbs (∑ i ∈ Icc 1 n, f (i*d)) > C`.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a Stage-3 entry-point lemma giving discrepancy witnesses with step size d ≥ 1 and n > 0.
- Proof is a thin wrapper around the existing nucleus witness form, keeping the hard-gate core lightweight.
