### PR TITLE
Discrepancy: add stable-surface support+edit starter example

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -1005,6 +1005,24 @@ example :
     (IsSignSequence.discOffset_edit_le_of_card_apSupport_diff_le
       (hf := hf) (hg := hg) (d := 1) (m := 2) (n := 5) (t := 1) (by decide) ht)
 
+/-!
+### NEW (Track B): support + edit pipeline (stable-surface starter pattern)
+
+This is the “generic” version of the common workflow:
+
+1. you have two sign sequences `f, g`;
+2. you know they differ on at most `t` points of the accessed-index finset `apSupport d m n`;
+3. you conclude `discOffset f d m n ≤ discOffset g d m n + 2*t`.
+
+It is intentionally a one-line `simpa` application of the stable-surface wrapper lemma.
+-/
+example (g : ℕ → ℤ) (hf : IsSignSequence f) (hg : IsSignSequence g)
+    (t : ℕ) (ht : ((apSupport d m n).filter (fun x => f x ≠ g x)).card ≤ t) :
+    discOffset f d m n ≤ discOffset g d m n + 2 * t := by
+  simpa using
+    (IsSignSequence.discOffset_edit_le_of_card_apSupport_diff_le
+      (hf := hf) (hg := hg) (d := d) (m := m) (n := n) (t := t) (by decide) ht)
+
 -- Regression (Track B / bounded-perturbation stability, `apSupport` form):
 -- a non-sign-sequence perturbation (values in `{0,2}`) still yields the same `+ 2*t` bound
 -- when we assume the pointwise `Int.natAbs (f x - g x) ≤ 2` hypothesis on `apSupport`.

--- a/MoltResearch/Discrepancy/NormalFormPipelineExample.lean
+++ b/MoltResearch/Discrepancy/NormalFormPipelineExample.lean
@@ -58,6 +58,60 @@ section
   end MicroPipeline
 
   /-!
+  A compact “support + edit” pipeline example.
+
+  Typical Track B pattern:
+
+  1. Use **support congruence** to ignore changes outside `apSupport d m n`.
+  2. Use **edit sensitivity** to compare two sign sequences that differ on ≤1 sampled index.
+
+  Compile-only; the goal is to keep the stable surface usable under:
+
+  ```lean
+  import MoltResearch.Discrepancy
+  ```
+  -/
+  example :
+      let f : ℕ → ℤ := fun _ => 1
+      let g : ℕ → ℤ := fun n => if n = 4 then (-1) else 1
+      let h : ℕ → ℤ := fun n => if n = 100 then (-1) else g n
+      -- (1) Changes outside the support do not affect `discOffset`.
+      discOffset h 1 0 6 = discOffset g 1 0 6 ∧
+      -- (2) If `f` and `h` differ on ≤1 sampled index in `range 6`, pay a +2 edit cost.
+      discOffset f 1 0 6 ≤ discOffset h 1 0 6 + 2 := by
+    intro f g h
+    constructor
+    · -- Support congruence: `h = g` on the relevant finite support.
+      refine (discOffset_congr_support (f := h) (g := g) (d := 1) (m := 0) (n := 6) ?_).symm
+      intro x hx
+      -- Any `x ∈ apSupport 1 0 6` satisfies `x ≤ 6`, so in particular `x ≠ 100`.
+      have hx' : ∃ i, 0 < i ∧ i ≤ 0 + 6 ∧ x = i * 1 := by
+        simpa [Nat.add_comm, Nat.add_left_comm, Nat.add_assoc] using
+          (mem_apSupport_iff_exists_endpoints (d := 1) (m := 0) (n := 6) (x := x)).1 hx
+      rcases hx' with ⟨i, hi0, hi6, rfl⟩
+      have hi6' : i ≤ 6 := by simpa using hi6
+      have hi100 : i ≠ 100 := by
+        -- `i ≤ 6 < 100`.
+        exact ne_of_lt (lt_of_le_of_lt hi6' (by decide))
+      -- Now `h` reduces to `g` on this support point.
+      simp [h, g, hi100]
+    · -- Edit sensitivity bound.
+      have hf : IsSignSequence f := by
+        intro n; simp [f]
+      have hh : IsSignSequence h := by
+        intro n
+        by_cases hn : n = 100
+        · simp [h, hn]
+        · by_cases h4 : n = 4 <;> simp [h, hn, g, h4]
+      have hcard :
+          ((Finset.range 6).filter (fun i => f ((0 + i + 1) * 1) ≠ h ((0 + i + 1) * 1))).card ≤ 1 := by
+        -- On sampled indices `1..6`, `h` agrees with `g`, so only the `i=3` (`n=4`) sample differs.
+        decide
+      simpa using
+        (IsSignSequence.discOffset_edit_le
+          (hf := hf) (hg := hh) (d := 1) (m := 0) (n := 6) (t := 1) hcard)
+
+  /-!
   A compact “edit + split + bound” example.
 
   We compare two sign sequences `f` and `g` that differ at exactly one sampled index, and we bound


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Stable-surface “support + edit” pipeline example: add a compile-only example showing the common pattern

Adds a short, generic compile-only example to `MoltResearch/Discrepancy/NormalFormExamples.lean` demonstrating the stable-surface “support + edit” workflow:
- use `apSupport d m n` to localize where two sign sequences differ
- apply `IsSignSequence.discOffset_edit_le_of_card_apSupport_diff_le` in one line

No new lemmas; just an example/regression test under `import MoltResearch.Discrepancy`.
