### PR TITLE
Track C: simp lemmas for stage3Out params

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -66,6 +66,23 @@ This lemma is a tiny wrapper around `stage3Out_out1`.
     (stage3Out (f := f) (hf := hf)).out1 = (stage2Out (f := f) (hf := hf)).out1 := by
   rfl
 
+/-- Deterministic Stage-2 parameter projections for `stage3Out`.
+
+These simp lemmas reduce rewriting noise when shuttling statements between Stage 2 and Stage 3.
+-/
+@[simp] theorem stage3Out_d (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    (stage3Out (f := f) (hf := hf)).out2.d = (stage2Out (f := f) (hf := hf)).d := by
+  rfl
+
+@[simp] theorem stage3Out_m (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    (stage3Out (f := f) (hf := hf)).out2.m = (stage2Out (f := f) (hf := hf)).m := by
+  rfl
+
+@[simp] theorem stage3Out_g (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    (stage3Out (f := f) (hf := hf)).out2.g = (stage2Out (f := f) (hf := hf)).g := by
+  rfl
+
+
 /-- Track C pipeline witness: Stage 3 yields unbounded fixed-step discrepancy along the reduced
 sequence, expressed using the verified core predicate `MoltResearch.UnboundedDiscrepancyAlong`.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add simp lemmas stage3Out_d, stage3Out_m, stage3Out_g so Stage-3 entry code rewrites to deterministic Stage-2 parameters with simp
- Proofs are definitional rfl, so this is purely API polish for the hard-gate minimal entry point
