### PR TITLE
Track C: use Stage 3 entry API

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
@@ -1,5 +1,4 @@
-import Conjectures.C0002_erdos_discrepancy.src.TrackCStage3
-import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Stub
+import Conjectures.C0002_erdos_discrepancy.src.TrackCStage3EntryCore
 
 /-!
 A conjecture-style stub for the Erdős discrepancy theorem (Tao 2015).
@@ -24,10 +23,8 @@ follow.
 -/
 theorem erdos_discrepancy_notBounded (f : ℕ → ℤ) (hf : IsSignSequence f) :
     ¬ BoundedDiscrepancy f := by
-  -- Stage 3 is proved glue on top of the Stage-2 axiom stub: run Stage 2, then close the global goal.
-  let out3 : Tao2015.Stage3Output f :=
-    Tao2015.Stage3Output.ofStage2Output (f := f) (Tao2015.stage2Out (f := f) (hf := hf))
-  exact Tao2015.Stage3Output.notBounded (f := f) out3
+  -- Delegate to the minimal Stage-3 entry-point API.
+  exact Tao2015.stage3_notBounded (f := f) (hf := hf)
 
 /-- Erdős discrepancy theorem.
 
@@ -38,10 +35,8 @@ Track-C output `¬ BoundedDiscrepancy f`.
 -/
 theorem erdos_discrepancy (f : ℕ → ℤ) (hf : IsSignSequence f) :
     ∀ C : ℕ, HasDiscrepancyAtLeast f C := by
-  -- Run the proved Stage-3 boundary API on the Stage-2 axiom stub.
-  let out3 : Tao2015.Stage3Output f :=
-    Tao2015.Stage3Output.ofStage2Output (f := f) (Tao2015.stage2Out (f := f) (hf := hf))
-  exact Tao2015.Stage3Output.forall_hasDiscrepancyAtLeast (f := f) out3
+  -- Delegate to the minimal Stage-3 entry-point API.
+  exact Tao2015.stage3_forall_hasDiscrepancyAtLeast (f := f) (hf := hf)
 
 /-!
 Additional witness-form corollaries live in


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Keep Conjectures.C0002_erdos_discrepancy.src.ErdosDiscrepancy thin by importing the Stage 3 entry core API.
- Delegate erdos_discrepancy_notBounded and erdos_discrepancy to Tao2015.stage3_notBounded / Tao2015.stage3_forall_hasDiscrepancyAtLeast.
