### PR TITLE
Discrepancy: apSupport membership normal forms

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -37,6 +37,7 @@ The goal is to pair verified artifacts with learning scaffolding.
 - **API note (`apSupport` bookkeeping helpers):** for common “no-op” shifts/dilations, the stable surface provides simp lemmas
   `apSupport_add_left_zero` and `apSupport_mul_right_one` so `simp` can discharge trivial `m+0` / `d*1` noise without unfolding.
   For unfold-free membership reasoning, use `mem_apSupport_iff`, or the binder-notation variant `mem_apSupport` when you want to feed the result directly to `simp`/`rcases` as `∃ i < n, ...`.
+  If you want the *paper endpoint convention* (`m < i ∧ i ≤ m+n` with accessed index `i*d`), use `mem_apSupport_iff_exists_endpoints`.
 - **API note (`apSupport` canonical membership):** if your membership goal is already in the normal form
   `((m + i + 1) * d) ∈ apSupport d m n`, and you have `hd : d > 0`, then `simp [mem_apSupport_index_iff (m := m) (n := n) (i := i) hd]` reduces it to the expected bound `i < n`.
 - **API note (shift–dilation coherence):** when you both (i) push an offset shift into the summand and (ii) pull a factor `q` into the step, use the commutation lemma `apSumOffset_shift_mul_right_comm` (and the wrapper `discOffset_shift_mul_right_comm`) to avoid redoing index algebra. Conceptually: “shift then dilate” = “dilate then shift (with scaled offset)”.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -309,6 +309,44 @@ finset reduces to the expected bound `i < n`.
   · intro hi
     exact mem_apSupport_of_lt (d := d) (m := m) (n := n) (i := i) hi
 
+/-!
+### Paper-endpoint membership normal form (Track B)
+
+Many later arguments phrase “agreement on accessed indices” in the paper endpoint convention
+`m < i ∧ i ≤ m+n` for the *multiplier* index `i` (so the accessed sequence index is `i*d`).
+
+This lemma provides an unfold-free bridge between:
+- the nucleus support object `apSupport d m n`, and
+- the paper-style endpoint bounds.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — `apSupport` image membership normal form.
+-/
+
+lemma mem_apSupport_iff_exists_endpoints {d m n x : ℕ} :
+    x ∈ apSupport d m n ↔ ∃ i, m < i ∧ i ≤ m + n ∧ x = i * d := by
+  constructor
+  · intro hx
+    rcases (mem_apSupport_iff (d := d) (m := m) (n := n) (x := x)).1 hx with ⟨k, hk, rfl⟩
+    refine ⟨m + k + 1, ?_, ?_, rfl⟩
+    · -- `m < m+k+1`
+      have : m < m + (k + 1) := Nat.lt_add_of_pos_right (Nat.succ_pos k)
+      simpa [Nat.add_assoc] using this
+    · -- `m+k+1 ≤ m+n`
+      have hk' : k + 1 ≤ n := Nat.succ_le_of_lt hk
+      -- cancel the common `m`
+      have : m + (k + 1) ≤ m + n := Nat.add_le_add_left hk' m
+      simpa [Nat.add_assoc, Nat.add_left_comm, Nat.add_comm] using this
+  · rintro ⟨i, hmi, hile, rfl⟩
+    -- Write `i = m + k + 1` using `m < i`.
+    rcases Nat.exists_eq_add_of_lt hmi with ⟨k, rfl⟩
+    -- From `m + k + 1 ≤ m + n` derive `k < n`.
+    have hk1 : k + 1 ≤ n := by
+      have : m + (k + 1) ≤ m + n := by
+        simpa [Nat.add_assoc, Nat.add_left_comm, Nat.add_comm] using hile
+      exact Nat.add_le_add_iff_left.mp this
+    have hk : k < n := lt_of_lt_of_le (Nat.lt_succ_self k) hk1
+    exact mem_apSupport_of_lt (d := d) (m := m) (n := n) (i := k) hk
+
 /-- Monotonicity in the length parameter: the accessed-index set can only grow when `n` increases.
 
 (Track B normal-form checklist item: support monotonicity API.)

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -137,6 +137,11 @@ example (d m n i : ℕ) (hd : d > 0) :
     (m + i + 1) * d ∈ apSupport d m n ↔ i < n := by
   simpa using (mem_apSupport_index_iff (d := d) (m := m) (n := n) (i := i) hd)
 
+-- Paper-endpoint bridge: membership can be rewritten into the `(m<i≤m+n)` witness form.
+example (d m n x : ℕ) :
+    x ∈ apSupport d m n ↔ ∃ i, m < i ∧ i ≤ m + n ∧ x = i * d := by
+  simpa using (mem_apSupport_iff_exists_endpoints (d := d) (m := m) (n := n) (x := x))
+
 /-!
 ### NEW (Track B): `discOffsetUpTo` degenerate-parameter simp coherence
 

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -393,9 +393,11 @@ Goal: build a *directed* lemma scaffold (not lemma-sprawl). Each checkbox should
 
 #### Auto-generated backlog (needs triage)
 
-- [ ] `apSupport` image membership normal form: add simp-friendly lemmas characterizing membership
+- [x] `apSupport` image membership normal form: add simp-friendly lemmas characterizing membership
   `x ∈ apSupport d m n` in terms of an explicit witness `i < n` with `x = (m + i + 1) * d` (and the equivalent `m < i ∧ i ≤ m+n` paper-endpoint form),
   so later proofs can move between set-level hypotheses and range/Icc hypotheses without unfolding.
+  (Implemented in `MoltResearch/Discrepancy/Basic.lean` as `mem_apSupport` / `mem_apSupport_iff_exists_endpoints`, with regression in
+  `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
 - [ ] `apSupport` size/monotonicity API: assuming `d > 0`, prove `Finset.card (apSupport d m n) = n` (no collisions) and
   `apSupport d m n ⊆ apSupport d m (n+k)`; add a stable-surface regression example under `import MoltResearch.Discrepancy`.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `apSupport` image membership normal form: add simp-friendly lemmas characterizing membership

What this adds
- `mem_apSupport_iff_exists_endpoints`: an unfold-free bridge between `x ∈ apSupport d m n` and the paper-style endpoint witness form `∃ i, m < i ∧ i ≤ m+n ∧ x = i*d`.
- Keeps the existing “range witness” interface (`mem_apSupport`) and the injective-index simp lemma (`mem_apSupport_index_iff`).
- Adds a stable-surface regression example under `import MoltResearch.Discrepancy`.

Files
- MoltResearch/Discrepancy/Basic.lean
- MoltResearch/Discrepancy/NormalFormExamples.lean
- Problems/erdos_discrepancy.md (checklist tick)
