### PR TITLE
Track C: add ≤ discOffset normal form

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/Tao2015Extras.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/Tao2015Extras.lean
@@ -99,6 +99,11 @@ theorem discOffset_le_iff_natAbs_apSumFrom_mul_le (f : ℕ → ℤ) (d m n B : �
     discOffset f d m n ≤ B ↔ Int.natAbs (apSumFrom f (m * d) d n) ≤ B := by
   simp [discOffset_eq_natAbs_apSumFrom_mul (f := f) (d := d) (m := m) (n := n)]
 
+/-- Inequality normal form: `B ≤ discOffset f d m n` rewritten using affine-tail nuclei. -/
+theorem le_discOffset_iff_le_natAbs_apSumFrom_mul (f : ℕ → ℤ) (d m n B : ℕ) :
+    B ≤ discOffset f d m n ↔ B ≤ Int.natAbs (apSumFrom f (m * d) d n) := by
+  simp [discOffset_eq_natAbs_apSumFrom_mul (f := f) (d := d) (m := m) (n := n)]
+
 /-- Normal form: boundedness of `discOffset f d m` expressed using affine-tail nuclei.
 
 This avoids unfolding `discOffset` and repeatedly rewriting `apSumOffset` into an `apSumFrom` tail.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add the missing inequality normal form rewriting B ≤ discOffset f d m n into the affine-tail nucleus form.
- Keeps Tao2015Extras as the home for tiny Conjectures-only consumer-facing rewrites.
