### PR TITLE
Track C: stage2 tail nuclei via start

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
@@ -171,36 +171,42 @@ theorem not_exists_boundedDiscOffset (out : Stage2Output f) :
       hunb
 
 /-- Negation-normal-form unboundedness statement for the affine-tail nuclei
-`Int.natAbs (apSumFrom f (out.m*d) out.d n)`.
+`Int.natAbs (apSumFrom f out.start out.d n)`.
 
 This is `unboundedDiscOffset` rewritten using the generic normal-form lemma
 `Tao2015.UnboundedDiscOffset.iff_not_exists_forall_natAbs_apSumFrom_mul_le`.
+
+We phrase this using the bundled start index `out.start = out.m * out.d` to reduce arithmetic noise
+in downstream stages.
 
 We keep this lemma in `TrackCStage2Core.lean` so downstream stages can access it without importing
 the larger convenience-lemma library `TrackCStage2Output.lean`.
 -/
 theorem not_exists_forall_natAbs_apSumFrom_mul_le (out : Stage2Output f) :
-    ¬ ∃ B : ℕ, ∀ n : ℕ, Int.natAbs (apSumFrom f (out.m * out.d) out.d n) ≤ B := by
+    ¬ ∃ B : ℕ, ∀ n : ℕ, Int.natAbs (apSumFrom f out.start out.d n) ≤ B := by
   have hunb : UnboundedDiscOffset f out.d out.m := out.unboundedDiscOffset (f := f)
-  exact
+  simpa [Stage2Output.start] using
     (Tao2015.UnboundedDiscOffset.iff_not_exists_forall_natAbs_apSumFrom_mul_le
         (f := f) (d := out.d) (m := out.m)).1
       hunb
 
 /-- Tail-nucleus witness form: Stage 2 yields arbitrarily large affine-tail nuclei
-`Int.natAbs (apSumFrom f (out.m*out.d) out.d n)`.
+`Int.natAbs (apSumFrom f out.start out.d n)`.
 
 This is a small convenience wrapper around the generic normal-form lemma
 `Tao2015.UnboundedDiscOffset.forall_exists_natAbs_apSumFrom_mul_gt_witness_pos`, specialized to
 the deterministic Stage-2 parameters.
 
+We phrase this using the bundled start index `out.start = out.m * out.d` to reduce arithmetic noise
+in downstream stages.
+
 We keep it in `TrackCStage2Core.lean` so downstream stages can access the witness form without
 importing the larger convenience-lemma library `TrackCStage2Output.lean`.
 -/
 theorem forall_exists_natAbs_apSumFrom_mul_gt_witness_pos (out : Stage2Output f) :
-    ∀ B : ℕ, ∃ n : ℕ, n > 0 ∧ Int.natAbs (apSumFrom f (out.m * out.d) out.d n) > B := by
+    ∀ B : ℕ, ∃ n : ℕ, n > 0 ∧ Int.natAbs (apSumFrom f out.start out.d n) > B := by
   have hunb : UnboundedDiscOffset f out.d out.m := out.unboundedDiscOffset (f := f)
-  simpa using
+  simpa [Stage2Output.start] using
     (Tao2015.UnboundedDiscOffset.forall_exists_natAbs_apSumFrom_mul_gt_witness_pos
       (f := f) (d := out.d) (m := out.m) hunb)
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Rephrased the Stage-2 affine-tail unboundedness normal forms to use the bundled start index out.start.
- Kept proofs as thin wrappers over the existing UnboundedDiscOffset normal forms (just simp [Stage2Output.start]).
- Goal: reduce downstream arithmetic noise when consuming Stage 2 tail-nucleus statements.
