### PR TITLE
Track C: strict-witness rewrite for Stage 1

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/Tao2015.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/Tao2015.lean
@@ -905,6 +905,12 @@ theorem discrepancy_le_iff_discOffset_le (out : ReductionOutput f) (n B : ℕ) :
     discrepancy out.g out.d n ≤ B ↔ discOffset f out.d out.m n ≤ B := by
   simp [out.discrepancy_eq_discOffset_via_contract (f := f) (n := n)]
 
+/-- Convenience: pointwise strict-inequality witnesses for the reduced sequence are exactly
+pointwise witnesses for the bundled offset family. -/
+theorem lt_discrepancy_iff_lt_discOffset (out : ReductionOutput f) (n B : ℕ) :
+    B < discrepancy out.g out.d n ↔ B < discOffset f out.d out.m n := by
+  simp [out.discrepancy_eq_discOffset_via_contract (f := f) (n := n)]
+
 /-- Convenience: uniform discrepancy bounds for the reduced sequence are exactly uniform bounds on
 the bundled offset family. -/
 theorem forall_discrepancy_le_iff_forall_discOffset_le (out : ReductionOutput f) (B : ℕ) :


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a small Stage-1 helper lemma rewriting strict witnesses B < discrepancy out.g out.d n into the bundled offset form B < discOffset f out.d out.m n.
- This keeps downstream unboundedness/witness proofs from having to manually rewrite via the Stage-1 contract equality each time.
