### PR TITLE
Track C: avoid unfolding unboundedness

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
@@ -92,8 +92,11 @@ theorem forall_exists_discrepancy_gt'_witness_pos (out : Stage2Output f) :
 /-- Equivalent packaging: arbitrarily large discrepancy witnesses along `out.d`. -/
 theorem forall_hasDiscrepancyAtLeastAlong (out : Stage2Output f) :
     ∀ C : ℕ, HasDiscrepancyAtLeastAlong out.g out.d C := by
-  -- `UnboundedDiscrepancyAlong` is definitionally `∀ C, HasDiscrepancyAtLeastAlong ... C`.
-  simpa [Tao2015.UnboundedDiscrepancyAlong, HasDiscrepancyAtLeastAlong] using out.unbounded
+  -- Package the definitional equivalence as a named lemma, avoiding repeated unfolding.
+  exact
+    (HasDiscrepancyAtLeastAlong.forall_hasDiscrepancyAtLeastAlong_iff_unboundedDiscrepancyAlong
+          (g := out.g) (d := out.d)).2
+      out.unbounded
 
 -- (moved to `TrackCStage2Core.lean`)
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Core.lean
@@ -61,9 +61,11 @@ This is the `HasDiscrepancyAtLeastAlong` normal form of `unboundedReducedAlong`.
 -/
 theorem forall_hasDiscrepancyAtLeastAlong (out : Stage3Output f) :
     ∀ C : ℕ, HasDiscrepancyAtLeastAlong out.g out.d C := by
-  -- `UnboundedDiscrepancyAlong` is definitionally `∀ C, HasDiscrepancyAtLeastAlong ... C`.
-  simpa [Tao2015.UnboundedDiscrepancyAlong, HasDiscrepancyAtLeastAlong, Stage3Output.g,
-    Stage3Output.d] using out.out2.unbounded
+  -- Package the definitional equivalence as a named lemma, avoiding repeated unfolding.
+  exact
+    (HasDiscrepancyAtLeastAlong.forall_hasDiscrepancyAtLeastAlong_iff_unboundedDiscrepancyAlong
+          (g := out.g) (d := out.d)).2
+      out.unboundedReducedAlong
 
 /-- Stage 3 implies the reduced sequence is not bounded along its fixed step size. -/
 theorem notBoundedReducedAlong (out : Stage3Output f) : ¬ BoundedDiscrepancyAlong out.g out.d := by


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Stage 2 and Stage 3 now derive forall_hasDiscrepancyAtLeastAlong via the named equivalence lemma, instead of unfolding definitions with simpa.
- Keeps the Stage-2/3 API surface the same while making the proofs more robust against definitional changes.
