### PR TITLE
Discrepancy: simp/coherence for apSupport at n=0

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -33,5 +33,6 @@ The goal is to pair verified artifacts with learning scaffolding.
   - `discOffsetUpTo f d m 0 = 0`
   - `discOffsetUpTo f d 0 N = discUpTo f d N`
   - step-one shift: `discOffsetUpTo f 1 m N = discUpTo (fun k => f (k + m)) 1 N`
+- **API note (degenerate length for `apSupport`):** when writing support-form hypotheses (agreement on `apSupport d m n`), the base case `n = 0` should reduce immediately. Use the simp lemma `apSupport_zero` to rewrite `apSupport d m 0` to `∅`.
 - **API note (shift–dilation coherence):** when you both (i) push an offset shift into the summand and (ii) pull a factor `q` into the step, use the commutation lemma `apSumOffset_shift_mul_right_comm` (and the wrapper `discOffset_shift_mul_right_comm`) to avoid redoing index algebra. Conceptually: “shift then dilate” = “dilate then shift (with scaled offset)”.
 - **Related tasks:** `T1_01`, `T1_07`, `T1_12`.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -241,6 +241,11 @@ the support still contains that index just once).
 def apSupport (d m n : ℕ) : Finset ℕ :=
   (Finset.range n).image (fun i => (m + i + 1) * d)
 
+/-- Degenerate case: no indices are accessed when `n = 0`. -/
+@[simp] lemma apSupport_zero (d m : ℕ) : apSupport d m 0 = ∅ := by
+  unfold apSupport
+  simp
+
 /-- If `i < n` then the corresponding index `(m + i + 1) * d` belongs to `apSupport d m n`. -/
 lemma mem_apSupport_of_lt {i d m n : ℕ} (hi : i < n) :
     (m + i + 1) * d ∈ apSupport d m n := by

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -74,6 +74,19 @@ example (g : ℕ → ℤ) (h : ∀ x ∈ apSupport d m n, f x = g x) :
   simpa using (discOffset_congr_support (f := f) (g := g) (d := d) (m := m) (n := n) h)
 
 /-!
+### NEW (Track B): `apSupport` simp/coherence (degenerate length)
+
+Regression: the support finset should simp cleanly when `n = 0`, and the `n+1` rewrite should
+reduce to inserting into `∅`.
+-/
+
+example (d m : ℕ) : apSupport d m 0 = ∅ := by
+  simp
+
+example (d m : ℕ) : apSupport d m (0 + 1) = insert ((m + 0 + 1) * d) (∅) := by
+  simpa using (apSupport_add_one (d := d) (m := m) (n := 0))
+
+/-!
 ### NEW (Track B): `discOffsetUpTo` degenerate-parameter simp coherence
 
 Compile-only regression tests ensuring the “degenerate parameter” simp lemmas stay one-liners.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `apSupport` simp/coherence surface: add minimal simp lemmas and rewrite helpers for `apSupport` (degenerate `n=0`,

What changed
- Added `[simp] apSupport_zero` so `apSupport d m 0` reduces to `∅`.
- Added stable-surface regression examples in `Discrepancy/NormalFormExamples.lean` verifying the `n=0` simp and that the `n+1` rewrite reduces to inserting into `∅`.

Notes
- Kept the change minimal and orientation-safe (no extra lemmas beyond the degenerate-length simp).
