### PR TITLE
Discrepancy: bridge BoundedDiscrepancyAlong ↔ discOffsetUpTo bound

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -31,6 +31,10 @@ The goal is to pair verified artifacts with learning scaffolding.
 - **API note (Lipschitz step):** for sign sequences, the one-step cutoff bound is `discOffsetUpTo_succ_le_add_one`:
   `discOffsetUpTo f d m (N+1) ≤ discOffsetUpTo f d m N + 1`. The reverse direction (monotonicity) is `discOffsetUpTo_le_succ`.
 - **API note (bounding a fixed tail):** to bound a particular `discOffset f d m n` by the max cutoff at the *same* `n`, use `discOffset_le_discOffsetUpTo_self` (it’s just the `N = n` specialization, so you don’t have to write `le_rfl`).
+- **API note (boundedness ↔ max-level nucleus, finite length):** for the finite-length “along `d`” predicate,
+  `BoundedDiscrepancyAlong f d len B` is equivalent to the single inequality
+  `discOffsetUpTo f d 0 len ≤ B` via `boundedDiscrepancyAlong_iff_discOffsetUpTo_le`.
+  This is the bridge that lets later steps rewrite boundedness hypotheses into a one-line max bound.
 - **API note (max recursion):** when you need to peel the last case off a cutoff, rewrite `discOffsetUpTo f d m (N+1)` using `discOffsetUpTo_succ` to get a clean `max (discOffsetUpTo … N) (discOffset … (N+1))` normal form.
 - **API note (step positivity):** when extracting unboundedness witnesses, prefer the `Nat.succ` normal forms (`HasDiscrepancyAtLeast.exists_witness_succ(_pos)` and the affine analogue) so you can work with a concrete positive step without carrying a separate `d ≥ 1` side condition.
   The corner case `d = 0` has `simp` normal forms too, but those are now behind `import MoltResearch.Discrepancy.Deprecated` to keep the stable surface focused on the `d ≥ 1` workflow.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -1366,6 +1366,30 @@ theorem boundedDiscrepancyAlong_iff_forall_le_discAlong_le (f : ℕ → ℤ) (d 
     BoundedDiscrepancyAlong f d len B ↔ ∀ n : ℕ, n ≤ len → discAlong f d n ≤ B :=
   Iff.rfl
 
+/-- Bridge lemma: finite-length along-`d` boundedness is equivalent to a bound on the finitary
+maximum `discOffsetUpTo f d 0 len`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) —
+Bridge lemma: `BoundedDiscrepancyAlong` ↔ max-level bound.
+-/
+theorem boundedDiscrepancyAlong_iff_discOffsetUpTo_le (f : ℕ → ℤ) (d len B : ℕ) :
+    BoundedDiscrepancyAlong f d len B ↔ discOffsetUpTo f d 0 len ≤ B := by
+  constructor
+  · intro h
+    classical
+    unfold discOffsetUpTo
+    refine Finset.sup_le ?_
+    intro n hn
+    have hn' : n ≤ len := Nat.le_of_lt_succ (Finset.mem_range.mp hn)
+    -- Rewrite `discAlong` to the nucleus wrapper `discOffset`.
+    simpa [discAlong] using h n hn'
+  · intro h
+    intro n hn
+    have hle : discOffset f d 0 n ≤ discOffsetUpTo f d 0 len :=
+      discOffset_le_discOffsetUpTo (f := f) (d := d) (m := 0) (n := n) (N := len) hn
+    have : discOffset f d 0 n ≤ B := le_trans hle h
+    simpa [discAlong] using this
+
 namespace BoundedDiscrepancyAlong
 
 /-- Monotonicity in the bound parameter `B`. -/

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -1418,6 +1418,13 @@ example (len B : ℕ) :
   simpa using
     (boundedDiscrepancyAlong_iff_forall_le_discAlong_le (f := f) (d := d) (len := len) (B := B))
 
+-- Regression (Track B / boundedness ↔ max-level nucleus):
+-- `BoundedDiscrepancyAlong` is equivalent to a single inequality about `discOffsetUpTo`.
+example (len B : ℕ) :
+    BoundedDiscrepancyAlong f d len B ↔ discOffsetUpTo f d 0 len ≤ B := by
+  simpa using
+    (boundedDiscrepancyAlong_iff_discOffsetUpTo_le (f := f) (d := d) (len := len) (B := B))
+
 -- Regression (Track B / boundedness under sequence translation): step-one wrapper.
 example (a len B : ℕ) :
     BoundedDiscrepancyAlong (fun k => f (k + a)) 1 len B ↔


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Bridge lemma: `BoundedDiscrepancyAlong` ↔ max-level bound: connect an along-`d` boundedness predicate to a uniform bound on `discOffsetUpTo` (or whichever max object is the nucleus), so later “boundedness” steps can be rewritten into a single inequality about `discOffsetUpTo`.

Summary:
- Add `boundedDiscrepancyAlong_iff_discOffsetUpTo_le`, a lightweight bridge between finite-length along-`d` boundedness and the nucleus max wrapper `discOffsetUpTo`.
- Add a stable-surface regression example under `import MoltResearch.Discrepancy` (NormalFormExamples) to ensure the rewrite stays one-line.
- Update `Learning/EDUCATIONAL_OVERLAYS.md` (canonical-module overlay hygiene) with a brief note on the new bridge.

CI:
- `make ci`