### PR TITLE
Discrepancy: add support+edit pipeline example

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -78,6 +78,27 @@ example (g : ℕ → ℤ) (h : ∀ x ∈ apSupport d m n, f x = g x) :
   simpa using (discOffset_congr_support (f := f) (g := g) (d := d) (m := m) (n := n) h)
 
 /-!
+### NEW (Track B): “support + edit” pipeline pattern
+
+A common workflow is:
+1. identify the finite “support” set `apSupport d m n`,
+2. define a modified sequence `g` by editing `f` *outside* (or inside) that support,
+3. rewrite `apSumOffset`/`discOffset` using the support-level congruence lemma.
+
+This example is compile-only and should remain a one-line `simp` proof under
+`import MoltResearch.Discrepancy`.
+-/
+
+example :
+    let g : ℕ → ℤ := fun x => if x ∈ apSupport d m n then f x else 0
+    discOffset f d m n = discOffset g d m n := by
+  intro g
+  refine discOffset_congr_support (f := f) (g := g) (d := d) (m := m) (n := n) ?_
+  intro x hx
+  -- On the support, `g` agrees with `f` by construction.
+  simp [g, hx]
+
+/-!
 ### NEW (Track B): endpoint-normalization helpers for `discOffset` witnesses
 
 Regression: a common hypothesis shape is stated using finitary endpoint sets


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Stable-surface “support + edit” pipeline example: add a compile-only example showing the common pattern

Adds a small compile-only regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean` demonstrating the common workflow:
- define an edited sequence `g` via `if x ∈ apSupport d m n then f x else 0`
- rewrite `discOffset` using `discOffset_congr_support`

No new lemmas; stable-surface-only usage under `import MoltResearch.Discrepancy`.
