### PR TITLE
Track C: add Stage2 discOffset NNF lemma

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
@@ -177,6 +177,23 @@ convenience-lemma file.
 
 -- (moved to `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Core`)
 
+/-- Negation-normal-form unboundedness statement for the bundled offset discrepancies
+`discOffset f out.d out.m`.
+
+Negation-normal form:
+`¬ ∃ B, ∀ n, discOffset f out.d out.m n ≤ B`.
+
+This is a thin wrapper around
+`Tao2015.unboundedDiscOffset_iff_not_exists_forall_discOffset_le`.
+-/
+theorem not_exists_forall_discOffset_le (out : Stage2Output f) :
+    ¬ ∃ B : ℕ, ∀ n : ℕ, discOffset f out.d out.m n ≤ B := by
+  have hunb : UnboundedDiscOffset f out.d out.m := out.unboundedDiscOffset (f := f)
+  exact
+    (Tao2015.unboundedDiscOffset_iff_not_exists_forall_discOffset_le (f := f)
+        (d := out.d) (m := out.m)).1
+      hunb
+
 /-- Negation-normal-form unboundedness statement for the bundled offset nuclei
 `Int.natAbs (apSumOffset f out.d out.m n)`.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a small Stage2Output convenience lemma: negation-normal-form unboundedness for discOffset f out.d out.m (no uniform upper bound).
- This is a thin wrapper around Tao2015.unboundedDiscOffset_iff_not_exists_forall_discOffset_le, specialized to the Stage-2 output parameters.
