### PR TITLE
Discrepancy: extend SurfaceAudit for discOffsetUpTo Lipschitz lemmas

### DIFF
--- a/MoltResearch/Discrepancy/SurfaceAudit.lean
+++ b/MoltResearch/Discrepancy/SurfaceAudit.lean
@@ -277,6 +277,20 @@ section
   #check discOffsetUpTo_add_le_add_discOffsetUpTo
   #check discOffsetUpTo_tail_concat_le
 
+  -- Boundedness-transfer / Lipschitz-by-1 inequalities (max-level `UpTo` API).
+  #check discOffsetUpTo_add_le
+  #check discOffsetUpTo_succ_le_add_one
+
+  -- One-line usage audit: these should be usable directly under `import MoltResearch.Discrepancy`.
+  example {f : ℕ → ℤ} (hf : IsSignSequence f) (d m N K : ℕ) :
+      discOffsetUpTo f d m (N + K) ≤ discOffsetUpTo f d m N + K := by
+    simpa using (discOffsetUpTo_add_le (f := f) (hf := hf) (d := d) (m := m) (N := N) (K := K))
+
+  example {f : ℕ → ℤ} (hf : IsSignSequence f) (d m N : ℕ) :
+      discOffsetUpTo f d m (N + 1) ≤ discOffsetUpTo f d m N + 1 := by
+    simpa using
+      (discOffsetUpTo_succ_le_add_one (f := f) (hf := hf) (d := d) (m := m) (N := N))
+
   -- (moved above as a one-line usage audit via `discOffsetUpTo_one_shift`)
 
   /-!


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Stable-surface audit for max-level APIs: extend `MoltResearch/Discrepancy/SurfaceAudit.lean` with `#check`/`example` coverage for the max-level normal forms (`discOffsetUpTo_*` lemmas), ensuring the intended rewrite pipeline stays one-line usable.

What changed:
- Extended `MoltResearch/Discrepancy/SurfaceAudit.lean` with `#check` + one-line `example` coverage for:
  - `discOffsetUpTo_add_le`
  - `discOffsetUpTo_succ_le_add_one`

Why:
- These boundedness-transfer/Lipschitz inequalities are high-leverage max-level APIs for Track B.
- The surface audit ensures they remain exported and usable directly under `import MoltResearch.Discrepancy`.
