### PR TITLE
Discrepancy: extend SurfaceAudit for discOffsetUpTo normal forms

### DIFF
--- a/MoltResearch/Discrepancy/SurfaceAudit.lean
+++ b/MoltResearch/Discrepancy/SurfaceAudit.lean
@@ -225,6 +225,17 @@ section
   #check discOffsetUpTo_le_add
   #check discOffsetUpTo_le_succ
 
+  -- One-line usage audit: the max-recursion normal form.
+  example :
+      discOffsetUpTo f d m (n + 1) =
+        max (discOffsetUpTo f d m n) (discOffset f d m (n + 1)) := by
+    simpa using (discOffsetUpTo_succ (f := f) (d := d) (m := m) (N := n))
+
+  -- One-line usage audit: advancing the start parameter is just a sequence shift by `k*d`.
+  example (k : ℕ) :
+      discOffsetUpTo f d (m + k) n = discOffsetUpTo (fun t => f (t + k * d)) d m n := by
+    simpa using (discOffsetUpTo_add_start (f := f) (d := d) (m := m) (k := k) (N := n))
+
   -- “Max over lengths/endpoints” normal-form expansions.
   #check discOffsetUpTo_eq_sup_Icc_lengths
   #check discOffsetUpTo_eq_sup_range_Icc


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Stable-surface audit for max-level APIs: extend `MoltResearch/Discrepancy/SurfaceAudit.lean` with `#check`/`example` coverage for the max-level normal forms (`discOffsetUpTo_*` lemmas), ensuring the intended rewrite pipeline stays one-line usable.

What changed
- Added compile-only `example`s exercising `discOffsetUpTo_succ` (max-recursion normal form) and `discOffsetUpTo_add_start` (start-shift vs sequence-shift coherence) under `import MoltResearch.Discrepancy`.

Notes
- No new lemmas introduced; this is surface audit / regression coverage only.
