### PR TITLE
Track C: Stage3Output hasDiscrepancyAtLeast

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Core.lean
@@ -28,6 +28,14 @@ consistent name at both boundaries.
 abbrev notBoundedOriginal (out : Stage3Output f) : ¬ BoundedDiscrepancy f :=
   out.notBounded
 
+/-- Specialization of `Stage3Output.forall_hasDiscrepancyAtLeast` at a fixed threshold `C`.
+
+This is a tiny convenience lemma, matching the Stage-2 API name
+`Stage2Output.hasDiscrepancyAtLeast`.
+-/
+theorem hasDiscrepancyAtLeast (out : Stage3Output f) (C : ℕ) : HasDiscrepancyAtLeast f C := by
+  exact (out.forall_hasDiscrepancyAtLeast (f := f)) C
+
 /-- Convenience projection: the reduced step size packaged in Stage 3.
 
 We intentionally route this through the Stage-2 boundary API (`Stage2Output.d`) so Stage 3 does not


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Added Stage3Output.hasDiscrepancyAtLeast (Stage-3 analogue of the Stage-2 API helper).
- Keeps Stage-3 core consumers from having to apply forall_hasDiscrepancyAtLeast manually at the call site.
