### PR TITLE
Track C: Stage2 discOffset witness-positivity lemma

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
@@ -112,6 +112,17 @@ theorem forall_exists_discOffset_gt'_witness_pos (out : Stage2Output f) :
     (Tao2015.UnboundedDiscOffset.forall_exists_discOffset_gt'_witness_pos
       (f := f) (d := out.d) (m := out.m) hunb)
 
+/-- Positive-length witness form: Stage 2 yields arbitrarily large bundled offset discrepancies
+`discOffset f out.d out.m n`, with witnesses `n > 0`.
+
+This is `forall_exists_discOffset_gt'_witness_pos` rewritten using `gt_iff_lt`.
+-/
+theorem forall_exists_discOffset_gt_witness_pos (out : Stage2Output f) :
+    ∀ B : ℕ, ∃ n : ℕ, n > 0 ∧ B < discOffset f out.d out.m n := by
+  intro B
+  rcases out.forall_exists_discOffset_gt'_witness_pos (f := f) B with ⟨n, hnpos, hn⟩
+  exact ⟨n, hnpos, (gt_iff_lt).1 hn⟩
+
 /-- Positive-length witness form: Stage 2 yields arbitrarily large bundled offset nuclei
 `Int.natAbs (apSumOffset f out.d out.m n)`, with witnesses `n > 0`.
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2CoreExtras.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2CoreExtras.lean
@@ -55,16 +55,8 @@ theorem discOffset_eq_natAbs_apSumFrom_start (out : Stage2Output f) (n : ℕ) :
   -- Rewrite the bundled offset nucleus `apSumOffset` to the affine-tail nucleus `apSumFrom`.
   rw [← out.apSumFrom_start_eq_apSumOffset (f := f) n]
 
-/-- Positive-length witness form: Stage 2 yields arbitrarily large bundled offset discrepancies
-`discOffset f out.d out.m n`, with witnesses `n > 0`.
-
-We keep this lemma in `TrackCStage2CoreExtras.lean` so downstream stages can access it without
-importing the large Stage-2 output-lemma library `TrackCStage2Output.lean`.
--/
-theorem forall_exists_discOffset_gt_witness_pos (out : Stage2Output f) :
-    ∀ B : ℕ, ∃ n : ℕ, n > 0 ∧ B < discOffset f out.d out.m n := by
-  have hunb : UnboundedDiscOffset f out.d out.m := out.unboundedDiscOffset (f := f)
-  exact UnboundedDiscOffset.forall_exists_discOffset_gt_witness_pos (hunb := hunb)
+-- Note: `Stage2Output.forall_exists_discOffset_gt_witness_pos` now lives in
+-- `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Core`.
 
 /-- The affine-tail start index `out.start` is a multiple of the reduced step size `out.d`. -/
 theorem d_dvd_start (out : Stage2Output f) : out.d ∣ out.start := by


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add Stage2Output.forall_exists_discOffset_gt_witness_pos to the Stage-2 core API.
- Prove it by rewriting the existing inequality-direction witness-positivity lemma via gt_iff_lt.
- Remove the duplicate definition from TrackCStage2CoreExtras (leave a short note).
