### PR TITLE
Track C: paper-notation witnesses from discOffset boundedness

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/Tao2015Extras.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/Tao2015Extras.lean
@@ -372,6 +372,21 @@ theorem not_exists_boundedDiscOffset_iff_forall_exists_natAbs_apSumFrom_mul_gt (
     (Tao2015.unboundedDiscOffset_iff_not_exists_boundedDiscOffset (f := f) (d := d) (m := m)).symm.trans
       (unboundedDiscOffset_iff_forall_exists_natAbs_apSumFrom_mul_gt' (f := f) (d := d) (m := m))
 
+/-- Paper-notation normal form: the negation-normal-form boundedness statement
+`¬ ∃ B, BoundedDiscOffset f d m B` expressed using interval sums on `Icc (m+1) (m+n)`.
+
+This is the composition of `Tao2015.unboundedDiscOffset_iff_not_exists_boundedDiscOffset` and
+`unboundedDiscOffset_iff_forall_exists_natAbs_sum_Icc_offset_gt'`.
+-/
+theorem not_exists_boundedDiscOffset_iff_forall_exists_natAbs_sum_Icc_offset_gt (f : ℕ → ℤ)
+    (d m : ℕ) :
+    (¬ ∃ B : ℕ, BoundedDiscOffset f d m B) ↔
+      (∀ B : ℕ, ∃ n : ℕ,
+        Int.natAbs ((Finset.Icc (m + 1) (m + n)).sum (fun i => f (i * d))) > B) := by
+  exact
+    (Tao2015.unboundedDiscOffset_iff_not_exists_boundedDiscOffset (f := f) (d := d) (m := m)).symm.trans
+      (unboundedDiscOffset_iff_forall_exists_natAbs_sum_Icc_offset_gt' (f := f) (d := d) (m := m))
+
 /-- Packaging: global bounded discrepancy gives a uniform bound for every bundled offset discrepancy family.
 
 This is the forward direction used implicitly in contrapositive arguments:


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a paper-notation normal form that turns not-exists boundedDiscOffset into interval-sum witnesses on Icc (m+1) (m+n).
- Keeps the helper in Tao2015Extras (Conjectures-only) to avoid growing the verified substrate.
