### PR TITLE
Track B: apSupport size/monotonicity API regression

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -140,6 +140,9 @@ example (d m n i : ℕ) (hd : d > 0) :
 example (d m n : ℕ) (hd : d > 0) : (apSupport d m n).card = n := by
   simpa using (card_apSupport (d := d) (m := m) (n := n) hd)
 
+example (d m n k : ℕ) : apSupport d m n ⊆ apSupport d m (n + k) := by
+  simpa using (apSupport_mono_right (d := d) (m := m) (n := n) (k := k))
+
 -- Paper-endpoint bridge: membership can be rewritten into the `(m<i≤m+n)` witness form.
 example (d m n x : ℕ) :
     x ∈ apSupport d m n ↔ ∃ i, m < i ∧ i ≤ m + n ∧ x = i * d := by

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -399,8 +399,10 @@ Goal: build a *directed* lemma scaffold (not lemma-sprawl). Each checkbox should
   (Implemented in `MoltResearch/Discrepancy/Basic.lean` as `mem_apSupport` / `mem_apSupport_iff_exists_endpoints`, with regression in
   `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
-- [ ] `apSupport` size/monotonicity API: assuming `d > 0`, prove `Finset.card (apSupport d m n) = n` (no collisions) and
+- [x] `apSupport` size/monotonicity API: assuming `d > 0`, prove `Finset.card (apSupport d m n) = n` (no collisions) and
   `apSupport d m n ⊆ apSupport d m (n+k)`; add a stable-surface regression example under `import MoltResearch.Discrepancy`.
+  (Implemented as `card_apSupport` / `apSupport_mono_right` in `MoltResearch/Discrepancy/Basic.lean`, with regression examples in
+  `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
 - [ ] Support-level congruence (sum-level): complement `discOffset_congr_support` with an `apSumOffset_congr_support` lemma
   `apSumOffset f d m n = apSumOffset g d m n` assuming `∀ x ∈ apSupport d m n, f x = g x`,


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `apSupport` size/monotonicity API: assuming `d > 0`, prove `Finset.card (apSupport d m n) = n` (no collisions) and

This PR:
- Adds a stable-surface regression example for the monotonicity lemma (`apSupport_mono_right`) under `import MoltResearch.Discrepancy`.
- Marks the checklist item complete with implementation pointers.

Local validation: `make ci`.