### PR TITLE
Track C: Stage2 offset-nucleus witness wrapper

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
@@ -112,6 +112,19 @@ theorem forall_exists_discOffset_gt'_witness_pos (out : Stage2Output f) :
     (Tao2015.UnboundedDiscOffset.forall_exists_discOffset_gt'_witness_pos
       (f := f) (d := out.d) (m := out.m) hunb)
 
+/-- Positive-length witness form: Stage 2 yields arbitrarily large bundled offset nuclei
+`Int.natAbs (apSumOffset f out.d out.m n)`, with witnesses `n > 0`.
+
+This is a thin wrapper around
+`Tao2015.UnboundedDiscOffset.forall_exists_natAbs_apSumOffset_gt_witness_pos`.
+-/
+theorem forall_exists_natAbs_apSumOffset_gt_witness_pos (out : Stage2Output f) :
+    ∀ B : ℕ, ∃ n : ℕ, n > 0 ∧ Int.natAbs (apSumOffset f out.d out.m n) > B := by
+  have hunb : UnboundedDiscOffset f out.d out.m := out.unboundedDiscOffset (f := f)
+  simpa using
+    (Tao2015.UnboundedDiscOffset.forall_exists_natAbs_apSumOffset_gt_witness_pos
+      (f := f) (d := out.d) (m := out.m) hunb)
+
 /-- Stage 2 implies there is no uniform bound on the bundled offset discrepancy family
 `discOffset f out.d out.m`.
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
@@ -58,12 +58,7 @@ theorem stage3_exists_params_one_le_forall_exists_natAbs_apSumOffset_gt_witness_
   let out := stage3Out (f := f) (hf := hf)
   refine ⟨out.out2.d, out.out2.m, out.out2.one_le_d (f := f), ?_⟩
   intro B
-  -- Use the proved Stage-2 core wrapper, then rewrite `discOffset` to the bundled nucleus form.
-  rcases out.out2.forall_exists_discOffset_gt'_witness_pos (f := f) B with ⟨n, hn, hdisc⟩
-  refine ⟨n, hn, ?_⟩
-  -- Avoid `simp` here (it can hit recursion limits); use the definitional lemma instead.
-  rw [discOffset_eq_natAbs_apSumOffset] at hdisc
-  exact hdisc
+  simpa using out.out2.forall_exists_natAbs_apSumOffset_gt_witness_pos (f := f) B
 
 /-- Consumer-facing shortcut: Stage 3 yields the discrepancy witness form
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Added a small Stage2Output wrapper lemma giving positive-length witnesses for unbounded bundled offset nuclei.
- Refactored the Stage 3 entry-core witness lemma to use this wrapper (removing a manual discOffset rewrite).
