### PR TITLE
Track C: positive-length affine-tail packaging

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
@@ -327,6 +327,18 @@ theorem exists_params_forall_exists_natAbs_apSumFrom_mul_gt (out : Stage2Output 
   rcases out.forall_exists_natAbs_apSumFrom_mul_gt (f := f) C with ⟨n, hn⟩
   exact ⟨n, hn⟩
 
+/-- Existential packaging: Stage 2 yields concrete parameters `d, m` such that the affine-tail nucleus
+`apSumFrom f (m*d) d n` takes arbitrarily large absolute values, with a positive-length witness `n > 0`.
+
+This is a thin wrapper around `forall_exists_natAbs_apSumFrom_mul_gt_witness_pos`.
+-/
+theorem exists_params_forall_exists_natAbs_apSumFrom_mul_gt_witness_pos (out : Stage2Output f) :
+    ∃ d m : ℕ, d > 0 ∧
+      (∀ C : ℕ, ∃ n : ℕ, n > 0 ∧ Int.natAbs (apSumFrom f (m * d) d n) > C) := by
+  refine ⟨out.d, out.m, out.hd, ?_⟩
+  intro C
+  simpa using out.forall_exists_natAbs_apSumFrom_mul_gt_witness_pos (f := f) C
+
 /-- Existential packaging variant of `exists_params_forall_exists_natAbs_apSumFrom_mul_gt` using
 the side condition `1 ≤ d`.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add an existential packaging lemma for the affine-tail nucleus witness form that ensures the witness length n is positive.
- Keeps the Stage-2 output API symmetric with the existing 1 ≤ d positive-witness packaging.
