### PR TITLE
Track C: Stage2 discOffset witnesses n>0

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
@@ -256,6 +256,16 @@ theorem exists_params_forall_exists_discOffset_gt (out : Stage2Output f) :
   intro B
   simpa using out.forall_exists_discOffset_gt (f := f) B
 
+/-- Strengthening of `exists_params_forall_exists_discOffset_gt` with a positive-length witness.
+
+The witness length `n` cannot be `0`, since `discOffset ... 0 = 0`.
+-/
+theorem exists_params_forall_exists_discOffset_gt_witness_pos (out : Stage2Output f) :
+    ∃ d m : ℕ, d > 0 ∧ (∀ B : ℕ, ∃ n : ℕ, n > 0 ∧ B < discOffset f d m n) := by
+  refine ⟨out.d, out.m, out.hd, ?_⟩
+  intro B
+  simpa using out.forall_exists_discOffset_gt_witness_pos (f := f) B
+
 /-- Inequality-direction variant of `exists_params_forall_exists_discOffset_gt`, written as
 `discOffset f d m n > B`.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Added a Stage2Output packaging lemma giving existential discOffset witnesses with positive length n > 0.
- Keeps the existing witness family normal form but upgrades it to the common n > 0 constraint (since discOffset at 0 is 0).
