### PR TITLE
Track C: discOffset witness lemma in core extras

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2CoreExtras.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2CoreExtras.lean
@@ -55,6 +55,17 @@ theorem discOffset_eq_natAbs_apSumFrom_start (out : Stage2Output f) (n : ℕ) :
   -- Rewrite the bundled offset nucleus `apSumOffset` to the affine-tail nucleus `apSumFrom`.
   rw [← out.apSumFrom_start_eq_apSumOffset (f := f) n]
 
+/-- Positive-length witness form: Stage 2 yields arbitrarily large bundled offset discrepancies
+`discOffset f out.d out.m n`, with witnesses `n > 0`.
+
+We keep this lemma in `TrackCStage2CoreExtras.lean` so downstream stages can access it without
+importing the large Stage-2 output-lemma library `TrackCStage2Output.lean`.
+-/
+theorem forall_exists_discOffset_gt_witness_pos (out : Stage2Output f) :
+    ∀ B : ℕ, ∃ n : ℕ, n > 0 ∧ B < discOffset f out.d out.m n := by
+  have hunb : UnboundedDiscOffset f out.d out.m := out.unboundedDiscOffset (f := f)
+  exact UnboundedDiscOffset.forall_exists_discOffset_gt_witness_pos (hunb := hunb)
+
 /-- The affine-tail start index `out.start` is a multiple of the reduced step size `out.d`. -/
 theorem d_dvd_start (out : Stage2Output f) : out.d ∣ out.start := by
   -- `out.start` is definitionally `m*d`.

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
@@ -137,16 +137,6 @@ theorem forall_exists_discOffset_gt (out : Stage2Output f) :
   simpa using
     ((out.out1.unboundedDiscrepancyAlong_iff_forall_exists_discOffset_gt (f := f)).1 out.unbounded)
 
-/-- Positive-length witness form of `forall_exists_discOffset_gt`.
-
-The witness length `n` cannot be `0`, since `discOffset ... 0 = 0`.
--/
-theorem forall_exists_discOffset_gt_witness_pos (out : Stage2Output f) :
-    ∀ B : ℕ, ∃ n : ℕ, n > 0 ∧ B < discOffset f out.d out.m n := by
-  have hunb : UnboundedDiscOffset f out.d out.m :=
-    (out.out1.unboundedDiscrepancyAlong_iff_unboundedDiscOffset (f := f)).1 out.unbounded
-  exact UnboundedDiscOffset.forall_exists_discOffset_gt_witness_pos (hunb := hunb)
-
 /-- Inequality-direction variant of `forall_exists_discOffset_gt`, written as `discOffset ... > B`.
 
 Many consumers prefer this normal form so they can `simp [gt_iff_lt]` at the call site.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Moved the positive-length witness lemma for bundled offset discrepancy (forall B, exists n > 0 with B < discOffset ...) into TrackCStage2CoreExtras.
- Removed the duplicate definition from TrackCStage2Output; the lemma is still available (and now usable without importing the large Stage-2 output file).
