### PR TITLE
Track C: Stage2 discOffset witness positivity

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
@@ -141,6 +141,19 @@ theorem unboundedDiscOffset (out : Stage2Output f) : UnboundedDiscOffset f out.d
   simpa [Stage2Output.d, Stage2Output.m] using
     ((out.out1.unboundedDiscrepancyAlong_iff_unboundedDiscOffset (f := f))).1 out.unbounded
 
+/-- Positive-length witness form: Stage 2 yields arbitrarily large bundled offset discrepancies
+`discOffset f out.d out.m n`, with witnesses `n > 0`.
+
+This is a thin wrapper around
+`Tao2015.UnboundedDiscOffset.forall_exists_discOffset_gt'_witness_pos`.
+-/
+theorem forall_exists_discOffset_gt'_witness_pos (out : Stage2Output f) :
+    ∀ B : ℕ, ∃ n : ℕ, n > 0 ∧ discOffset f out.d out.m n > B := by
+  have hunb : UnboundedDiscOffset f out.d out.m := out.unboundedDiscOffset (f := f)
+  simpa using
+    (Tao2015.UnboundedDiscOffset.forall_exists_discOffset_gt'_witness_pos
+      (f := f) (d := out.d) (m := out.m) hunb)
+
 /-- Stage 2 implies there is no uniform bound on the bundled offset discrepancy family
 `discOffset f out.d out.m`.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Added a Stage2Output core lemma giving positive-length witnesses for discOffset unboundedness (n > 0).
- Implemented by specializing the generic UnboundedDiscOffset witness-positivity lemma, keeping the Stage-2 core import surface small.
