### PR TITLE
Discrepancy: extend SurfaceAudit for residue-class UpTo API

### DIFF
--- a/MoltResearch/Discrepancy/SurfaceAudit.lean
+++ b/MoltResearch/Discrepancy/SurfaceAudit.lean
@@ -227,6 +227,10 @@ section
   #check discOffsetUpTo_le_succ
   #check exists_discOffset_eq_discOffsetUpTo
 
+  -- Residue-class `UpTo` wrappers (max-level APIs): ensure the packaged definitions remain exported.
+  #check discOffsetUpTo_modEq
+  #check exists_discOffset_eq_discOffsetUpTo_modEq
+
   -- One-line usage audit: any particular `discOffset` is bounded by the corresponding `UpTo`.
   example (N : ℕ) (hn : n ≤ N) : discOffset f d m n ≤ discOffsetUpTo f d m N := by
     simpa using (discOffset_le_discOffsetUpTo (f := f) (d := d) (m := m) (n := n) (N := N) hn)
@@ -245,6 +249,13 @@ section
   -- One-line usage audit: the `sup` in `discOffsetUpTo` is attained by some `t ≤ N`.
   example : ∃ t ≤ n, discOffset f d m t = discOffsetUpTo f d m n := by
     simpa using (exists_discOffset_eq_discOffsetUpTo (f := f) (d := d) (m := m) (N := n))
+
+  -- One-line usage audit: residue-class `UpTo` extraction wrappers.
+  example (q r : ℕ)
+      (hne : ((Finset.range (n + 1)).filter (fun t => t ≡ r [MOD q])).Nonempty) :
+      ∃ t ≤ n, t ≡ r [MOD q] ∧ discOffset f d m t = discOffsetUpTo_modEq f d m n q r := by
+    simpa using
+      (exists_discOffset_eq_discOffsetUpTo_modEq (f := f) (d := d) (m := m) (N := n) (q := q) (r := r) hne)
 
   -- Additional one-line usage audits for other max-level `discOffsetUpTo_*` lemmas.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Stable-surface audit for max-level APIs: extend `MoltResearch/Discrepancy/SurfaceAudit.lean` with `#check`/`example` coverage for the max-level normal forms (`discOffsetUpTo_*` lemmas), ensuring the intended rewrite pipeline stays one-line usable.

What changed
- Extended `MoltResearch/Discrepancy/SurfaceAudit.lean` with stable-surface `#check`s and a one-line `example` for the residue-class max-level API (`discOffsetUpTo_modEq` / `exists_discOffset_eq_discOffsetUpTo_modEq`).

Notes
- No new lemmas were introduced; this is compile-time API surface regression coverage only.
- `make ci` passes locally.
