### PR TITLE
Track C: discAlong = discOffset bridge

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/Tao2015.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/Tao2015.lean
@@ -935,6 +935,16 @@ theorem discrepancy_eq_discOffset_via_contract (out : ReductionOutput f) (n : �
   -- Now normalize discrepancy of a shift by `m*d`.
   simp [hgfun, discrepancy_shift_mul_simp (f := f) (m := out.m) (d := out.d) (n := n)]
 
+/-- Consumer-facing rewrite: the stable wrapper `discAlong` for the reduced sequence equals the
+bundled offset discrepancy wrapper for the original sequence.
+
+This is a tiny packaging lemma around `discrepancy_eq_discOffset_via_contract`.
+-/
+theorem discAlong_eq_discOffset (out : ReductionOutput f) (n : ℕ) :
+    discAlong out.g out.d n = discOffset f out.d out.m n := by
+  simpa [discAlong_eq_discrepancy] using
+    out.discrepancy_eq_discOffset_via_contract (f := f) (n := n)
+
 /-- Convenience: pointwise discrepancy bounds for the reduced sequence are exactly pointwise bounds
 on the bundled offset family. -/
 theorem discrepancy_le_iff_discOffset_le (out : ReductionOutput f) (n B : ℕ) :


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a small packaging lemma ReductionOutput.discAlong_eq_discOffset.
- This lets consumers rewrite discAlong out.g out.d n directly into the bundled discOffset f out.d out.m n form.
