### PR TITLE
Discrepancy: stable-surface audit/example for apSumOffset_congr_support

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -63,11 +63,15 @@ example :
     (discOffset_shift_mul_right_comm (f := f) (d := d) (m := m) (n := n) (q := p))
 
 /-!
-### NEW (Track B): support-level congruence for `discOffset`
+### NEW (Track B): support-level congruence for `apSumOffset`/`discOffset`
 
-Regression: if two sequences agree on `apSupport d m n`, then the discrepancy wrapper agrees.
-This should remain a one-line `simpa` under `import MoltResearch.Discrepancy`.
+Regression: if two sequences agree on `apSupport d m n`, then both the sum and the discrepancy
+wrapper agree. These should remain one-line `simpa` proofs under `import MoltResearch.Discrepancy`.
 -/
+
+example (g : ℕ → ℤ) (h : ∀ x ∈ apSupport d m n, f x = g x) :
+    apSumOffset f d m n = apSumOffset g d m n := by
+  simpa using (apSumOffset_congr_support (f := f) (g := g) (d := d) (m := m) (n := n) h)
 
 example (g : ℕ → ℤ) (h : ∀ x ∈ apSupport d m n, f x = g x) :
     discOffset f d m n = discOffset g d m n := by

--- a/MoltResearch/Discrepancy/SurfaceAudit.lean
+++ b/MoltResearch/Discrepancy/SurfaceAudit.lean
@@ -235,6 +235,7 @@ section
   #check discOffset_mul_eq_discOffset_map_mul_left
 
   -- Local surgery / congruence.
+  #check apSumOffset_congr_support
   #check discOffset_congr_support
   #check discOffset_congr
   #check discOffset_congr_range


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Support-level congruence (sum-level): complement `discOffset_congr_support` with an `apSumOffset_congr_support` lemma

This PR makes `apSumOffset_congr_support` part of the audited stable surface and adds a compile-only regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.

- Adds `#check apSumOffset_congr_support` to `MoltResearch/Discrepancy/SurfaceAudit.lean`
- Adds a one-line `simpa` regression example for `apSumOffset_congr_support`

CI: `make ci`
