### PR TITLE
Track B: apSupport simp/coherence surface (checklist bookkeeping)

### DIFF
--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -378,8 +378,11 @@ Goal: build a *directed* lemma scaffold (not lemma-sprawl). Each checkbox should
   “pull a common factor into the step” commute in the nucleus API (for `apSumOffset` and `discOffset`),
   so normalization pipelines can reorder these steps without manual algebra.
 
-- [ ] `apSupport` simp/coherence surface: add minimal simp lemmas and rewrite helpers for `apSupport` (degenerate `n=0`,
+- [x] `apSupport` simp/coherence surface: add minimal simp lemmas and rewrite helpers for `apSupport` (degenerate `n=0`,
   start-shift, dilation) so support-level congruence lemmas are ergonomic and don’t require unfolding.
+  (Implemented in `MoltResearch/Discrepancy/Basic.lean` (`apSupport_zero`, `apSupport_add_left_zero`, `apSupport_mul_right_one`,
+  plus rewrite helpers `apSupport_add_left`/`apSupport_mul_right`), with stable-surface regression examples in
+  `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
 - [ ] Endpoint-normalization for `discOffset` witnesses: add a small family of simp-friendly lemmas normalizing common endpoint
   algebra (`m+(n+k)`, `m+1+(n-1)`, etc.) into the exact shapes expected by the stable witness APIs (cut/split/affine-tail),


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `apSupport` simp/coherence surface: add minimal simp lemmas and rewrite helpers for `apSupport` (degenerate `n=0`, start-shift, dilation)

This PR marks the checklist item complete and links it to the already-landed implementation:
- `MoltResearch/Discrepancy/Basic.lean`: `apSupport_zero`, `apSupport_add_left_zero`, `apSupport_mul_right_one`, and the rewrite helpers `apSupport_add_left`/`apSupport_mul_right`.
- `MoltResearch/Discrepancy/NormalFormExamples.lean`: stable-surface regression examples showing one-line `simp`/`simpa` usage without unfolding.
