### PR TITLE
Track C: start-index tail witness lemma

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2CoreExtras.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2CoreExtras.lean
@@ -164,6 +164,17 @@ theorem forall_exists_natAbs_apSumFrom_mul_gt_witness_pos (out : Stage2Output f)
     (Tao2015.UnboundedDiscOffset.forall_exists_natAbs_apSumFrom_mul_gt_witness_pos
       (f := f) (d := out.d) (m := out.m) hunb)
 
+/-- Tail-nucleus witness form without the positive-length side condition.
+
+This is a small convenience corollary of
+`Stage2Output.forall_exists_natAbs_apSumFrom_mul_gt_witness_pos`.
+-/
+theorem forall_exists_natAbs_apSumFrom_start_gt (out : Stage2Output f) :
+    ∀ B : ℕ, ∃ n : ℕ, Int.natAbs (apSumFrom f out.start out.d n) > B := by
+  intro B
+  rcases out.forall_exists_natAbs_apSumFrom_mul_gt_witness_pos (f := f) B with ⟨n, _hnpos, hgt⟩
+  exact ⟨n, hgt⟩
+
 end Stage2Output
 
 end Tao2015


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a small corollary lemma Stage2Output.forall_exists_natAbs_apSumFrom_start_gt in the Stage-2 core-extras layer.
- This provides the tail-nucleus witness form using the bundled start index, without requiring the n > 0 side condition.
