### PR TITLE
Track C: dedupe Stage2/3 wrapper lemmas

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancyWitnesses.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancyWitnesses.lean
@@ -165,10 +165,9 @@ The witness length `n` cannot be `0`, since `discOffset f d m 0 = 0`.
 theorem erdos_discrepancy_exists_params_forall_exists_discOffset_gt_witness_pos (f : ℕ → ℤ)
     (hf : IsSignSequence f) :
     ∃ d m : ℕ, d > 0 ∧ (∀ B : ℕ, ∃ n : ℕ, n > 0 ∧ B < discOffset f d m n) := by
-  rcases erdos_discrepancy_exists_params_unboundedDiscOffset (f := f) (hf := hf) with
-    ⟨d, m, hd, hunb⟩
-  refine ⟨d, m, hd, ?_⟩
-  exact Tao2015.UnboundedDiscOffset.forall_exists_discOffset_gt_witness_pos (hunb := hunb)
+  simpa using
+    (Tao2015.Stage2Output.exists_params_forall_exists_discOffset_gt_witness_pos (f := f)
+      (Tao2015.stage3Out (f := f) (hf := hf)).out2)
 
 /-- Variant of `erdos_discrepancy_exists_params_forall_exists_discOffset_gt` packaging the step-size
 side condition as `1 ≤ d`.

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
@@ -193,19 +193,8 @@ theorem not_exists_forall_natAbs_apSumOffset_le (out : Stage2Output f) :
         (d := out.d) (m := out.m)).1
       hunb
 
-/-- Negation-normal-form unboundedness statement for the affine-tail nuclei
-`Int.natAbs (apSumFrom f (m*d) d n)` at the concrete Stage-2 parameters `(out.d, out.m)`.
-
-This is the tail-nucleus analogue of `not_exists_forall_natAbs_apSumOffset_le`.
--/
-theorem not_exists_forall_natAbs_apSumFrom_mul_le (out : Stage2Output f) :
-    ¬ ∃ B : ℕ, ∀ n : ℕ, Int.natAbs (apSumFrom f (out.m * out.d) out.d n) ≤ B := by
-  have hunb : UnboundedDiscOffset f out.d out.m := out.unboundedDiscOffset (f := f)
-  -- Use the generic tail-nucleus normal form for `UnboundedDiscOffset`.
-  exact
-    (Tao2015.UnboundedDiscOffset.iff_not_exists_forall_natAbs_apSumFrom_mul_le (f := f)
-        (d := out.d) (m := out.m)).1
-      hunb
+-- Note: `Stage2Output.not_exists_forall_natAbs_apSumFrom_mul_le` lives in
+-- `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2CoreExtras` (core import surface).
 
 /-- Negation-normal-form unboundedness statement for the paper-notation shifted progression sums
 `∑ i ∈ Icc (m+1) (m+n), f (i*d)` at the concrete Stage-2 parameters `(out.d, out.m)`.

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Core.lean
@@ -95,14 +95,7 @@ theorem unboundedDiscrepancyAlong_core (out : Stage3Output f) :
 /-- Convenience projection: the bundled offset parameter packaged in Stage 3. -/
 abbrev m (out : Stage3Output f) : ℕ := out.out2.m
 
-/-- Stage 3 retains the Stage-2 bundled offset unboundedness witness.
-
-This is a tiny convenience projection so consumers of `Stage3Output` do not have to reach into the
-nested Stage-2 record field `out.out2`.
--/
-theorem unboundedDiscOffset (out : Stage3Output f) : UnboundedDiscOffset f out.d out.m := by
-  simpa [Stage3Output.d, Stage3Output.m] using
-    (Stage2Output.unboundedDiscOffset (f := f) out.out2)
+-- Note: `Stage3Output.unboundedDiscOffset` is defined in `TrackCStage3.lean`.
 
 /-- Convenience projection: the affine-tail start index `m*d` packaged in Stage 3. -/
 abbrev start (out : Stage3Output f) : ℕ := out.m * out.d

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Entry.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Entry.lean
@@ -172,30 +172,8 @@ theorem stage3_forall_exists_discrepancy_gt_d_ge_one_witness_pos (f : ℕ → �
 
 -- (moved to `Conjectures.C0002_erdos_discrepancy.src.TrackCStage3EntryCore`)
 
-/-- Consumer-facing shortcut: Stage 3 yields unboundedness of the bundled offset discrepancy family
-`discOffset f d m` at the deterministic parameters produced by the pipeline.
-
-We keep this lemma in the `...TrackCStage3Entry` import path so consumers can access the offset
-witness without importing `TrackCStage3Proof`.
--/
-theorem stage3_unboundedDiscOffset (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    UnboundedDiscOffset f (stage3_d (f := f) (hf := hf)) (stage3_m (f := f) (hf := hf)) := by
-  -- Route through the proved Stage-2 core lemma (a thin wrapper around the Stage-1 transport
-  -- contract).
-  simpa [stage3_d, stage3_m, stage2_d, stage2_m] using
-    (Stage2Output.unboundedDiscOffset (f := f) (stage2Out (f := f) (hf := hf)))
-
-/-- Negation-normal-form: Stage 3 yields no uniform bound on the bundled offset discrepancy family
-`discOffset f d m` at the deterministic parameters produced by the pipeline.
-
-This is a thin wrapper around the Stage-2 core lemma
-`Stage2Output.not_exists_boundedDiscOffset`.
--/
-theorem stage3_not_exists_boundedDiscOffset (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    ¬ ∃ B : ℕ,
-        BoundedDiscOffset f (stage3_d (f := f) (hf := hf)) (stage3_m (f := f) (hf := hf)) B := by
-  simpa [stage3_d, stage3_m, stage2_d, stage2_m, Stage2Output.d, Stage2Output.m] using
-    (Stage2Output.not_exists_boundedDiscOffset (f := f) (stage2Out (f := f) (hf := hf)))
+-- Note: `stage3_unboundedDiscOffset` and `stage3_not_exists_boundedDiscOffset` live in
+-- `Conjectures.C0002_erdos_discrepancy.src.TrackCStage3EntryMinimal`.
 
 /-- Witness-family form of `stage3_unboundedDiscOffset` (inequality-direction), with a positive-length
 witness.

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Output.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Output.lean
@@ -175,15 +175,8 @@ theorem exists_params_one_le_unboundedDiscOffset (out : Stage3Output f) :
   refine ⟨out.d, out.m, out.one_le_d (f := f), ?_⟩
   simpa [Stage3Output.d, Stage3Output.m] using out.unboundedDiscOffset (f := f)
 
-/-- Negation-normal-form: there is no uniform bound on the bundled offset discrepancy family
-`discOffset f out.d out.m`.
-
-This is a thin wrapper around `Stage2Output.not_exists_boundedDiscOffset`.
--/
-theorem not_exists_boundedDiscOffset (out : Stage3Output f) :
-    ¬ ∃ B : ℕ, BoundedDiscOffset f out.d out.m B := by
-  simpa [Stage3Output.d, Stage3Output.m] using
-    (Stage2Output.not_exists_boundedDiscOffset (f := f) out.out2)
+-- Note: `Stage3Output.not_exists_boundedDiscOffset` is defined in
+-- `Conjectures.C0002_erdos_discrepancy.src.TrackCStage3`.
 
 /-- Negation-normal-form unboundedness statement for the bundled offset nuclei
 `Int.natAbs (apSumOffset f out.d out.m n)`.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Remove duplicate Stage-2 and Stage-3 wrapper lemma declarations so the convenience layers build without name-collision errors.
- Simplify the positive-length discOffset witness packaging in ErdosDiscrepancyWitnesses by reusing the existing Stage2Output lemma.
- Hard-gate target Conjectures.C0002_erdos_discrepancy.src.ErdosDiscrepancy still builds successfully.
