### PR TITLE
discOffset: reverse triangle bounds

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -22,6 +22,7 @@ The goal is to pair verified artifacts with learning scaffolding.
 - **Intuition:** foundational discrepancy definitions and small bounds let later modules reuse a common vocabulary.
 - **Proof sketch pattern:** normalize definitions first, then prove small local inequalities and compose.
 - **Common pitfalls:** jumping into advanced lemmas before reducing to canonical definitions.
+- **API note (triangle vs reverse triangle):** for concatenation, `discOffset_add_le` is the forward triangle inequality. The reverse-triangle companions are `discOffset_left_le_add` / `discOffset_right_le_add`, proved by rewriting `S(n₁) = S(n₁+n₂) - S'(n₂)` and applying `Int.natAbs_sub_le`.
 - **API note:** `discOffsetUpTo` is monotone in the cutoff. Use `discOffsetUpTo_mono` for an arbitrary `N ≤ N'`, or the convenience wrapper `discOffsetUpTo_le_add` for the common “extend by `K`” case `N ≤ N+K`.
 - **API note (Lipschitz step):** for sign sequences, the one-step cutoff bound is `discOffsetUpTo_succ_le_add_one`:
   `discOffsetUpTo f d m (N+1) ≤ discOffsetUpTo f d m N + 1`. The reverse direction (monotonicity) is `discOffsetUpTo_le_succ`.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -2009,6 +2009,50 @@ lemma discOffset_add_le (f : ℕ → ℤ) (d m n₁ n₂ : ℕ) :
   simpa using
     (natAbs_apSumOffset_add_le (f := f) (d := d) (m := m) (n₁ := n₁) (n₂ := n₂))
 
+/-- Reverse triangle inequality (prefix form) for offset AP sums.
+
+If `S(n₁ + n₂) = S(n₁) + S'(n₂)` then `|S(n₁)| ≤ |S(n₁ + n₂)| + |S'(n₂)|`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — `discOffset` reverse triangle bounds.
+-/
+lemma natAbs_apSumOffset_left_le_add (f : ℕ → ℤ) (d m n₁ n₂ : ℕ) :
+    Int.natAbs (apSumOffset f d m n₁) ≤
+      Int.natAbs (apSumOffset f d m (n₁ + n₂)) + Int.natAbs (apSumOffset f d (m + n₁) n₂) := by
+  -- `|x| = |(x+y) - y| ≤ |x+y| + |y|`.
+  simpa [apSumOffset_add_len, sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using
+    (Int.natAbs_sub_le (apSumOffset f d m (n₁ + n₂)) (apSumOffset f d (m + n₁) n₂))
+
+/-- Reverse triangle inequality (suffix form) for offset AP sums.
+
+If `S(n₁ + n₂) = S(n₁) + S'(n₂)` then `|S'(n₂)| ≤ |S(n₁ + n₂)| + |S(n₁)|`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — `discOffset` reverse triangle bounds.
+-/
+lemma natAbs_apSumOffset_right_le_add (f : ℕ → ℤ) (d m n₁ n₂ : ℕ) :
+    Int.natAbs (apSumOffset f d (m + n₁) n₂) ≤
+      Int.natAbs (apSumOffset f d m (n₁ + n₂)) + Int.natAbs (apSumOffset f d m n₁) := by
+  -- `|y| = |(x+y) - x| ≤ |x+y| + |x|`.
+  simpa [apSumOffset_add_len, sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using
+    (Int.natAbs_sub_le (apSumOffset f d m (n₁ + n₂)) (apSumOffset f d m n₁))
+
+/-- Reverse triangle inequality for `discOffset` (prefix form).
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — `discOffset` reverse triangle bounds.
+-/
+lemma discOffset_left_le_add (f : ℕ → ℤ) (d m n₁ n₂ : ℕ) :
+    discOffset f d m n₁ ≤ discOffset f d m (n₁ + n₂) + discOffset f d (m + n₁) n₂ := by
+  simpa using
+    (natAbs_apSumOffset_left_le_add (f := f) (d := d) (m := m) (n₁ := n₁) (n₂ := n₂))
+
+/-- Reverse triangle inequality for `discOffset` (suffix form).
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — `discOffset` reverse triangle bounds.
+-/
+lemma discOffset_right_le_add (f : ℕ → ℤ) (d m n₁ n₂ : ℕ) :
+    discOffset f d (m + n₁) n₂ ≤ discOffset f d m (n₁ + n₂) + discOffset f d m n₁ := by
+  simpa using
+    (natAbs_apSumOffset_right_le_add (f := f) (d := d) (m := m) (n₁ := n₁) (n₂ := n₂))
+
 /-- Two-cut normal form bound (discOffset-level): concatenate three segments.
 
 Checklist item: Problems/erdos_discrepancy.md (Track B) — Two-cut normal form (discOffset-level).

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -2463,6 +2463,15 @@ example :
     discOffset f d m (n₁ + n₂) ≤ discOffset f d m n₁ + discOffset f d (m + n₁) n₂ := by
   simpa using (discOffset_add_le (f := f) (d := d) (m := m) (n₁ := n₁) (n₂ := n₂))
 
+-- `discOffset` reverse triangle inequality regressions (Track B item: reverse triangle bounds).
+example :
+    discOffset f d m n₁ ≤ discOffset f d m (n₁ + n₂) + discOffset f d (m + n₁) n₂ := by
+  simpa using (discOffset_left_le_add (f := f) (d := d) (m := m) (n₁ := n₁) (n₂ := n₂))
+
+example :
+    discOffset f d (m + n₁) n₂ ≤ discOffset f d m (n₁ + n₂) + discOffset f d m n₁ := by
+  simpa using (discOffset_right_le_add (f := f) (d := d) (m := m) (n₁ := n₁) (n₂ := n₂))
+
 -- `discAlong` triangle inequality regression (Track B item: along-`d` concatenation bound).
 example :
     discAlong f d (n₁ + n₂) ≤ discAlong f d n₁ + discAlong (fun k => f (k + n₁ * d)) d n₂ := by


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `discOffset` reverse triangle bounds: complement `discOffset_add_le` with packaged “reverse triangle” corollaries

### What
- Add reverse-triangle corollaries for concatenation at the `apSumOffset`/`discOffset` level:
  - prefix bound: `discOffset … n₁ ≤ discOffset … (n₁+n₂) + discOffset … n₂`
  - suffix bound: `discOffset … n₂ ≤ discOffset … (n₁+n₂) + discOffset … n₁`
- Add stable-surface regression examples under `import MoltResearch.Discrepancy` (in `NormalFormExamples.lean`).

### Why
These are the standard reverse-triangle companions to `discOffset_add_le`, useful for normal-form discrepancy pipelines.

### Notes
- Proofs use `Int.natAbs_sub_le` + the concatenation normal form `apSumOffset_add_len` (no unfolding of `discOffset`).
