### PR TITLE
Track B: discOffsetUpTo max-attainment wrapper regression

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -247,6 +247,18 @@ example : discOffsetUpTo f d m n ≤ discOffsetUpTo f d m (n + 1) := by
   simpa using (discOffsetUpTo_le_succ (f := f) (d := d) (m := m) (N := n))
 
 /-!
+### NEW (Track B): Max-attainment wrapper for `discOffsetUpTo`
+
+Compile-only regression test checking the witness-extraction lemma can be used without
+unfolding `discOffsetUpTo`.
+-/
+
+example (f : ℕ → ℤ) (d m N : ℕ) :
+    ∃ n ≤ N, discOffset f d m n = discOffsetUpTo f d m N := by
+  -- This is the packaged witness-extraction lemma.
+  simpa using (exists_discOffset_eq_discOffsetUpTo (f := f) (d := d) (m := m) (N := N))
+
+/-!
 Periodic (non-constant) sanity check: the alternating sign sequence has period 2.
 
 When the step `d` is even, the sampled indices are all even, so the sequence restricts to the

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -1079,7 +1079,7 @@ Definition of done:
 
 #### Auto-generated backlog (needs triage)
 
-- [ ] Max-attainment wrapper for `discOffsetUpTo`: prove an `∃ n ≤ N` witness lemma saying the `sup`/`max` in `discOffsetUpTo f d m N` is attained by some concrete interval length `n`, packaged so later proofs can `obtain ⟨n, hn, hmax⟩` without unfolding.
+- [x] Max-attainment wrapper for `discOffsetUpTo`: prove an `∃ n ≤ N` witness lemma saying the `sup`/`max` in `discOffsetUpTo f d m N` is attained by some concrete interval length `n`, packaged so later proofs can `obtain ⟨n, hn, hmax⟩` without unfolding. (Implemented as `exists_discOffset_eq_discOffsetUpTo` in `MoltResearch/Discrepancy/Basic.lean`; compile-only regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
 - [ ] Start-shift vs sequence-shift coherence at the max level: a lemma relating
   `discOffsetUpTo f d (m+k) N` to `discOffsetUpTo (fun t => f (t + k*d)) d m N` (repo-preferred `shift_add` normal form), so “advance the start” is one `rw`.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Max-attainment wrapper for `discOffsetUpTo`

This PR marks the checklist item as completed (the witness-extraction lemma already exists as
`exists_discOffset_eq_discOffsetUpTo` in `MoltResearch/Discrepancy/Basic.lean`) and adds a small
compile-only regression example under `import MoltResearch.Discrepancy` (`NormalFormExamples.lean`)
showing how to extract the witness without unfolding `discOffsetUpTo`.
