### PR TITLE
EDP: residue max inequality checklist + regression

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -4334,6 +4334,17 @@ example (f : ℕ → ℤ) (d m N C : ℕ) :
     (discOffsetUpTo_le_iff_forall_Icc_endpoints (f := f) (d := d) (m := m) (N := N) (C := C))
 
 /-!
+## Residue-class max-level bound regression tests
+-/
+
+example (f : ℕ → ℤ) (d m q N : ℕ) (hq : q > 0) :
+    discOffsetUpTo_blockLen_mul_succ f d m q N ≤
+      (Finset.range q).sum (fun r => discOffsetUpTo_residueTerm f d m q r N) := by
+  simpa using
+    (discOffsetUpTo_blockLen_mul_succ_le_sum_range_residueTerm (f := f) (d := d) (m := m) (q := q)
+      (N := N) hq)
+
+/-!
 ## `disc` wrapper regression tests
 
 These ensure the homogeneous wrapper `disc` stays coherent with the offset wrapper `discOffset`.

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -1104,7 +1104,8 @@ Definition of done:
 - [x] Bridge lemma: `BoundedDiscrepancyAlong` ↔ max-level bound: connect an along-`d` boundedness predicate to a uniform bound on `discOffsetUpTo` (or whichever max object is the nucleus), so later “boundedness” steps can be rewritten into a single inequality about `discOffsetUpTo`.
   (Implemented as `boundedDiscrepancyAlong_iff_discOffsetUpTo_le` in `MoltResearch/Discrepancy/Basic.lean`, with stable-surface regression in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
-- [ ] “Residue max” inequality (clean API surface): after residue-class splitting, add a packaged lemma bounding a single `discOffsetUpTo` by a sum (or max) of residue-class `discOffsetUpTo` objects with consistent parameter ordering (no ad-hoc reindexing in downstream proofs).
+- [x] “Residue max” inequality (clean API surface): after residue-class splitting, add a packaged lemma bounding a single `discOffsetUpTo` by a sum (or max) of residue-class `discOffsetUpTo` objects with consistent parameter ordering (no ad-hoc reindexing in downstream proofs).
+  (Implemented as `discOffsetUpTo_blockLen_mul_succ_le_sum_range_residueTerm` (plus `discOffsetUpTo_residueTerm`) in `MoltResearch/Discrepancy/Residue.lean`, with stable-surface regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
 - [ ] Stable-surface audit for max-level APIs: extend `MoltResearch/Discrepancy/SurfaceAudit.lean` with `#check`/`example` coverage for the max-level normal forms (`discOffsetUpTo_*` lemmas), ensuring the intended rewrite pipeline stays one-line usable.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: “Residue max” inequality (clean API surface)

What changed:
- Mark the Track B checklist item as done (it was already implemented in `MoltResearch/Discrepancy/Residue.lean`).
- Add a stable-surface regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean` exercising:
  - `discOffsetUpTo_blockLen_mul_succ_le_sum_range_residueTerm`
  - `discOffsetUpTo_residueTerm`

CI:
- `make ci`