### PR TITLE
Track C: Stage2Output start_add_mod_d

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2CoreExtras.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2CoreExtras.lean
@@ -77,6 +77,11 @@ theorem add_start_mod_d (out : Stage2Output f) (n : ℕ) :
   have hstart : out.start % out.d = 0 := out.start_mod_d (f := f)
   simp [Nat.add_mod, hstart]
 
+/-- Variant of `add_start_mod_d` with the start index on the left. -/
+theorem start_add_mod_d (out : Stage2Output f) (n : ℕ) :
+    (out.start + n) % out.d = n % out.d := by
+  simpa [Nat.add_comm] using out.add_start_mod_d (f := f) (n := n)
+
 /-- Recover the offset parameter `out.m` by dividing the start index `out.start` by the step size
 `out.d`.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add Stage2Output.start_add_mod_d, a symmetric variant of add_start_mod_d with the start index on the left.
- Keeps Stage-2 start-index modulo rewriting ergonomic for downstream consumers.
