### PR TITLE
Discrepancy: apSumOffset two-cut normal form

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -2397,6 +2397,13 @@ example : apSum f d (m + n) - apSum f d m = apSum (fun k => f (k + m * d)) d n :
 example : apSumOffset f d m (n₁ + n₂) = apSumOffset f d m n₁ + apSumOffset f d (m + n₁) n₂ := by
   simpa using apSumOffset_add_length (f := f) (d := d) (m := m) (n₁ := n₁) (n₂ := n₂)
 
+-- Two-cut normal form for `apSumOffset`: split into three consecutive blocks.
+example :
+    apSumOffset f d m (n₁ + n₂ + n₃) =
+      apSumOffset f d m n₁ + apSumOffset f d (m + n₁) n₂ + apSumOffset f d (m + n₁ + n₂) n₃ := by
+  simpa using
+    (apSumOffset_add_len_add_len (f := f) (d := d) (m := m) (n₁ := n₁) (n₂ := n₂) (n₃ := n₃))
+
 -- Range-cut normal form for `apSumOffset`: split at a cut length `k ≤ n`.
 example {k : ℕ} (hk : k ≤ n) :
     apSumOffset f d m n = apSumOffset f d m k + apSumOffset f d (m + k) (n - k) := by

--- a/MoltResearch/Discrepancy/Offset.lean
+++ b/MoltResearch/Discrepancy/Offset.lean
@@ -203,6 +203,22 @@ lemma apSumOffset_eq_add_apSumOffset_cut (f : ℕ → ℤ) (d m n k : ℕ) (hk :
           -- Each block is exactly the stable `Finset.range` normal form of an `apSumOffset`.
           simp [apSumOffset_eq_sum_range']
 
+/-- Two-cut normal form for `apSumOffset`: split into three consecutive blocks.
+
+This is the length-based (canonical) version of “split at two interior cuts”:
+cut at length `n₁`, then at length `n₁+n₂`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — `apSumOffset` two-cut normal form.
+-/
+lemma apSumOffset_add_len_add_len (f : ℕ → ℤ) (d m n₁ n₂ n₃ : ℕ) :
+    apSumOffset f d m (n₁ + n₂ + n₃) =
+      apSumOffset f d m n₁ + apSumOffset f d (m + n₁) n₂ + apSumOffset f d (m + n₁ + n₂) n₃ := by
+  -- Split off the last block `n₃`, then split the prefix into `n₁` and `n₂`.
+  have h₁ := apSumOffset_add_length (f := f) (d := d) (m := m) (n₁ := n₁ + n₂) (n₂ := n₃)
+  have h₂ := apSumOffset_add_length (f := f) (d := d) (m := m) (n₁ := n₁) (n₂ := n₂)
+  -- `simp` uses `h₂` to expand the `(n₁+n₂)` prefix in `h₁`.
+  simpa [Nat.add_assoc, Nat.add_left_comm, Nat.add_comm, h₂] using h₁
+
 /-- Difference normal form for `apSumOffset`: the tail after cutting at `k ≤ n`.
 
 This is the exact (non-`natAbs`) companion to `apSumOffset_eq_add_apSumOffset_cut`:


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `apSumOffset` two-cut normal form: add a canonical lemma splitting at *two* interior cuts

Adds a single canonical lemma `apSumOffset_add_len_add_len` (length-based three-block split) and a stable-surface regression example in `NormalFormExamples.lean`.

CI: `make ci`
