### PR TITLE
Track C: Stage 4 d != 0 witness form

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage4.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage4.lean
@@ -83,6 +83,13 @@ theorem forall_exists_d_pos_witness_pos (out : Stage4Output f) :
   refine ⟨d, n, ?_, hn, hw⟩
   exact lt_of_lt_of_le Nat.zero_lt_one hd
 
+/-- Variant of `forall_exists_d_pos_witness_pos` with the step-size condition written as `d ≠ 0`. -/
+theorem forall_exists_d_ne_zero_witness_pos (out : Stage4Output f) :
+    ∀ C : ℕ, ∃ d n : ℕ, d ≠ 0 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C := by
+  intro C
+  rcases out.forall_exists_d_pos_witness_pos (f := f) C with ⟨d, n, hd, hn, hw⟩
+  exact ⟨d, n, Nat.ne_of_gt hd, hn, hw⟩
+
 /-- Stage 4 output implies the explicit discrepancy witness normal form
 
 `∀ C, ∃ d n, d > 0 ∧ discrepancy f d n > C`.
@@ -193,6 +200,13 @@ Normal form:
 theorem stage4_forall_exists_d_pos_witness_pos (f : ℕ → ℤ) (hf : IsSignSequence f) :
     ∀ C : ℕ, ∃ d n : ℕ, d > 0 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C := by
   exact (stage4Out (f := f) (hf := hf)).forall_exists_d_pos_witness_pos (f := f)
+
+/-- Variant of `stage4_forall_exists_d_pos_witness_pos` with the step-size condition written as
+`d ≠ 0`.
+-/
+theorem stage4_forall_exists_d_ne_zero_witness_pos (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    ∀ C : ℕ, ∃ d n : ℕ, d ≠ 0 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C := by
+  exact (stage4Out (f := f) (hf := hf)).forall_exists_d_ne_zero_witness_pos (f := f)
 
 /-- Consumer-facing shortcut: Stage 4 yields explicit discrepancy witnesses
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add Stage 4 witness normal form with step-size condition d ≠ 0 (both as a Stage4Output lemma and as a stage4_... convenience wrapper).
- This matches the existing Stage 3 witness variants and makes Stage 4 easier to consume in later pipeline steps.
