### PR TITLE
Track C: simp discOffset in apSumOffset witness lemma

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
@@ -62,8 +62,7 @@ theorem stage3_exists_params_one_le_forall_exists_natAbs_apSumOffset_gt_witness_
   rcases out.out2.forall_exists_discOffset_gt'_witness_pos (f := f) B with ⟨n, hn, hdisc⟩
   refine ⟨n, hn, ?_⟩
   -- `discOffset` is definitionally `Int.natAbs (apSumOffset ...)`.
-  change discOffset f out.out2.d out.out2.m n > B
-  exact hdisc
+  simpa [discOffset] using hdisc
 
 /-- Consumer-facing shortcut: Stage 3 yields the discrepancy witness form
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- In TrackCStage3EntryCore, make the apSumOffset witness lemma explicitly unfold discOffset via simp.
- Avoid relying on change to a definitional equality; the proof now matches the intent of the comment (discOffset = natAbs apSumOffset).
