### PR TITLE
Discrepancy: discOffsetUpTo start-shift coherence

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -647,6 +647,12 @@ example :
       max (discOffsetUpTo f d m n) (discOffset f d m (n + 1)) := by
   simpa using (discOffsetUpTo_succ (f := f) (d := d) (m := m) (N := n))
 
+-- Regression (Track B / start-shift vs sequence-shift coherence at max level): advancing the start
+-- index is equivalent to shifting the underlying sequence.
+example :
+    discOffsetUpTo f d (m + k) n = discOffsetUpTo (fun t => f (t + k * d)) d m n := by
+  simpa using (discOffsetUpTo_add_start (f := f) (d := d) (m := m) (k := k) (N := n))
+
 -- Regression (Track B / paper-endpoint normalization for `discOffsetUpTo`): rewrite into a `sup`
 -- of paper-interval expressions with the repo's preferred endpoints.
 example :

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -1081,8 +1081,9 @@ Definition of done:
 
 - [x] Max-attainment wrapper for `discOffsetUpTo`: prove an `∃ n ≤ N` witness lemma saying the `sup`/`max` in `discOffsetUpTo f d m N` is attained by some concrete interval length `n`, packaged so later proofs can `obtain ⟨n, hn, hmax⟩` without unfolding. (Implemented as `exists_discOffset_eq_discOffsetUpTo` in `MoltResearch/Discrepancy/Basic.lean`; compile-only regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
-- [ ] Start-shift vs sequence-shift coherence at the max level: a lemma relating
+- [x] Start-shift vs sequence-shift coherence at the max level: a lemma relating
   `discOffsetUpTo f d (m+k) N` to `discOffsetUpTo (fun t => f (t + k*d)) d m N` (repo-preferred `shift_add` normal form), so “advance the start” is one `rw`.
+  (Implemented as `discOffsetUpTo_add_start` in `MoltResearch/Discrepancy/Basic.lean`, with stable-surface regression in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
 - [ ] `discOffsetUpTo` tail concatenation inequality: a max-level analogue of `discOffset_add_le` but with start shifts, e.g.
   `discOffsetUpTo f d m (N+K) ≤ discOffsetUpTo f d m N + discOffsetUpTo f d (m+N) K`, packaged with a statement that matches the later Tao2015 step bookkeeping (avoid manual `Nat` algebra).


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Start-shift vs sequence-shift coherence at the max level

Implements the Track B item by adding a stable-surface regression example for `discOffsetUpTo_add_start`, and marks the checklist entry complete.

- Lemma: `discOffsetUpTo_add_start` (`MoltResearch/Discrepancy/Basic.lean`)
- Regression: `MoltResearch/Discrepancy/NormalFormExamples.lean`

CI: `make ci`