### PR TITLE
Track C: de-duplicate Stage2/3 output lemmas

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancyWitnesses.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancyWitnesses.lean
@@ -158,6 +158,18 @@ theorem erdos_discrepancy_exists_params_forall_exists_discOffset_gt (f : ℕ →
     (Tao2015.Stage2Output.exists_params_forall_exists_discOffset_gt (f := f)
       (Tao2015.stage3Out (f := f) (hf := hf)).out2)
 
+/-- Positive-length witness form of `erdos_discrepancy_exists_params_forall_exists_discOffset_gt`.
+
+The witness length `n` cannot be `0`, since `discOffset f d m 0 = 0`.
+-/
+theorem erdos_discrepancy_exists_params_forall_exists_discOffset_gt_witness_pos (f : ℕ → ℤ)
+    (hf : IsSignSequence f) :
+    ∃ d m : ℕ, d > 0 ∧ (∀ B : ℕ, ∃ n : ℕ, n > 0 ∧ B < discOffset f d m n) := by
+  rcases erdos_discrepancy_exists_params_unboundedDiscOffset (f := f) (hf := hf) with
+    ⟨d, m, hd, hunb⟩
+  refine ⟨d, m, hd, ?_⟩
+  exact Tao2015.UnboundedDiscOffset.forall_exists_discOffset_gt_witness_pos (hunb := hunb)
+
 /-- Variant of `erdos_discrepancy_exists_params_forall_exists_discOffset_gt` packaging the step-size
 side condition as `1 ≤ d`.
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
@@ -98,18 +98,6 @@ theorem forall_exists_natAbs_apSumFrom_mul_gt (out : Stage2Output f) :
   simpa using
     (out.unbounded_iff_forall_exists_natAbs_apSumFrom_mul_gt (f := f)).1 out.unbounded
 
-/-- Positive-length witness form of `forall_exists_natAbs_apSumFrom_mul_gt`.
-
-The witness length `n` cannot be `0`, since `apSumFrom ... 0 = 0`.
--/
-theorem forall_exists_natAbs_apSumFrom_mul_gt_witness_pos (out : Stage2Output f) :
-    ∀ C : ℕ, ∃ n : ℕ, n > 0 ∧ Int.natAbs (apSumFrom f (out.m * out.d) out.d n) > C := by
-  have hunb : UnboundedDiscOffset f out.d out.m :=
-    (out.out1.unboundedDiscrepancyAlong_iff_unboundedDiscOffset (f := f)).1 out.unbounded
-  simpa using
-    (UnboundedDiscOffset.forall_exists_natAbs_apSumFrom_mul_gt_witness_pos (f := f) (d := out.d)
-      (m := out.m) hunb)
-
 -- (moved to `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Core`)
 
 /-- Stage 2 implies the reduced sequence is not bounded along its fixed step size. -/

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Output.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Output.lean
@@ -117,16 +117,6 @@ theorem forall_exists_sum_Icc_d_ge_one_witness_pos (out : Stage3Output f) :
 
 -- (moved to `TrackCStage3Core.lean`)
 
-/-- Stage 3 output yields unboundedness of the bundled offset discrepancy family
-`discOffset f d m` at the concrete parameters coming from Stage 1.
-
-This is a thin wrapper around `Stage2Output.unboundedDiscOffset`.
--/
-theorem unboundedDiscOffset (out : Stage3Output f) :
-    UnboundedDiscOffset f out.d out.m := by
-  simpa [Stage3Output.d, Stage3Output.m] using
-    (Stage2Output.unboundedDiscOffset (f := f) out.out2)
-
 /-- Witness-family form: Stage 3 yields arbitrarily large values of the bundled offset discrepancy
 family `discOffset f out.d out.m`.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a witness-positive packaging lemma for unbounded discOffset parameters (n can be taken > 0).
- Remove a duplicate Stage2Output witness-positive lemma from TrackCStage2Output (it already lives in TrackCStage2Core).
- Remove a duplicate Stage3Output unboundedDiscOffset lemma from TrackCStage3Output (it already lives in TrackCStage3Core).
