### PR TITLE
Track C: promote d≥1 discrepancy witness

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Entry.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Entry.lean
@@ -153,23 +153,8 @@ Most of these are intentionally kept out of the hard-gate core module.
 -- The discrepancy witness normal form `stage3_forall_exists_discrepancy_gt` lives in
 -- `TrackCStage3EntryCore.lean` (hard-gate surface).
 
-/-- Variant of `stage3_forall_exists_discrepancy_gt_witness_pos` with the step-size condition
-written as `d ≥ 1`.
-
-Normal form:
-`∀ C, ∃ d n, d ≥ 1 ∧ n > 0 ∧ discrepancy f d n > C`.
--/
-theorem stage3_forall_exists_discrepancy_gt_d_ge_one_witness_pos (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    ∀ C : ℕ, ∃ d n : ℕ, d ≥ 1 ∧ n > 0 ∧ discrepancy f d n > C := by
-  intro C
-  rcases stage3_forall_exists_d_ge_one_witness_pos (f := f) (hf := hf) C with
-    ⟨d, n, hd, hn, hw⟩
-  refine ⟨d, n, hd, hn, ?_⟩
-  -- `discrepancy f d n` is definitionally `Int.natAbs (apSum f d n)`.
-  change Int.natAbs (apSum f d n) > C
-  exact hw
-
--- (moved to `Conjectures.C0002_erdos_discrepancy.src.TrackCStage3EntryCore`)
+-- The lemma `stage3_forall_exists_discrepancy_gt_d_ge_one_witness_pos` is provided by
+-- `Conjectures.C0002_erdos_discrepancy.src.TrackCStage3EntryCore`.
 
 -- Note: `stage3_unboundedDiscOffset` and `stage3_not_exists_boundedDiscOffset` live in
 -- `Conjectures.C0002_erdos_discrepancy.src.TrackCStage3EntryMinimal`.

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
@@ -87,6 +87,22 @@ theorem stage3_forall_exists_d_ge_one_witness_pos (f : ℕ → ℤ) (hf : IsSign
     (forall_hasDiscrepancyAtLeast_iff_forall_exists_d_ge_one_witness_pos f).1
       (stage3_forall_hasDiscrepancyAtLeast (f := f) (hf := hf))
 
+/-- Discrepancy-form variant of `stage3_forall_exists_d_ge_one_witness_pos`.
+
+Normal form:
+`∀ C, ∃ d n, d ≥ 1 ∧ n > 0 ∧ discrepancy f d n > C`.
+-/
+theorem stage3_forall_exists_discrepancy_gt_d_ge_one_witness_pos (f : ℕ → ℤ)
+    (hf : IsSignSequence f) :
+    ∀ C : ℕ, ∃ d n : ℕ, d ≥ 1 ∧ n > 0 ∧ discrepancy f d n > C := by
+  intro C
+  rcases stage3_forall_exists_d_ge_one_witness_pos (f := f) (hf := hf) C with
+    ⟨d, n, hd, hn, hw⟩
+  refine ⟨d, n, hd, hn, ?_⟩
+  -- `discrepancy f d n` is definitionally `Int.natAbs (apSum f d n)`.
+  change Int.natAbs (apSum f d n) > C
+  exact hw
+
 /-- Variant of `stage3_forall_exists_d_ge_one_witness_pos` with strict positivity for `d`.
 
 Normal form:
@@ -150,7 +166,7 @@ theorem stage3_forall_exists_discrepancy_gt_witness_pos (f : ℕ → ℤ) (hf : 
   change Int.natAbs (apSum f d n) > C
   exact hw
 
--- (moved to `Conjectures.C0002_erdos_discrepancy.src.TrackCStage3Entry`)
+-- (also available via `Conjectures.C0002_erdos_discrepancy.src.TrackCStage3Entry`)
 
 end Tao2015
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Moved the d ≥ 1 discrepancy witness lemma stage3_forall_exists_discrepancy_gt_d_ge_one_witness_pos into TrackCStage3EntryCore so it is available from the hard-gate core surface.
- Left TrackCStage3Entry as the lightweight convenience layer, with a brief note pointing to the core definition.
