### PR TITLE
Discrepancy: stable-surface support+edit pipeline example

### DIFF
--- a/MoltResearch/Discrepancy/SupportEditPipelineExample.lean
+++ b/MoltResearch/Discrepancy/SupportEditPipelineExample.lean
@@ -1,0 +1,30 @@
+import MoltResearch.Discrepancy
+
+/-!
+# Discrepancy: stable-surface “support + edit” pipeline example
+
+Compile-only regression test wired into `MoltResearch.Discrepancy.SurfaceAudit`.
+
+Checklist item (Track B): Problems/erdos_discrepancy.md
+- "Stable-surface support + edit pipeline example"
+
+This is the common downstream workflow:
+1. Work on the finite accessed-index finset `apSupport d m n`.
+2. Prove `f` and `g` differ on at most `t` points of this support.
+3. Conclude a `discOffset` bound via the edit-sensitivity wrapper.
+-/
+
+namespace MoltResearch
+
+section
+  variable (f g : ℕ → ℤ) (d m n t : ℕ)
+
+  example (hd : 0 < d) (hf : IsSignSequence f) (hg : IsSignSequence g)
+      (ht : ((apSupport d m n).filter (fun x => f x ≠ g x)).card ≤ t) :
+      discOffset f d m n ≤ discOffset g d m n + 2 * t := by
+    simpa using
+      (IsSignSequence.discOffset_edit_le_of_card_apSupport_diff_le
+        (hf := hf) (hg := hg) (d := d) (m := m) (n := n) (t := t) hd ht)
+end
+
+end MoltResearch

--- a/MoltResearch/Discrepancy/SurfaceAudit.lean
+++ b/MoltResearch/Discrepancy/SurfaceAudit.lean
@@ -1,6 +1,7 @@
 import MoltResearch.Discrepancy
 import MoltResearch.Discrepancy.NormalFormPipelineExample
 import MoltResearch.Discrepancy.MiniPipelineMaxExample
+import MoltResearch.Discrepancy.SupportEditPipelineExample
 
 /-!
 # Discrepancy: stable surface audit (compile-time regression tests)

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -430,7 +430,7 @@ Goal: build a *directed* lemma scaffold (not lemma-sprawl). Each checkbox should
   (Implemented in `MoltResearch/Discrepancy/Basic.lean` as `discOffset_left_le_add` / `discOffset_right_le_add`,
   with stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
-- [ ] Stable-surface “support + edit” pipeline example: add a compile-only example showing the common pattern
+- [x] Stable-surface “support + edit” pipeline example: add a compile-only example showing the common pattern
   “assume two sequences agree on `apSupport` outside a small set → apply edit-sensitivity → conclude a `discOffset` bound”,
   wired into `SurfaceAudit`.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Stable-surface “support + edit” pipeline example: add a compile-only example showing the common pattern

Summary:
- Add `MoltResearch.Discrepancy.SupportEditPipelineExample` (compile-only) demonstrating the common support/edit-sensitivity workflow under `import MoltResearch.Discrepancy`.
- Wire the example into `MoltResearch.Discrepancy.SurfaceAudit` so it cannot silently regress.
- Mark the corresponding Track B checklist item as done.

CI:
- `make ci`
