### PR TITLE
Track C: lighten Stage 3 boundary imports

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
@@ -1,4 +1,4 @@
-import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Core
+import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Boundary
 
 /-!
 # Track C: Stage 3 boundary (Tao 2015 plane)
@@ -50,8 +50,9 @@ output (via `ReductionOutput.not_boundedDiscrepancy_of_unboundedDiscrepancyAlong
 does not need to import the larger Stage-2 convenience-lemma layer.
 -/
 theorem notBounded (out : Stage3Output f) : ¬ BoundedDiscrepancy f := by
-  -- Delegate to the canonical Stage-2 “bridge back to the global statement” lemma.
-  exact out.out2.notBoundedOriginal (f := f)
+  -- Use the Stage-1 transport contract stored in the Stage-2 output.
+  exact
+    out.out2.out1.not_boundedDiscrepancy_of_unboundedDiscrepancyAlong (f := f) out.out2.unbounded
 
 /-- Deterministic Stage-3 completion: a Stage-2 output already contains enough information to
 contradict any global boundedness hypothesis.
@@ -67,8 +68,8 @@ We keep this lemma in the hard-gate module so `ErdosDiscrepancy.lean` can remain
 -/
 theorem forall_hasDiscrepancyAtLeast (out : Stage3Output f) :
     ∀ C : ℕ, HasDiscrepancyAtLeast f C := by
-  -- Reuse the Stage-2 surface lemma rather than re-proving it.
-  exact out.out2.forall_hasDiscrepancyAtLeast (f := f)
+  refine (forall_hasDiscrepancyAtLeast_iff_not_boundedDiscrepancy f).2 ?_
+  exact out.notBounded (f := f)
 
 end Stage3Output
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Make TrackCStage3 depend only on the Stage-2 boundary module (not the Stage-2 core lemma layer).
- Reprove Stage3Output.notBounded and Stage3Output.forall_hasDiscrepancyAtLeast directly from the Stage-1 transport contract carried by the Stage-2 output.
- Keeps the hard-gate Stage-3 boundary as API + wiring and reduces its import footprint.
