### PR TITLE
Discrepancy: regression for discOffset_congr_support

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -50,6 +50,17 @@ example : discOffset (fun _ => (1 : ℤ)) d m n = n := by
   simpa [discOffset_const_one]
 
 /-!
+### NEW (Track B): support-level congruence for `discOffset`
+
+Regression: if two sequences agree on `apSupport d m n`, then the discrepancy wrapper agrees.
+This should remain a one-line `simpa` under `import MoltResearch.Discrepancy`.
+-/
+
+example (g : ℕ → ℤ) (h : ∀ x ∈ apSupport d m n, f x = g x) :
+    discOffset f d m n = discOffset g d m n := by
+  simpa using (discOffset_congr_support (f := f) (g := g) (d := d) (m := m) (n := n) h)
+
+/-!
 ### NEW (Track B): `discOffsetUpTo` degenerate-parameter simp coherence
 
 Compile-only regression tests ensuring the “degenerate parameter” simp lemmas stay one-liners.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Support-level congruence for `discOffset`: package a stable lemma

Adds a stable-surface regression example (compile-only) for `discOffset_congr_support`, ensuring support-level congruence stays a one-liner under `import MoltResearch.Discrepancy`.

CI: `make ci`