### PR TITLE
Track C: Stage4 exposes Stage1 reduction output

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage4.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage4.lean
@@ -43,6 +43,15 @@ to re-run earlier stages.
 abbrev out2 (out : Stage4Output f) : Tao2015.Stage2Output f :=
   out.out3.out2
 
+/-- Stage 4 carries the full Stage-2 output, hence also carries the underlying Stage-1 reduction output.
+
+This projection is occasionally useful for later stages that want access to the deterministic
+parameters `g, d, m` and the Stage-1 transport contracts, without forcing them to reach through
+the nested record fields.
+-/
+abbrev out1 (out : Stage4Output f) : Tao2015.ReductionOutput f :=
+  out.out3.out2.out1
+
 /-- Stage 4 output already carries the Stage-3 conclusion `¬ BoundedDiscrepancy f`. -/
 theorem notBounded (out : Stage4Output f) : ¬ BoundedDiscrepancy f :=
   out.out3.notBounded
@@ -179,6 +188,16 @@ without importing the larger Stage-3 convenience layer.
     (stage4Out (f := f) (hf := hf)).out2 = stage2Out (f := f) (hf := hf) := by
   -- Expand `stage4Out` to its Stage-3 payload, then use the Stage-3 definitional rewrite.
   simpa [Stage4Output.out2] using (stage3Out_out2 (f := f) (hf := hf))
+
+/-- The Stage-1 reduction output stored inside `stage4Out` is definitionally the Stage-1 reduction
+output produced by Stage 2.
+
+This lemma is tiny but useful for rewriting when shuttling statements between Stage 1 and Stage 4.
+-/
+@[simp] theorem stage4Out_out1 (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    (stage4Out (f := f) (hf := hf)).out1 = (stage2Out (f := f) (hf := hf)).out1 := by
+  simpa [Stage4Output.out1] using
+    congrArg Tao2015.Stage2Output.out1 (stage4Out_out2 (f := f) (hf := hf))
 
 /-- Consumer-facing shortcut: Stage 4 closes the core goal `¬ BoundedDiscrepancy f`. -/
 theorem stage4_notBounded (f : ℕ → ℤ) (hf : IsSignSequence f) : ¬ BoundedDiscrepancy f := by


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add Stage4Output.out1 projection so later stages can access the Stage-1 ReductionOutput carried through Stage 4.
- Add simp rewrite stage4Out_out1 to shuttle definitions between Stage 2 and Stage 4 cleanly.
