### PR TITLE
Track C: Stage4 NNF wrappers + Stage3 unfold fix

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
@@ -62,7 +62,9 @@ theorem stage3_exists_params_one_le_forall_exists_natAbs_apSumOffset_gt_witness_
   rcases out.out2.forall_exists_discOffset_gt'_witness_pos (f := f) B with ⟨n, hn, hdisc⟩
   refine ⟨n, hn, ?_⟩
   -- `discOffset` is definitionally `Int.natAbs (apSumOffset ...)`.
-  simpa [discOffset] using hdisc
+  -- Avoid `simp` here (it can hit recursion limits); unfold the definition directly.
+  unfold discOffset at hdisc
+  exact hdisc
 
 /-- Consumer-facing shortcut: Stage 3 yields the discrepancy witness form
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage4Proof.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage4Proof.lean
@@ -25,6 +25,33 @@ theorem unboundedDiscOffset (out : Stage4Output f) :
     UnboundedDiscOffset f out.out2.d out.out2.m := by
   simpa using (out.out2.unboundedDiscOffset (f := f))
 
+/-- Negation-normal-form packaging of Stage-4 offset unboundedness:
+`¬ ∃ B, ∀ n, discOffset f out.out2.d out.out2.m n ≤ B`.
+
+This is a thin wrapper around the equivalence
+`unboundedDiscOffset_iff_not_exists_forall_discOffset_le`.
+-/
+theorem not_exists_forall_discOffset_le (out : Stage4Output f) :
+    ¬ ∃ B : ℕ, ∀ n : ℕ, discOffset f out.out2.d out.out2.m n ≤ B := by
+  have hunb : UnboundedDiscOffset f out.out2.d out.out2.m := out.unboundedDiscOffset (f := f)
+  exact
+    (unboundedDiscOffset_iff_not_exists_forall_discOffset_le (f := f)
+          (d := out.out2.d) (m := out.out2.m)).1
+      hunb
+
+/-- Negation-normal-form packaging of Stage-4 offset unboundedness at the raw nucleus level:
+`¬ ∃ B, ∀ n, Int.natAbs (apSumOffset f out.out2.d out.out2.m n) ≤ B`.
+
+This is `not_exists_forall_discOffset_le` rewritten by unfolding `discOffset`.
+-/
+theorem not_exists_forall_natAbs_apSumOffset_le (out : Stage4Output f) :
+    ¬ ∃ B : ℕ, ∀ n : ℕ, Int.natAbs (apSumOffset f out.out2.d out.out2.m n) ≤ B := by
+  have hunb : UnboundedDiscOffset f out.out2.d out.out2.m := out.unboundedDiscOffset (f := f)
+  exact
+    (UnboundedDiscOffset.iff_not_exists_forall_natAbs_apSumOffset_le (f := f)
+          (d := out.out2.d) (m := out.out2.m)).1
+      hunb
+
 /-- Existential packaging: Stage 4 yields concrete Stage-2 parameters `d, m` (with `1 ≤ d`) such
 that the bundled offset discrepancy family `discOffset f d m` is unbounded.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Stage3EntryCore: replace simp-based unfolding of discOffset with a direct unfold to avoid max recursion depth failures.
- Stage4Proof: add Stage4Output negation-normal-form wrappers ruling out boundedness of discOffset and apSumOffset at the carried Stage2 parameters.
