### PR TITLE
Discrepancy: card_apSupport (d>0)

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -40,6 +40,8 @@ The goal is to pair verified artifacts with learning scaffolding.
   If you want the *paper endpoint convention* (`m < i ∧ i ≤ m+n` with accessed index `i*d`), use `mem_apSupport_iff_exists_endpoints`.
 - **API note (`apSupport` canonical membership):** if your membership goal is already in the normal form
   `((m + i + 1) * d) ∈ apSupport d m n`, and you have `hd : d > 0`, then `simp [mem_apSupport_index_iff (m := m) (n := n) (i := i) hd]` reduces it to the expected bound `i < n`.
+- **API note (`apSupport` size / no collisions):** if you need a cardinality statement, use `card_apSupport (m := m) (n := n) (hd := hd)` to rewrite
+  `(apSupport d m n).card = n` (the proof is by injectivity of `i ↦ (m+i+1)*d` when `d > 0`).
 - **API note (shift–dilation coherence):** when you both (i) push an offset shift into the summand and (ii) pull a factor `q` into the step, use the commutation lemma `apSumOffset_shift_mul_right_comm` (and the wrapper `discOffset_shift_mul_right_comm`) to avoid redoing index algebra. Conceptually: “shift then dilate” = “dilate then shift (with scaled offset)”.
 - **API note (paper interval normalization):** many downstream proofs naturally produce paper-style terms like `Int.natAbs ((Finset.Icc (m+1) (m+n)).sum ...)`. The stable surface exports simp lemmas rewriting these directly to `discOffset f d m n`, so endpoint algebra can be normalized by `simp` without manually rewriting `discOffset_eq_natAbs_sum_Icc` back and forth.
 - **API note (endpoint normalization):** when you have endpoint-style constraints in a `Finset.Icc` form, you can convert cleanly to the paper-style conjunction used by `discOffset_congr_endpoints`. Use `endpoints_lt_le_iff_mem_finset_Icc` to rewrite

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -310,6 +310,29 @@ finset reduces to the expected bound `i < n`.
     exact mem_apSupport_of_lt (d := d) (m := m) (n := n) (i := i) hi
 
 /-!
+### Cardinality (Track B)
+
+Assuming `d > 0`, the map `i ↦ (m + i + 1) * d` is injective, so the support finset contains
+exactly `n` distinct indices.
+
+(Track B normal-form checklist item: `apSupport` size API / no-collision guarantee.)
+-/
+
+lemma card_apSupport {d m n : ℕ} (hd : d > 0) : (apSupport d m n).card = n := by
+  classical
+  unfold apSupport
+  have hinj : Function.Injective (fun i : ℕ => (m + i + 1) * d) := by
+    intro i j hij
+    have hmul : m + i + 1 = m + j + 1 := Nat.mul_right_cancel hd hij
+    have hmul' : m + (i + 1) = m + (j + 1) := by
+      simpa [Nat.add_assoc] using hmul
+    have : i + 1 = j + 1 := Nat.add_left_cancel hmul'
+    exact Nat.succ_inj.mp this
+  simpa [Finset.card_range] using
+    (Finset.card_image_of_injective (s := Finset.range n)
+      (f := fun i : ℕ => (m + i + 1) * d) hinj)
+
+/-!
 ### Paper-endpoint membership normal form (Track B)
 
 Many later arguments phrase “agreement on accessed indices” in the paper endpoint convention

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -137,6 +137,9 @@ example (d m n i : ℕ) (hd : d > 0) :
     (m + i + 1) * d ∈ apSupport d m n ↔ i < n := by
   simpa using (mem_apSupport_index_iff (d := d) (m := m) (n := n) (i := i) hd)
 
+example (d m n : ℕ) (hd : d > 0) : (apSupport d m n).card = n := by
+  simpa using (card_apSupport (d := d) (m := m) (n := n) hd)
+
 -- Paper-endpoint bridge: membership can be rewritten into the `(m<i≤m+n)` witness form.
 example (d m n x : ℕ) :
     x ∈ apSupport d m n ↔ ∃ i, m < i ∧ i ≤ m + n ∧ x = i * d := by


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `apSupport` size/monotonicity API: assuming `d > 0`, prove `Finset.card (apSupport d m n) = n` (no collisions)

### What
- Add `card_apSupport` lemma: for `d > 0`, `apSupport d m n` has cardinality `n`.
- Add a stable-surface regression example in `NormalFormExamples.lean`.

### Why
Gives a clean “no-collision / size” API for the normal-form support finset `apSupport`, so downstream proofs can reason about support size without unfolding.

### Tests
- `make ci`
