### PR TITLE
Track C: shrink Stage-3 hard-gate surface

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
@@ -76,17 +76,7 @@ theorem stage3_forall_exists_d_ge_one_witness_pos (f : ℕ → ℤ) (hf : IsSign
     (forall_hasDiscrepancyAtLeast_iff_forall_exists_d_ge_one_witness_pos f).1
       (stage3_forall_hasDiscrepancyAtLeast (f := f) (hf := hf))
 
-/-- Variant of `stage3_forall_exists_d_ge_one_witness_pos` with strict positivity for `d`.
-
-Normal form:
-`∀ C, ∃ d n, d > 0 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C`.
--/
-theorem stage3_forall_exists_d_pos_witness_pos (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    ∀ C : ℕ, ∃ d n : ℕ, d > 0 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C := by
-  intro C
-  rcases stage3_forall_exists_d_ge_one_witness_pos (f := f) (hf := hf) C with ⟨d, n, hd, hn, hw⟩
-  refine ⟨d, n, ?_, hn, hw⟩
-  exact lt_of_lt_of_le Nat.zero_lt_one hd
+-- (moved to `Conjectures.C0002_erdos_discrepancy.src.TrackCStage3Entry`)
 
 end Tao2015
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Shrink Stage 3 hard-gate core surface by removing the strict-positivity d > 0 witness wrapper.
- Keep the pipeline-friendly d ≥ 1 nucleus witness wrapper in the core; the d > 0 variant remains available in TrackCStage3Entry.
