### PR TITLE
Endpoint-normalization helpers for discOffset witnesses

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -41,4 +41,7 @@ The goal is to pair verified artifacts with learning scaffolding.
 - **API note (paper interval normalization):** many downstream proofs naturally produce paper-style terms like `Int.natAbs ((Finset.Icc (m+1) (m+n)).sum ...)`. The stable surface exports simp lemmas rewriting these directly to `discOffset f d m n`, so endpoint algebra can be normalized by `simp` without manually rewriting `discOffset_eq_natAbs_sum_Icc` back and forth.
 - **API note (endpoint normalization):** when you have endpoint-style constraints in a `Finset.Icc` form, you can convert cleanly to the paper-style conjunction used by `discOffset_congr_endpoints`. Use `endpoints_lt_le_iff_mem_finset_Icc` to rewrite
   `m < i ∧ i ≤ m+n` ↔ `i ∈ Finset.Icc (m+1) (m+n)`, and `endpoints_lt_le_iff_succ_le_lt_succ` for the variant `m+1 ≤ i ∧ i < m+n+1`.
+- **API note (endpoint arithmetic normalization):** when your upper endpoint algebra is off by a “successor/pred” shim (common after `Nat.succ`/`Nat.pred` normalizations), use
+  `add_one_add_pred_eq_add` / `add_pred_add_one_eq_add` (both require `0 < n`) to normalize `m+1+(n-1)` (or `m+(n-1)+1`) back to `m+n`.
+  We *do not* add generic associativity/commutativity theorems to the simp set here: that tends to loop. Keep these helper lemmas explicit.
 - **Related tasks:** `T1_01`, `T1_07`, `T1_12`.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -1482,6 +1482,36 @@ lemma endpoints_lt_le_iff_succ_le_lt_succ (m n i : ℕ) :
     -- `i < m+n+1` iff `i ≤ m+n`.
     exact (Nat.lt_succ_iff).1 (by simpa [Nat.add_assoc] using h.2)
 
+/-!
+### Endpoint-normalization: small arithmetic simp helpers (Track B)
+
+These are intentionally tiny rewrite lemmas that steer `simp` towards the exact endpoint shapes
+that the stable witness APIs use (`m+1`, `m+n`, etc.).
+
+We only orient them towards a **right-associated** normal form to avoid simp loops.
+-/
+
+lemma add_assoc_right (m n k : ℕ) : m + (n + k) = m + n + k := by
+  simpa [Nat.add_assoc]
+
+lemma add_assoc_right' (m n k : ℕ) : (m + n) + k = m + n + k := by
+  rfl
+
+/-- Normalize the common upper-endpoint algebra `m+1+(n-1)` into `m+n` (for `n>0`). -/
+lemma add_one_add_pred_eq_add (m n : ℕ) (hn : 0 < n) : m + 1 + (n - 1) = m + n := by
+  cases n with
+  | zero => cases hn
+  | succ n =>
+      -- `Nat.succ` case: `n+1-1 = n`.
+      simp [Nat.add_assoc, Nat.add_left_comm, Nat.add_comm]
+
+/-- Variant of `add_one_add_pred_eq_add` with the trailing `+1` on the right. -/
+lemma add_pred_add_one_eq_add (m n : ℕ) (hn : 0 < n) : m + (n - 1) + 1 = m + n := by
+  cases n with
+  | zero => cases hn
+  | succ n =>
+      simp [Nat.add_assoc, Nat.add_left_comm, Nat.add_comm]
+
 /-- Range-form congruence lemma for `discOffset`.
 
 If `f` and `g` agree on every summation index `i ∈ Finset.range n` in the `range`-expanded normal

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -384,9 +384,12 @@ Goal: build a *directed* lemma scaffold (not lemma-sprawl). Each checkbox should
   plus rewrite helpers `apSupport_add_left`/`apSupport_mul_right`), with stable-surface regression examples in
   `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
-- [ ] Endpoint-normalization for `discOffset` witnesses: add a small family of simp-friendly lemmas normalizing common endpoint
+- [x] Endpoint-normalization for `discOffset` witnesses: add a small family of simp-friendly lemmas normalizing common endpoint
   algebra (`m+(n+k)`, `m+1+(n-1)`, etc.) into the exact shapes expected by the stable witness APIs (cut/split/affine-tail),
   reducing `simp` churn in large proofs.
+  (Implemented in `MoltResearch/Discrepancy/Basic.lean` as `endpoints_lt_le_iff_mem_finset_Icc`,
+  `endpoints_lt_le_iff_succ_le_lt_succ`, plus small arithmetic helpers; stable-surface regression examples live in
+  `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
 #### Track C - Tao2015 "build the plane" (context; Track C checklist below)
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Endpoint-normalization for `discOffset` witnesses

This PR:
- Adds small endpoint arithmetic normalization helpers in `MoltResearch/Discrepancy/Basic.lean`.
- Marks the Track B checklist item as completed in `Problems/erdos_discrepancy.md`.

Notes:
- These lemmas are kept *simp-friendly* but are **not** added to the global simp set (to avoid loops).
- Stable-surface regression already exists in `MoltResearch/Discrepancy/NormalFormExamples.lean`.
