### PR TITLE
Discrepancy: endpoint-normalization helpers for discOffset

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -39,4 +39,6 @@ The goal is to pair verified artifacts with learning scaffolding.
   For unfold-free membership reasoning, use `mem_apSupport_iff`.
 - **API note (shift–dilation coherence):** when you both (i) push an offset shift into the summand and (ii) pull a factor `q` into the step, use the commutation lemma `apSumOffset_shift_mul_right_comm` (and the wrapper `discOffset_shift_mul_right_comm`) to avoid redoing index algebra. Conceptually: “shift then dilate” = “dilate then shift (with scaled offset)”.
 - **API note (paper interval normalization):** many downstream proofs naturally produce paper-style terms like `Int.natAbs ((Finset.Icc (m+1) (m+n)).sum ...)`. The stable surface exports simp lemmas rewriting these directly to `discOffset f d m n`, so endpoint algebra can be normalized by `simp` without manually rewriting `discOffset_eq_natAbs_sum_Icc` back and forth.
+- **API note (endpoint normalization):** when you have endpoint-style constraints in a `Finset.Icc` form, you can convert cleanly to the paper-style conjunction used by `discOffset_congr_endpoints`. Use `endpoints_lt_le_iff_mem_finset_Icc` to rewrite
+  `m < i ∧ i ≤ m+n` ↔ `i ∈ Finset.Icc (m+1) (m+n)`, and `endpoints_lt_le_iff_succ_le_lt_succ` for the variant `m+1 ≤ i ∧ i < m+n+1`.
 - **Related tasks:** `T1_01`, `T1_07`, `T1_12`.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -1435,6 +1435,53 @@ lemma discOffset_congr_endpoints (f g : ℕ → ℤ) (d m n : ℕ)
   refine congrArg Int.natAbs ?_
   exact apSumOffset_congr_endpoints (f := f) (g := g) (d := d) (m := m) (n := n) (h := h)
 
+/-!
+### Endpoint-normalization lemmas (Track B)
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — Endpoint-normalization for `discOffset` witnesses.
+
+These lemmas package the small Nat arithmetic conversions that routinely arise when moving between
+endpoint-style hypotheses (paper notation) and finitary `Finset.Icc` membership hypotheses.
+
+We keep them **simp-friendly** (usable via `simp`/`simpa`) but avoid adding aggressive global
+`[simp]` attributes to prevent loops.
+-/
+
+/-- Endpoint-normalization lemma: endpoint-style constraints are `Finset.Icc` membership.
+
+Concretely,
+`m < i ∧ i ≤ m+n` is equivalent to `i ∈ Finset.Icc (m+1) (m+n)`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — Endpoint-normalization for `discOffset` witnesses.
+-/
+lemma endpoints_lt_le_iff_mem_finset_Icc (m n i : ℕ) :
+    (m < i ∧ i ≤ m + n) ↔ i ∈ Finset.Icc (m + 1) (m + n) := by
+  constructor
+  · intro h
+    exact Finset.mem_Icc.2 ⟨(Nat.succ_le_iff).2 h.1, h.2⟩
+  · intro h
+    have h' : m + 1 ≤ i ∧ i ≤ m + n := (Finset.mem_Icc).1 h
+    exact ⟨(Nat.succ_le_iff).1 h'.1, h'.2⟩
+
+/-- Endpoint-normalization lemma: endpoint constraints in `≤` form can be written in `lt` form.
+
+Concretely,
+`m < i ∧ i ≤ m+n` is equivalent to `m+1 ≤ i ∧ i < m+n+1`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — Endpoint-normalization for `discOffset` witnesses.
+-/
+lemma endpoints_lt_le_iff_succ_le_lt_succ (m n i : ℕ) :
+    (m < i ∧ i ≤ m + n) ↔ (m + 1 ≤ i ∧ i < m + n + 1) := by
+  constructor
+  · intro h
+    refine ⟨(Nat.succ_le_iff).2 h.1, ?_⟩
+    -- `i ≤ m+n` iff `i < m+n+1`.
+    exact (Nat.lt_succ_iff).2 (by simpa [Nat.add_assoc] using h.2)
+  · intro h
+    refine ⟨(Nat.succ_le_iff).1 h.1, ?_⟩
+    -- `i < m+n+1` iff `i ≤ m+n`.
+    exact (Nat.lt_succ_iff).1 (by simpa [Nat.add_assoc] using h.2)
+
 /-- Range-form congruence lemma for `discOffset`.
 
 If `f` and `g` agree on every summation index `i ∈ Finset.range n` in the `range`-expanded normal

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -74,6 +74,26 @@ example (g : ℕ → ℤ) (h : ∀ x ∈ apSupport d m n, f x = g x) :
   simpa using (discOffset_congr_support (f := f) (g := g) (d := d) (m := m) (n := n) h)
 
 /-!
+### NEW (Track B): endpoint-normalization helpers for `discOffset` witnesses
+
+Regression: a common hypothesis shape is stated using finitary endpoint sets
+`i ∈ Finset.Icc (m+1) (m+n)`; the nucleus API also supports the paper-style conjunction
+`m < i ∧ i ≤ m+n`.
+
+This example ensures the helper lemma `endpoints_lt_le_iff_mem_finset_Icc` keeps the conversion
+one-line under `import MoltResearch.Discrepancy`.
+-/
+
+example (g : ℕ → ℤ)
+    (h : ∀ i, i ∈ Finset.Icc (m + 1) (m + n) → f (i * d) = g (i * d)) :
+    discOffset f d m n = discOffset g d m n := by
+  refine discOffset_congr_endpoints (f := f) (g := g) (d := d) (m := m) (n := n) ?_
+  intro i hi
+  have hi' : i ∈ Finset.Icc (m + 1) (m + n) :=
+    (endpoints_lt_le_iff_mem_finset_Icc (m := m) (n := n) (i := i)).1 hi
+  exact h i hi'
+
+/-!
 ### NEW (Track B): `apSupport` simp/coherence (degenerate length)
 
 Regression: the support finset should simp cleanly when `n = 0`, and the `n+1` rewrite should
@@ -1026,6 +1046,26 @@ example : UnboundedDiscrepancyAlong f d ↔ (∀ C : ℕ, ∃ n : ℕ, C < discO
 example (g : ℕ → ℤ) (h : ∀ x ∈ apSupport d m n, f x = g x) :
     discOffset f d m n = discOffset g d m n := by
   simpa using (discOffset_congr_support (f := f) (g := g) (d := d) (m := m) (n := n) h)
+
+/-!
+### NEW (Track B): endpoint-normalization helpers for `discOffset` witnesses
+
+Regression: a common hypothesis shape is stated using finitary endpoint sets
+`i ∈ Finset.Icc (m+1) (m+n)`; the nucleus API also supports the paper-style conjunction
+`m < i ∧ i ≤ m+n`.
+
+This example ensures the helper lemma `endpoints_lt_le_iff_mem_finset_Icc` keeps the conversion
+one-line under `import MoltResearch.Discrepancy`.
+-/
+
+example (g : ℕ → ℤ)
+    (h : ∀ i, i ∈ Finset.Icc (m + 1) (m + n) → f (i * d) = g (i * d)) :
+    discOffset f d m n = discOffset g d m n := by
+  refine discOffset_congr_endpoints (f := f) (g := g) (d := d) (m := m) (n := n) ?_
+  intro i hi
+  have hi' : i ∈ Finset.Icc (m + 1) (m + n) :=
+    (endpoints_lt_le_iff_mem_finset_Icc (m := m) (n := n) (i := i)).1 hi
+  exact h i hi'
 
 -- Regression (Track B / local surgery at homogeneous `disc` level):
 -- if two sequences agree on `apSupport d 0 n`, then their homogeneous discrepancies coincide.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Endpoint-normalization for `discOffset` witnesses: add a small family of simp-friendly lemmas normalizing common endpoint

What changed
- Added two small endpoint-normalization lemmas in `MoltResearch.Discrepancy.Basic`:
  - `endpoints_lt_le_iff_mem_finset_Icc`: rewrite `m < i ∧ i ≤ m+n` ↔ `i ∈ Finset.Icc (m+1) (m+n)`.
  - `endpoints_lt_le_iff_succ_le_lt_succ`: rewrite `m < i ∧ i ≤ m+n` ↔ `m+1 ≤ i ∧ i < m+n+1`.
- Added a stable-surface regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean` showing `discOffset_congr_endpoints` can be used from a `Finset.Icc`-style hypothesis via the new helper lemma.

Notes
- Kept `[simp]` usage conservative (no new global simp attributes on the equivalence lemmas) to avoid loops.
