### PR TITLE
Discrepancy: package HasDiscrepancyAtLeast monotone-in-C API

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -34,6 +34,9 @@ The goal is to pair verified artifacts with learning scaffolding.
 - **API note (max recursion):** when you need to peel the last case off a cutoff, rewrite `discOffsetUpTo f d m (N+1)` using `discOffsetUpTo_succ` to get a clean `max (discOffsetUpTo … N) (discOffset … (N+1))` normal form.
 - **API note (step positivity):** when extracting unboundedness witnesses, prefer the `Nat.succ` normal forms (`HasDiscrepancyAtLeast.exists_witness_succ(_pos)` and the affine analogue) so you can work with a concrete positive step without carrying a separate `d ≥ 1` side condition.
   The corner case `d = 0` has `simp` normal forms too, but those are now behind `import MoltResearch.Discrepancy.Deprecated` to keep the stable surface focused on the `d ≥ 1` workflow.
+- **API note (monotone-in-`C`):** `HasDiscrepancyAtLeast f C` is **antitone** in `C` (the witness inequality is `> C`).
+  Use `HasDiscrepancyAtLeast.mono` to *lower* the bound, and the contrapositive lemma
+  `HasDiscrepancyAtLeast.not_mono` to *raise* bounds under negation (useful for boundedness normal forms).
 - **API note (degenerate parameters for `UpTo`):** in downstream goals, you often want to normalize away “spurious” degenerate parameters without unfolding the finitary `Finset.sup` definition. The stable surface exports simp lemmas for:
   - `discOffsetUpTo f d m 0 = 0`
   - `discOffsetUpTo f d 0 N = discUpTo f d N`

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -2331,11 +2331,27 @@ def HasDiscrepancyAtLeast (f : ℕ → ℤ) (C : ℕ) : Prop :=
     -- Rewrite the goal to match `hgt`.
     simpa [hnatAbs] using hgt
 
-/-- Monotonicity of `HasDiscrepancyAtLeast` in the bound. -/
+/-- Monotonicity of `HasDiscrepancyAtLeast` in the bound.
+
+⚠️ Note the direction: `HasDiscrepancyAtLeast f C` is **easier** to satisfy for smaller `C`
+(because the witness inequality is `> C`). So the predicate is antitone in `C`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — `HasDiscrepancyAtLeast` monotone-in-`C`
+API (avoid unfolding definitions in quantifier manipulations).
+-/
 lemma HasDiscrepancyAtLeast.mono {f : ℕ → ℤ} {C₁ C₂ : ℕ}
     (h : HasDiscrepancyAtLeast f C₂) (hC : C₁ ≤ C₂) : HasDiscrepancyAtLeast f C₁ := by
   rcases h with ⟨d, n, hd, hn⟩
   exact ⟨d, n, hd, lt_of_le_of_lt hC hn⟩
+
+/-- Contrapositive monotonicity: if you cannot beat a smaller bound, you cannot beat a larger one.
+
+This is the logically convenient “negated” form used when normalizing boundedness hypotheses.
+-/
+lemma HasDiscrepancyAtLeast.not_mono {f : ℕ → ℤ} {C₁ C₂ : ℕ}
+    (h : ¬ HasDiscrepancyAtLeast f C₁) (hC : C₁ ≤ C₂) : ¬ HasDiscrepancyAtLeast f C₂ := by
+  intro h₂
+  exact h (HasDiscrepancyAtLeast.mono (f := f) (C₁ := C₁) (C₂ := C₂) h₂ hC)
 
 /-- Decrease the bound by one. -/
 lemma HasDiscrepancyAtLeast.of_succ {f : ℕ → ℤ} {C : ℕ}

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -37,6 +37,21 @@ example : (HasAffineDiscrepancyAtLeast f C ↔ Nonempty (AffineDiscrepancyWitnes
   simpa using (HasAffineDiscrepancyAtLeast.iff_nonempty_witnessGeOne (f := f) (C := C))
 
 /-!
+### NEW (Track B): `HasDiscrepancyAtLeast` monotone-in-`C` API
+
+Compile-only regression: we can move bounds around (including under negation) without unfolding
+`HasDiscrepancyAtLeast`.
+-/
+
+variable (C' : ℕ)
+
+example (h : HasDiscrepancyAtLeast f C') (hC : C ≤ C') : HasDiscrepancyAtLeast f C := by
+  simpa using (HasDiscrepancyAtLeast.mono (f := f) (C₁ := C) (C₂ := C') h hC)
+
+example (h : ¬ HasDiscrepancyAtLeast f C) (hC : C ≤ C') : ¬ HasDiscrepancyAtLeast f C' := by
+  simpa using (HasDiscrepancyAtLeast.not_mono (f := f) (C₁ := C) (C₂ := C') h hC)
+
+/-!
 ### NEW (Track B): constant-sequence sanity checks (`apSum`/`discOffset`)
 
 These are explicit computed examples that should remain one-line `simp`/`simpa` proofs under the


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `HasDiscrepancyAtLeast` monotone-in-C API: package lemmas like

Summary:
- Document that `HasDiscrepancyAtLeast f C` is antitone in `C` (since the witness inequality is `> C`).
- Add a negated/contrapositive monotonicity lemma (`HasDiscrepancyAtLeast.not_mono`) for boundedness normal forms.
- Add stable-surface compile-only regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean`.

CI:
- `make ci`
