### PR TITLE
Track B: residue-class discOffset inequality regression

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -275,6 +275,20 @@ example (q : ℕ) : apSumFrom (fun t => f (t * q)) a d n = apSumFrom f (a * q) (
   simpa using (apSumFrom_map_mul_right (f := f) (q := q) (a := a) (d := d) (n := n))
 
 /-!
+### NEW (Track B): residue-class splitting (disc-level inequality wrapper)
+
+Compile-only regression: the inequality wrapper should be usable under the stable surface
+`import MoltResearch.Discrepancy`.
+-/
+
+example (q : ℕ) (hq : q > 0) :
+    discOffset f d m (q * (n + 1)) ≤
+      (Finset.range q).sum (fun r =>
+        Int.natAbs (f ((m + r + 1) * d) + apSumFrom f ((m + r + 1) * d) (q * d) n)) := by
+  simpa using
+    (discOffset_mul_len_succ_le_sum_range_natAbs (f := f) (d := d) (m := m) (q := q) (n := n) hq)
+
+/-!
 ### Regression: linearity normal forms (Track B / sum-level)
 
 These should stay one-liners: pushing `+`/`-` out of `apSum`/`apSumOffset`.

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -370,7 +370,7 @@ Goal: build a *directed* lemma scaffold (not lemma-sprawl). Each checkbox should
   `apSumOffset f d m (r*(n+1))` (and the homogeneous `apSum` analogue) as a `Finset.range r` sum of residue blocks at step `r*d`, in a single `rw` away from nucleus terms.
   (Implemented as `apSum_mul_len_succ_eq_sum_range` and `apSumOffset_mul_len_succ_eq_sum_range` in `MoltResearch/Discrepancy/Residue.lean`, with stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
-- [ ] Residue-class splitting (disc-level, inequality wrapper): package the triangle-inequality corollary bounding
+- [x] Residue-class splitting (disc-level, inequality wrapper): package the triangle-inequality corollary bounding
   `discOffset f d m n` by the sum of the residue-class discrepancies produced by the split-equality lemma,
   with a stable regression example under `import MoltResearch.Discrepancy`.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Residue-class splitting (disc-level, inequality wrapper): package the triangle-inequality corollary bounding

Adds a stable-surface regression example for the existing lemma `discOffset_mul_len_succ_le_sum_range_natAbs` (residue-class split + triangle inequality), and marks the Track B checklist item complete.
