### PR TITLE
Track C: stabilize discOffset rewrites

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/Tao2015.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/Tao2015.lean
@@ -311,9 +311,11 @@ sum.
 theorem discOffset_eq_natAbs_sum_Icc (f : ℕ → ℤ) (d m n : ℕ) :
     discOffset f d m n =
       Int.natAbs ((Finset.Icc (m + 1) (m + n)).sum (fun i => f (i * d))) := by
-  -- `discOffset` is definitionally `Int.natAbs (apSumOffset ...)`.
-  unfold discOffset
-  exact natAbs_apSumOffset_eq_natAbs_sum_Icc (f := f) (d := d) (m := m) (n := n)
+  calc
+    discOffset f d m n = Int.natAbs (apSumOffset f d m n) :=
+      discOffset_eq_natAbs_apSumOffset (f := f) (d := d) (m := m) (n := n)
+    _ = Int.natAbs ((Finset.Icc (m + 1) (m + n)).sum (fun i => f (i * d))) :=
+      natAbs_apSumOffset_eq_natAbs_sum_Icc (f := f) (d := d) (m := m) (n := n)
 
 namespace UnboundedDiscOffset
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
@@ -58,12 +58,11 @@ theorem stage3_exists_params_one_le_forall_exists_natAbs_apSumOffset_gt_witness_
   let out := stage3Out (f := f) (hf := hf)
   refine ⟨out.out2.d, out.out2.m, out.out2.one_le_d (f := f), ?_⟩
   intro B
-  -- Use the proved Stage-2 core wrapper, then unfold `discOffset`.
+  -- Use the proved Stage-2 core wrapper, then rewrite `discOffset` to the bundled nucleus form.
   rcases out.out2.forall_exists_discOffset_gt'_witness_pos (f := f) B with ⟨n, hn, hdisc⟩
   refine ⟨n, hn, ?_⟩
-  -- `discOffset` is definitionally `Int.natAbs (apSumOffset ...)`.
-  -- Avoid `simp` here (it can hit recursion limits); unfold the definition directly.
-  unfold discOffset at hdisc
+  -- Avoid `simp` here (it can hit recursion limits); use the definitional lemma instead.
+  rw [discOffset_eq_natAbs_apSumOffset] at hdisc
   exact hdisc
 
 /-- Consumer-facing shortcut: Stage 3 yields the discrepancy witness form


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Stage 3 entry core: rewrite discOffset to Int.natAbs (apSumOffset ...) using the definitional lemma, avoiding simp recursion.
- Tao2015: express discOffset_eq_natAbs_sum_Icc as a calc chain via discOffset_eq_natAbs_apSumOffset (no unfolding).
