### PR TITLE
Track C: expose Stage 3 reduced unboundedness

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancyWitnesses.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancyWitnesses.lean
@@ -23,10 +23,9 @@ theorem erdos_discrepancy_unboundedDiscrepancyAlong_core (f : ℕ → ℤ) (hf :
     MoltResearch.UnboundedDiscrepancyAlong
       (Tao2015.stage3Out (f := f) (hf := hf)).g
       (Tao2015.stage3Out (f := f) (hf := hf)).d := by
-  -- Name the Stage-3 output once, to avoid repeating `stage3Out` in the proof term.
-  set out := Tao2015.stage3Out (f := f) (hf := hf) with hout
-  simpa [hout.symm] using
-    (Tao2015.Stage3Output.unboundedDiscrepancyAlong_core (f := f) out)
+  -- Delegate to the hard-gate minimal Stage-3 entry point lemma.
+  simpa [Tao2015.Stage3Output.g, Tao2015.Stage3Output.d, Tao2015.Stage2Output.g, Tao2015.Stage2Output.d] using
+    (Tao2015.stage3_unboundedDiscrepancyAlong_core (f := f) (hf := hf))
 
 /-- Paper-notation witness form for the concrete Stage-3 offset parameters.
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -66,6 +66,23 @@ This lemma is a tiny wrapper around `stage3Out_out1`.
     (stage3Out (f := f) (hf := hf)).out1 = (stage2Out (f := f) (hf := hf)).out1 := by
   rfl
 
+/-- Track C pipeline witness: Stage 3 yields unbounded fixed-step discrepancy along the reduced
+sequence, expressed using the verified core predicate `MoltResearch.UnboundedDiscrepancyAlong`.
+
+This lemma is a small convenience wrapper around the bridge equivalence
+`Tao2015.unboundedDiscrepancyAlong_iff_core`.
+-/
+theorem stage3_unboundedDiscrepancyAlong_core (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    MoltResearch.UnboundedDiscrepancyAlong
+      (stage3Out (f := f) (hf := hf)).out2.out1.g
+      (stage3Out (f := f) (hf := hf)).out2.out1.d := by
+  set out := stage3Out (f := f) (hf := hf) with hout
+  have hunb : Tao2015.UnboundedDiscrepancyAlong out.out2.out1.g out.out2.out1.d :=
+    out.out2.unbounded
+  simpa [hout.symm] using
+    (Tao2015.unboundedDiscrepancyAlong_iff_core (g := out.out2.out1.g) (d := out.out2.out1.d)).1
+      hunb
+
 /-- Consumer-facing shortcut: the Stage-3 pipeline closes the core goal `¬ BoundedDiscrepancy f`.
 
 We keep this lemma in the hard-gate minimal module so `ErdosDiscrepancy.lean` can remain minimal.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a hard-gate minimal lemma exposing Stage 3 reduced-sequence unboundedness in the verified core predicate form.
- Refactor ErdosDiscrepancyWitnesses to use this lemma, reducing proof duplication in the witness corollary.
