### PR TITLE
Discrepancy: discOffsetUpTo start-shift coherence

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -34,6 +34,9 @@ The goal is to pair verified artifacts with learning scaffolding.
   - `discOffsetUpTo f d m 0 = 0`
   - `discOffsetUpTo f d 0 N = discUpTo f d N`
   - step-one shift: `discOffsetUpTo f 1 m N = discUpTo (fun k => f (k + m)) 1 N`
+- **API note (start-shift vs sequence-shift, max-level):** if you want to “advance the start” without pushing arithmetic through the `Finset.sup` definition, rewrite using
+  `discOffsetUpTo_add_start`:
+  `discOffsetUpTo f d (m + k) N = discOffsetUpTo (fun t => f (t + k*d)) d m N`.
 - **API note (degenerate length for `apSupport`):** when writing support-form hypotheses (agreement on `apSupport d m n`), the base case `n = 0` should reduce immediately. Use the simp lemma `apSupport_zero` to rewrite `apSupport d m 0` to `∅`.
 - **API note (`apSupport` bookkeeping helpers):** for common “no-op” shifts/dilations, the stable surface provides simp lemmas
   `apSupport_add_left_zero` and `apSupport_mul_right_one` so `simp` can discharge trivial `m+0` / `d*1` noise without unfolding.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -817,6 +817,22 @@ lemma discOffsetUpTo_succ (f : ℕ → ℤ) (d m N : ℕ) :
   -- Then `Finset.sup_insert` computes the new supremum as a `max`.
   simpa [Finset.range_add_one, max_comm, max_left_comm, max_assoc]
 
+/-- Start-shift vs sequence-shift coherence at max level.
+
+Normal form: rewriting a start advance `m ↦ m + k` is equivalent to shifting the underlying
+sequence by `k*d`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — “Start-shift vs sequence-shift coherence
+at the max level”.
+-/
+lemma discOffsetUpTo_add_start (f : ℕ → ℤ) (d m k N : ℕ) :
+    discOffsetUpTo f d (m + k) N = discOffsetUpTo (fun t => f (t + k * d)) d m N := by
+  classical
+  unfold discOffsetUpTo
+  -- Pointwise, `discOffset` is definitionally `Int.natAbs (apSumOffset ...)` and
+  -- `apSumOffset_map_add_mul` performs the start/sequence shift rewrite.
+  simp [discOffset, apSumOffset_map_add_mul, Nat.add_assoc, Nat.add_left_comm, Nat.add_comm]
+
 /-- Any particular `disc f d n` with `n ≤ N` is bounded by `discUpTo f d N`.
 
 Checklist item: Problems/erdos_discrepancy.md (Track B) — “Max discrepancy up to N” API.

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -82,6 +82,12 @@ example :
       discOffset (fun t => f (t + (n₁ + n₂) * d)) d m n := by
   simp
 
+example :
+    discOffsetUpTo f d (m + (n₁ + n₂)) n =
+      discOffsetUpTo (fun t => f (t + (n₁ + n₂) * d)) d m n := by
+  simpa using
+    (discOffsetUpTo_add_start (f := f) (d := d) (m := m) (k := n₁ + n₂) (N := n))
+
 /-!
 ### NEW (Track B): support-level congruence for `apSumOffset`/`discOffset`
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Start-shift vs sequence-shift coherence at the max level

Adds `discOffsetUpTo_add_start`:
- `discOffsetUpTo f d (m + k) N = discOffsetUpTo (fun t => f (t + k*d)) d m N`

Also adds a stable-surface regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.

CI:
- `make ci`
