### PR TITLE
Discrepancy: discOffsetUpTo tail concatenation wrapper

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -24,6 +24,10 @@ The goal is to pair verified artifacts with learning scaffolding.
 - **Common pitfalls:** jumping into advanced lemmas before reducing to canonical definitions.
 - **API note (triangle vs reverse triangle):** for concatenation, `discOffset_add_le` is the forward triangle inequality. The reverse-triangle companions are `discOffset_left_le_add` / `discOffset_right_le_add`, proved by rewriting `S(n₁) = S(n₁+n₂) - S'(n₂)` and applying `Int.natAbs_sub_le`.
 - **API note:** `discOffsetUpTo` is monotone in the cutoff. Use `discOffsetUpTo_mono` for an arbitrary `N ≤ N'`, or the convenience wrapper `discOffsetUpTo_le_add` for the common “extend by `K`” case `N ≤ N+K`.
+- **API note (tail concatenation, max-level):** for later Tao2015 bookkeeping, prefer the wrapper
+  `discOffsetUpTo_tail_concat_le`:
+  `discOffsetUpTo f d m (N+K) ≤ discOffsetUpTo f d m N + discOffsetUpTo f d (m+N) K`.
+  It is just a stable-name wrapper around `discOffsetUpTo_add_le_add_discOffsetUpTo`, but avoids downstream proofs having to remember that name.
 - **API note (Lipschitz step):** for sign sequences, the one-step cutoff bound is `discOffsetUpTo_succ_le_add_one`:
   `discOffsetUpTo f d m (N+1) ≤ discOffsetUpTo f d m N + 1`. The reverse direction (monotonicity) is `discOffsetUpTo_le_succ`.
 - **API note (bounding a fixed tail):** to bound a particular `discOffset f d m n` by the max cutoff at the *same* `n`, use `discOffset_le_discOffsetUpTo_self` (it’s just the `N = n` specialization, so you don’t have to write `le_rfl`).

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -3427,6 +3427,20 @@ lemma discOffsetUpTo_add_le_add_discOffsetUpTo {f : ℕ → ℤ} (d m N K : ℕ)
     simpa [Nat.add_assoc] using hNt
 
 
+/-- Tail concatenation inequality for `discOffsetUpTo` (bookkeeping-friendly wrapper).
+
+This is a max-level analogue of `discOffset_add_le`, expressed so later arguments can split an
+initial segment of length `N` from a tail segment of length `K` without manual `Nat` algebra.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) —
+`discOffsetUpTo` tail concatenation inequality.
+-/
+lemma discOffsetUpTo_tail_concat_le {f : ℕ → ℤ} (d m N K : ℕ) :
+    discOffsetUpTo f d m (N + K) ≤ discOffsetUpTo f d m N + discOffsetUpTo f d (m + N) K := by
+  simpa using
+    (discOffsetUpTo_add_le_add_discOffsetUpTo (f := f) (d := d) (m := m) (N := N) (K := K))
+
+
 /-- Triangle inequality API for splitting a homogeneous AP sum by length. -/
 lemma natAbs_apSum_add_length_le (f : ℕ → ℤ) (d n₁ n₂ : ℕ) :
     Int.natAbs (apSum f d (n₁ + n₂)) ≤

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -697,6 +697,12 @@ example :
   simpa using
     (discOffsetUpTo_add_le_add_discOffsetUpTo (f := f) (d := d) (m := m) (N := n₁) (K := n₂))
 
+-- Same regression, but via the bookkeeping-friendly wrapper name.
+example :
+    discOffsetUpTo f d m (n₁ + n₂) ≤ discOffsetUpTo f d m n₁ + discOffsetUpTo f d (m + n₁) n₂ := by
+  simpa using
+    (discOffsetUpTo_tail_concat_le (f := f) (d := d) (m := m) (N := n₁) (K := n₂))
+
 -- Regression (Track B / “max discrepancy up to N” API, residue-friendly witness):
 example (q r : ℕ)
     (hne : ((Finset.range (n + 1)).filter (fun t => t ≡ r [MOD q])).Nonempty) :

--- a/MoltResearch/Discrepancy/SurfaceAudit.lean
+++ b/MoltResearch/Discrepancy/SurfaceAudit.lean
@@ -204,6 +204,8 @@ section
   #check discOffsetUpTo_zero
   #check discOffsetUpTo_zero_start
   #check discOffsetUpTo_one_shift
+  #check discOffsetUpTo_add_le_add_discOffsetUpTo
+  #check discOffsetUpTo_tail_concat_le
 
   example : discOffsetUpTo f d m 0 = 0 := by
     simp

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -1085,8 +1085,10 @@ Definition of done:
   `discOffsetUpTo f d (m+k) N` to `discOffsetUpTo (fun t => f (t + k*d)) d m N` (repo-preferred `shift_add` normal form), so “advance the start” is one `rw`.
   (Implemented as `discOffsetUpTo_add_start` in `MoltResearch/Discrepancy/Basic.lean`, with stable-surface regression in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
-- [ ] `discOffsetUpTo` tail concatenation inequality: a max-level analogue of `discOffset_add_le` but with start shifts, e.g.
+- [x] `discOffsetUpTo` tail concatenation inequality: a max-level analogue of `discOffset_add_le` but with start shifts, e.g.
   `discOffsetUpTo f d m (N+K) ≤ discOffsetUpTo f d m N + discOffsetUpTo f d (m+N) K`, packaged with a statement that matches the later Tao2015 step bookkeeping (avoid manual `Nat` algebra).
+  (Implemented as `discOffsetUpTo_tail_concat_le` (wrapper around `discOffsetUpTo_add_le_add_discOffsetUpTo`) in
+  `MoltResearch/Discrepancy/Basic.lean`, with stable-surface regression in `MoltResearch/Discrepancy/NormalFormExamples.lean` and audit coverage in `MoltResearch/Discrepancy/SurfaceAudit.lean`.)
 
 - [ ] GCD/step normalization helper: add a lemma suite that normalizes hypotheses to `Nat.coprime d m` (or `gcd d m = 1`) by factoring out `g := Nat.gcd d m` and rewriting the corresponding `apSumOffset`/`discOffset` terms, so later stages can assume coprimality “for free”.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `discOffsetUpTo` tail concatenation inequality: a max-level analogue of `discOffset_add_le` but with start shifts

Summary:
- Add `discOffsetUpTo_tail_concat_le` as a bookkeeping-friendly wrapper around the existing concatenation inequality.
- Extend stable-surface regression examples and SurfaceAudit coverage for the new name.
- Mark the corresponding backlog item as completed.

Tests:
- `make ci`
