### PR TITLE
Track B: HasDiscrepancyAtLeast mono-in-C checklist

### DIFF
--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -1097,8 +1097,9 @@ Definition of done:
   surface `import MoltResearch.Discrepancy`; compile-only regression examples live in
   `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
-- [ ] `HasDiscrepancyAtLeast` monotone-in-C API: package lemmas like
-  `HasDiscrepancyAtLeast f C → C ≤ C' → HasDiscrepancyAtLeast f C'` and the contrapositive/negated boundedness versions, so later quantifier manipulations don’t unfold definitions.
+- [x] `HasDiscrepancyAtLeast` monotone-in-`C` API: package lemmas like
+  `HasDiscrepancyAtLeast f C' → C ≤ C' → HasDiscrepancyAtLeast f C` and the contrapositive/negated forms, so later quantifier manipulations don’t unfold definitions.
+  (Implemented as `HasDiscrepancyAtLeast.mono` / `.not_mono` in `MoltResearch/Discrepancy/Basic.lean`, with stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
 - [ ] Bridge lemma: `BoundedDiscrepancyAlong` ↔ max-level bound: connect an along-`d` boundedness predicate to a uniform bound on `discOffsetUpTo` (or whichever max object is the nucleus), so later “boundedness” steps can be rewritten into a single inequality about `discOffsetUpTo`.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `HasDiscrepancyAtLeast` monotone-in-`C` API

This checks off the Track B checklist item by updating the card text to match the actual (antitone-in-`C`) monotonicity direction, and linking to the already-implemented lemmas:
- `HasDiscrepancyAtLeast.mono` / `HasDiscrepancyAtLeast.not_mono` in `MoltResearch/Discrepancy/Basic.lean`
- stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean`
