### PR TITLE
Track C: Stage-2 fixed-threshold wrapper

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2ProofCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2ProofCore.lean
@@ -45,6 +45,14 @@ theorem stage2_forall_hasDiscrepancyAtLeast (f : ℕ → ℤ) (hf : IsSignSequen
     (forall_hasDiscrepancyAtLeast_iff_not_boundedDiscrepancy f).2
       (stage2_notBounded (f := f) (hf := hf))
 
+/-- Specialization of `stage2_forall_hasDiscrepancyAtLeast` at a fixed threshold `C`.
+
+This is a tiny convenience lemma: it avoids an extra application at the call site.
+-/
+theorem stage2_hasDiscrepancyAtLeast (f : ℕ → ℤ) (hf : IsSignSequence f) (C : ℕ) :
+    HasDiscrepancyAtLeast f C := by
+  exact (stage2_forall_hasDiscrepancyAtLeast (f := f) (hf := hf)) C
+
 /-- Consumer-facing shortcut: Stage 2 yields unbounded discrepancy along the deterministic reduced
 sequence `stage2_g` at the deterministic step size `stage2_d`.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a tiny Stage-2 convenience lemma stage2_hasDiscrepancyAtLeast specializing the global statement at a fixed threshold C.
- Keeps TrackCStage2ProofCore as lightweight API glue while making downstream call sites cleaner.
