### PR TITLE
Track C: Stage2Output hasDiscrepancyAtLeast

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
@@ -78,6 +78,13 @@ theorem forall_hasDiscrepancyAtLeast (out : Stage2Output f) :
   refine (forall_hasDiscrepancyAtLeast_iff_not_boundedDiscrepancy f).2 ?_
   exact out.notBoundedOriginal (f := f)
 
+/-- Specialization of `forall_hasDiscrepancyAtLeast` at a fixed threshold `C`.
+
+This is a tiny convenience lemma: it avoids an extra application at the call site.
+-/
+theorem hasDiscrepancyAtLeast (out : Stage2Output f) (C : ℕ) : HasDiscrepancyAtLeast f C := by
+  exact (out.forall_hasDiscrepancyAtLeast (f := f)) C
+
 /-!
 ## Offset-discrepancy normal forms used by Stage 3
 -/


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add Stage2Output.hasDiscrepancyAtLeast as a small specialization of forall_hasDiscrepancyAtLeast.
- This avoids an extra application at call sites while keeping the Stage-2 core API thin.
