### PR TITLE
Track C: minimal Stage 3 entry module

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
@@ -1,4 +1,4 @@
-import Conjectures.C0002_erdos_discrepancy.src.TrackCStage3EntryCore
+import Conjectures.C0002_erdos_discrepancy.src.TrackCStage3EntryMinimal
 
 /-!
 A conjecture-style stub for the Erdős discrepancy theorem (Tao 2015).

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
@@ -1,35 +1,15 @@
-import Conjectures.C0002_erdos_discrepancy.src.TrackCStage3
-import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Stub
+import Conjectures.C0002_erdos_discrepancy.src.TrackCStage3EntryMinimal
 
 /-!
 # Track C: Stage 3 entry point (hard-gate core)
 
 This file is **Conjectures-only** glue.
 
-It provides the minimal Stage-3 entry point API needed by the Track-C hard-gate target
-`Conjectures.C0002_erdos_discrepancy.src.ErdosDiscrepancy`:
-
-- `stage3` / `stage3Out` : produce a `Stage3Output f` from a sign sequence `f`
-- `stage3_notBounded` : close the core goal `¬ BoundedDiscrepancy f`
-- `stage3_forall_hasDiscrepancyAtLeast` : the usual surface statement `∀ C, HasDiscrepancyAtLeast f C`
-- `stage3_exists_params_one_le_unboundedDiscOffset` : existential packaging of the concrete Stage-2 parameters
-  `∃ d m, 1 ≤ d ∧ UnboundedDiscOffset f d m`
-- `stage3_exists_params_unboundedDiscOffset` : same packaging with strict positivity for `d`
-  `∃ d m, d > 0 ∧ UnboundedDiscOffset f d m`
-- `stage3_forall_exists_discrepancy_gt` : discrepancy witness form
-  `∀ C, ∃ d n, d > 0 ∧ discrepancy f d n > C`
-- `stage3_forall_exists_discrepancy_gt_witness_pos` : discrepancy witness form with `n > 0`
-  `∀ C, ∃ d n, d > 0 ∧ n > 0 ∧ discrepancy f d n > C`
-- `stage3_forall_exists_d_ge_one_witness_pos` : the pipeline-friendly nucleus witness normal form
-  `∀ C, ∃ d n, d ≥ 1 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C`
-- `stage3_forall_exists_d_pos_witness_pos` : nucleus witness form with `d > 0`
-  `∀ C, ∃ d n, d > 0 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C`
-- `stage3_forall_exists_d_ne_zero_witness_pos` : nucleus witness form with `d ≠ 0`
-  `∀ C, ∃ d n, d ≠ 0 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C`
-- `stage3_forall_exists_sum_Icc_witness_pos` : paper-notation witness form
-  `∀ C, ∃ d n, d > 0 ∧ n > 0 ∧ Int.natAbs (∑ i ∈ Icc 1 n, f (i*d)) > C`
-- `stage3_forall_exists_sum_Icc_d_ge_one_witness_pos` : paper-notation witness form with `d ≥ 1`
-  `∀ C, ∃ d n, d ≥ 1 ∧ n > 0 ∧ Int.natAbs (∑ i ∈ Icc 1 n, f (i*d)) > C`
+- `Conjectures.C0002_erdos_discrepancy.src.TrackCStage3EntryMinimal` contains the minimal Stage-3
+  API needed by the Track-C hard-gate target
+  `Conjectures.C0002_erdos_discrepancy.src.ErdosDiscrepancy`.
+- This file adds a small collection of pipeline-friendly witness forms and existential packaging
+  lemmas, without pulling in the larger convenience layer `TrackCStage3Entry`.
 
 All additional projections and rewrite lemmas (e.g. `stage3_d`, `stage3_g`, `stage3_start`,
 `stage3_g_eq`, ...) live in `Conjectures.C0002_erdos_discrepancy.src.TrackCStage3Entry`.
@@ -38,75 +18,6 @@ All additional projections and rewrite lemmas (e.g. `stage3_d`, `stage3_g`, `sta
 namespace MoltResearch
 
 namespace Tao2015
-
-/-- Conjectures-only Stage 3 entry point: run Stage 2, then close the global goal via the proved
-Stage-3 boundary lemma `Stage3Output.ofStage2Output`.
-
-This is a definition (not an axiom): Stage 3 is non-stub glue on top of the Stage-2 axiom.
--/
-noncomputable def stage3 (f : ℕ → ℤ) (hf : IsSignSequence f) : Stage3Output f :=
-  Stage3Output.ofStage2Output (f := f) (stage2Out (f := f) (hf := hf))
-
-/-- Deterministic name for the Stage-3 output (useful to keep later statements readable). -/
-noncomputable abbrev stage3Out (f : ℕ → ℤ) (hf : IsSignSequence f) : Stage3Output f :=
-  stage3 (f := f) (hf := hf)
-
-/-- The Stage-2 output stored inside `stage3Out` is definitionally the Stage-2 output produced by
-Stage 2.
-
-This lemma is tiny but useful for rewriting when shuttling statements between Stage 2 and Stage 3.
-
-We keep it in the hard-gate core so consumers don't need to import the larger Stage-3 convenience
-layer `TrackCStage3Entry` just to access this definitional rewrite.
--/
-@[simp] theorem stage3Out_out2 (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    (stage3Out (f := f) (hf := hf)).out2 = stage2Out (f := f) (hf := hf) := by
-  rfl
-
-/-- The Stage-1 reduction output stored inside `stage3Out` is definitionally the Stage-1 reduction
-output produced by Stage 2.
-
-This lemma is tiny but useful for rewriting when shuttling statements between Stage 1 and Stage 3.
-
-We keep it in the hard-gate core so consumers don't need to import the larger Stage-3 convenience
-layer `TrackCStage3Entry` just to access this definitional rewrite.
--/
-@[simp] theorem stage3Out_out1 (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    (stage3Out (f := f) (hf := hf)).out2.out1 = (stage2Out (f := f) (hf := hf)).out1 := by
-  rfl
-
-/-- The Stage-1 reduction output stored inside `stage3Out` can also be accessed through the
-convenience projection `Stage3Output.out1`.
-
-This lemma is a tiny wrapper around `stage3Out_out1`.
--/
-@[simp] theorem stage3Out_out1' (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    (stage3Out (f := f) (hf := hf)).out1 = (stage2Out (f := f) (hf := hf)).out1 := by
-  rfl
-
-/-- Consumer-facing shortcut: the Stage-3 pipeline closes the core goal `¬ BoundedDiscrepancy f`.
-
-We keep this lemma in the hard-gate core so `ErdosDiscrepancy.lean` can remain minimal.
--/
-theorem stage3_notBounded (f : ℕ → ℤ) (hf : IsSignSequence f) : ¬ BoundedDiscrepancy f := by
-  exact (stage3Out (f := f) (hf := hf)).notBounded
-
-/-- Consumer-facing shortcut: the Stage-3 pipeline yields the usual surface statement
-`∀ C, HasDiscrepancyAtLeast f C`.
-
-This is a thin wrapper around `Stage3Output.forall_hasDiscrepancyAtLeast`.
--/
-theorem stage3_forall_hasDiscrepancyAtLeast (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    ∀ C : ℕ, HasDiscrepancyAtLeast f C := by
-  exact Stage3Output.forall_hasDiscrepancyAtLeast (f := f) (stage3Out (f := f) (hf := hf))
-
-/-- Specialization of `stage3_forall_hasDiscrepancyAtLeast` at a fixed threshold `C`.
-
-This is a tiny convenience lemma: it avoids an extra application at the call site.
--/
-theorem stage3_hasDiscrepancyAtLeast (f : ℕ → ℤ) (hf : IsSignSequence f) (C : ℕ) :
-    HasDiscrepancyAtLeast f C := by
-  exact (stage3_forall_hasDiscrepancyAtLeast (f := f) (hf := hf)) C
 
 /-- Stage 3 yields concrete Stage-2 parameters `d, m` (with `1 ≤ d`) such that the bundled offset
 discrepancy family `discOffset f d m` is unbounded.

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -1,0 +1,95 @@
+import Conjectures.C0002_erdos_discrepancy.src.TrackCStage3
+import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Stub
+
+/-!
+# Track C: Stage 3 entry point (hard-gate minimal)
+
+This file is **Conjectures-only** glue.
+
+It provides the minimal Stage-3 entry point API needed by the Track-C hard-gate target
+`Conjectures.C0002_erdos_discrepancy.src.ErdosDiscrepancy`:
+
+- `stage3` / `stage3Out` : produce a `Stage3Output f` from a sign sequence `f`
+- `stage3_notBounded` : close the core goal `¬ BoundedDiscrepancy f`
+- `stage3_forall_hasDiscrepancyAtLeast` : the usual surface statement
+  `∀ C, HasDiscrepancyAtLeast f C`
+- `stage3_hasDiscrepancyAtLeast` : specialization at a fixed threshold `C`
+
+All additional witness-form corollaries live in
+`Conjectures.C0002_erdos_discrepancy.src.TrackCStage3EntryCore`.
+-/
+
+namespace MoltResearch
+
+namespace Tao2015
+
+/-- Conjectures-only Stage 3 entry point: run Stage 2, then close the global goal via the proved
+Stage-3 boundary lemma `Stage3Output.ofStage2Output`.
+
+This is a definition (not an axiom): Stage 3 is non-stub glue on top of the Stage-2 axiom.
+-/
+noncomputable def stage3 (f : ℕ → ℤ) (hf : IsSignSequence f) : Stage3Output f :=
+  Stage3Output.ofStage2Output (f := f) (stage2Out (f := f) (hf := hf))
+
+/-- Deterministic name for the Stage-3 output (useful to keep later statements readable). -/
+noncomputable abbrev stage3Out (f : ℕ → ℤ) (hf : IsSignSequence f) : Stage3Output f :=
+  stage3 (f := f) (hf := hf)
+
+/-- The Stage-2 output stored inside `stage3Out` is definitionally the Stage-2 output produced by
+Stage 2.
+
+This lemma is tiny but useful for rewriting when shuttling statements between Stage 2 and Stage 3.
+
+We keep it in the hard-gate minimal module so `ErdosDiscrepancy.lean` can stay minimal.
+-/
+@[simp] theorem stage3Out_out2 (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    (stage3Out (f := f) (hf := hf)).out2 = stage2Out (f := f) (hf := hf) := by
+  rfl
+
+/-- The Stage-1 reduction output stored inside `stage3Out` is definitionally the Stage-1 reduction
+output produced by Stage 2.
+
+This lemma is tiny but useful for rewriting when shuttling statements between Stage 1 and Stage 3.
+
+We keep it in the hard-gate minimal module so `ErdosDiscrepancy.lean` can stay minimal.
+-/
+@[simp] theorem stage3Out_out1 (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    (stage3Out (f := f) (hf := hf)).out2.out1 = (stage2Out (f := f) (hf := hf)).out1 := by
+  rfl
+
+/-- The Stage-1 reduction output stored inside `stage3Out` can also be accessed through the
+convenience projection `Stage3Output.out1`.
+
+This lemma is a tiny wrapper around `stage3Out_out1`.
+-/
+@[simp] theorem stage3Out_out1' (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    (stage3Out (f := f) (hf := hf)).out1 = (stage2Out (f := f) (hf := hf)).out1 := by
+  rfl
+
+/-- Consumer-facing shortcut: the Stage-3 pipeline closes the core goal `¬ BoundedDiscrepancy f`.
+
+We keep this lemma in the hard-gate minimal module so `ErdosDiscrepancy.lean` can remain minimal.
+-/
+theorem stage3_notBounded (f : ℕ → ℤ) (hf : IsSignSequence f) : ¬ BoundedDiscrepancy f := by
+  exact (stage3Out (f := f) (hf := hf)).notBounded
+
+/-- Consumer-facing shortcut: the Stage-3 pipeline yields the usual surface statement
+`∀ C, HasDiscrepancyAtLeast f C`.
+
+This is a thin wrapper around `Stage3Output.forall_hasDiscrepancyAtLeast`.
+-/
+theorem stage3_forall_hasDiscrepancyAtLeast (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    ∀ C : ℕ, HasDiscrepancyAtLeast f C := by
+  exact Stage3Output.forall_hasDiscrepancyAtLeast (f := f) (stage3Out (f := f) (hf := hf))
+
+/-- Specialization of `stage3_forall_hasDiscrepancyAtLeast` at a fixed threshold `C`.
+
+This is a tiny convenience lemma: it avoids an extra application at the call site.
+-/
+theorem stage3_hasDiscrepancyAtLeast (f : ℕ → ℤ) (hf : IsSignSequence f) (C : ℕ) :
+    HasDiscrepancyAtLeast f C := by
+  exact (stage3_forall_hasDiscrepancyAtLeast (f := f) (hf := hf)) C
+
+end Tao2015
+
+end MoltResearch


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Added a minimal Stage-3 entry module for the hard-gate target (stage3Out + core theorems).
- Refactored TrackCStage3EntryCore to import the minimal module and keep only witness-form / packaging lemmas.
- Switched ErdosDiscrepancy to import the minimal entry module to reduce the hard-gate compilation surface.
