### PR TITLE
Track C: expose Stage3Output.out1

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
@@ -32,6 +32,15 @@ namespace Stage3Output
 
 variable {f : ℕ → ℤ}
 
+/-- Convenience projection: Stage 3 carries the full Stage-2 output, hence also carries the
+underlying Stage-1 reduction output.
+
+This is occasionally useful when later stages want access to the deterministic parameters
+`g, d, m` and the Stage-1 transport contracts, without reaching through multiple record fields.
+-/
+abbrev out1 (out : Stage3Output f) : Tao2015.ReductionOutput f :=
+  out.out2.out1
+
 /-- Stage 3 already closes the global goal `¬ BoundedDiscrepancy f`.
 
 We intentionally do not store this as a field: it is derived from the Stage-2 output.

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
@@ -73,6 +73,15 @@ layer `TrackCStage3Entry` just to access this definitional rewrite.
     (stage3Out (f := f) (hf := hf)).out2.out1 = (stage2Out (f := f) (hf := hf)).out1 := by
   rfl
 
+/-- The Stage-1 reduction output stored inside `stage3Out` can also be accessed through the
+convenience projection `Stage3Output.out1`.
+
+This lemma is a tiny wrapper around `stage3Out_out1`.
+-/
+@[simp] theorem stage3Out_out1' (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    (stage3Out (f := f) (hf := hf)).out1 = (stage2Out (f := f) (hf := hf)).out1 := by
+  rfl
+
 /-- Consumer-facing shortcut: the Stage-3 pipeline closes the core goal `¬ BoundedDiscrepancy f`.
 
 We keep this lemma in the hard-gate core so `ErdosDiscrepancy.lean` can remain minimal.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a Stage3Output out1 convenience projection to expose the carried Stage-1 reduction output.
- Add a simp rewrite lemma stage3Out_out1' for rewriting the Stage-1 reduction output stored inside stage3Out.
