### PR TITLE
Track C: discAlong normal form for unboundedness

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/Tao2015.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/Tao2015.lean
@@ -127,6 +127,20 @@ theorem unboundedDiscrepancyAlong_iff_forall_exists_discrepancy_gt' (g : ℕ →
     rcases h B with ⟨n, hn⟩
     exact ⟨n, hn⟩
 
+/-- Inequality-direction variant of `UnboundedDiscrepancyAlong`, written using the stable wrapper
+`discAlong`.
+
+Normal form:
+`∀ B, ∃ n, discAlong g d n > B`.
+
+This is `unboundedDiscrepancyAlong_iff_forall_exists_discrepancy_gt'` rewritten using
+`discAlong_eq_discrepancy`.
+-/
+theorem unboundedDiscrepancyAlong_iff_forall_exists_discAlong_gt' (g : ℕ → ℤ) (d : ℕ) :
+    UnboundedDiscrepancyAlong g d ↔ (∀ B : ℕ, ∃ n : ℕ, discAlong g d n > B) := by
+  simpa [discAlong_eq_discrepancy] using
+    (unboundedDiscrepancyAlong_iff_forall_exists_discrepancy_gt' (g := g) (d := d))
+
 /-- Nucleus normal form for `UnboundedDiscrepancyAlong`.
 
 Normal form:


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Added a discAlong-based normal form for Stage-2 style unboundedness along a fixed step d.
- This avoids unfolding discrepancy at call sites by rewriting through discAlong_eq_discrepancy.
