### PR TITLE
Discrepancy: apSupport simp/coherence surface

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -34,5 +34,8 @@ The goal is to pair verified artifacts with learning scaffolding.
   - `discOffsetUpTo f d 0 N = discUpTo f d N`
   - step-one shift: `discOffsetUpTo f 1 m N = discUpTo (fun k => f (k + m)) 1 N`
 - **API note (degenerate length for `apSupport`):** when writing support-form hypotheses (agreement on `apSupport d m n`), the base case `n = 0` should reduce immediately. Use the simp lemma `apSupport_zero` to rewrite `apSupport d m 0` to `∅`.
+- **API note (`apSupport` bookkeeping helpers):** for common “no-op” shifts/dilations, the stable surface provides simp lemmas
+  `apSupport_add_left_zero` and `apSupport_mul_right_one` so `simp` can discharge trivial `m+0` / `d*1` noise without unfolding.
+  For unfold-free membership reasoning, use `mem_apSupport_iff`.
 - **API note (shift–dilation coherence):** when you both (i) push an offset shift into the summand and (ii) pull a factor `q` into the step, use the commutation lemma `apSumOffset_shift_mul_right_comm` (and the wrapper `discOffset_shift_mul_right_comm`) to avoid redoing index algebra. Conceptually: “shift then dilate” = “dilate then shift (with scaled offset)”.
 - **Related tasks:** `T1_01`, `T1_07`, `T1_12`.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -253,6 +253,24 @@ lemma mem_apSupport_of_lt {i d m n : ℕ} (hi : i < n) :
   refine Finset.mem_image.2 ?_
   exact ⟨i, Finset.mem_range.2 hi, rfl⟩
 
+/-!
+### Membership characterization (Track B)
+
+This is a small “unfold-free” interface lemma for the `apSupport` support finset.
+
+We do *not* mark it `[simp]` to avoid loops with `Finset.mem_image`.
+-/
+
+lemma mem_apSupport_iff {d m n x : ℕ} :
+    x ∈ apSupport d m n ↔ ∃ i, i < n ∧ x = (m + i + 1) * d := by
+  unfold apSupport
+  constructor
+  · intro hx
+    rcases Finset.mem_image.1 hx with ⟨i, hi, rfl⟩
+    exact ⟨i, Finset.mem_range.1 hi, rfl⟩
+  · rintro ⟨i, hi, rfl⟩
+    exact Finset.mem_image.2 ⟨i, Finset.mem_range.2 hi, rfl⟩
+
 /-- Monotonicity in the length parameter: the accessed-index set can only grow when `n` increases.
 
 (Track B normal-form checklist item: support monotonicity API.)
@@ -388,6 +406,22 @@ lemma apSupport_mul_right (d m n q : ℕ) :
     refine Finset.mem_image.2 ?_
     refine ⟨i, hi, ?_⟩
     simp [Nat.mul_assoc]
+
+/-! ### Degenerate-parameter simp lemmas (Track B)
+
+These provide a small simp surface so “start-shift” and “dilation” bookkeeping doesn't force
+unfolding `apSupport`.
+
+We keep them minimal to avoid simp loops.
+-/
+
+@[simp] lemma apSupport_add_left_zero (d m n : ℕ) :
+    apSupport d (m + 0) n = apSupport d m n := by
+  simpa using (apSupport_add_left (d := d) (m := m) (n := n) (k := 0))
+
+@[simp] lemma apSupport_mul_right_one (d m n : ℕ) :
+    apSupport (d * 1) m n = apSupport d m n := by
+  simpa [Nat.mul_one] using (apSupport_mul_right (d := d) (m := m) (n := n) (q := 1))
 
 /-!
 ### “Contracted support” API (Track B)

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -87,6 +87,33 @@ example (d m : ℕ) : apSupport d m (0 + 1) = insert ((m + 0 + 1) * d) (∅) := 
   simpa using (apSupport_add_one (d := d) (m := m) (n := 0))
 
 /-!
+### NEW (Track B): `apSupport` simp/coherence (start-shift, dilation, membership)
+
+These are compile-only regression tests ensuring the “support finset” API can be used without
+unfolding.
+-/
+
+example (d m n : ℕ) : apSupport d (m + 0) n = apSupport d m n := by
+  simp
+
+example (d m n : ℕ) : apSupport (d * 1) m n = apSupport d m n := by
+  simp
+
+example (d m n k : ℕ) : apSupport d (m + k) n = (apSupport d m n).image (fun x => x + k * d) := by
+  simpa using (apSupport_add_left (d := d) (m := m) (n := n) (k := k))
+
+example (d m n q : ℕ) : apSupport (d * q) m n = (apSupport d m n).image (fun x => x * q) := by
+  simpa using (apSupport_mul_right (d := d) (m := m) (n := n) (q := q))
+
+example (d m n : ℕ) :
+    ((m + 0 + 1) * d) ∈ apSupport d m (n + 1) := by
+  -- `mem_apSupport_iff` is the unfold-free membership interface.
+  have : ∃ i, i < n + 1 ∧ ((m + 0 + 1) * d) = (m + i + 1) * d := by
+    refine ⟨0, Nat.succ_pos _, ?_⟩
+    simp
+  exact (mem_apSupport_iff (d := d) (m := m) (n := n + 1) (x := (m + 0 + 1) * d)).2 this
+
+/-!
 ### NEW (Track B): `discOffsetUpTo` degenerate-parameter simp coherence
 
 Compile-only regression tests ensuring the “degenerate parameter” simp lemmas stay one-liners.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `apSupport` simp/coherence surface: add minimal simp lemmas and rewrite helpers for `apSupport` (degenerate `n=0`,

Summary:
- Add `mem_apSupport_iff` as an unfold-free membership characterization for `apSupport`.
- Add minimal simp helpers for common degenerate bookkeeping:
  - `apSupport_add_left_zero`
  - `apSupport_mul_right_one`
- Add stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean` covering:
  - n=0 and n+1 insert rewrite
  - start-shift and dilation coherence rewrites
  - a small membership example using `mem_apSupport_iff`

Notes:
- No opportunistic lemma sprawl; changes are confined to the `apSupport` simp/coherence surface.