### PR TITLE
SurfaceAudit: one-line examples for discOffsetUpTo concatenation

### DIFF
--- a/MoltResearch/Discrepancy/SurfaceAudit.lean
+++ b/MoltResearch/Discrepancy/SurfaceAudit.lean
@@ -288,6 +288,17 @@ section
   #check discOffsetUpTo_add_le_add_discOffsetUpTo
   #check discOffsetUpTo_tail_concat_le
 
+  -- One-line usage audit: tail concatenation inequality.
+  example (N K : ℕ) :
+      discOffsetUpTo f d m (N + K) ≤ discOffsetUpTo f d m N + discOffsetUpTo f d (m + N) K := by
+    simpa using
+      (discOffsetUpTo_add_le_add_discOffsetUpTo (f := f) (d := d) (m := m) (N := N) (K := K))
+
+  -- One-line usage audit: same inequality under the shorter `*_tail_concat_le` name.
+  example (N K : ℕ) :
+      discOffsetUpTo f d m (N + K) ≤ discOffsetUpTo f d m N + discOffsetUpTo f d (m + N) K := by
+    simpa using (discOffsetUpTo_tail_concat_le (f := f) (d := d) (m := m) (N := N) (K := K))
+
   -- Boundedness-transfer / Lipschitz-by-1 inequalities (max-level `UpTo` API).
   #check discOffsetUpTo_add_le
   #check discOffsetUpTo_succ_le_add_one


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Stable-surface audit for max-level APIs: extend `MoltResearch/Discrepancy/SurfaceAudit.lean` with `#check`/`example` coverage for the max-level normal forms (`discOffsetUpTo_*` lemmas), ensuring the intended rewrite pipeline stays one-line usable.

Summary:
- Add one-line `example` regressions exercising the `discOffsetUpTo_add_le_add_discOffsetUpTo` and `discOffsetUpTo_tail_concat_le` inequalities.
- Keeps max-level `discOffsetUpTo_*` normal-form pipeline “one import, one line” usable.

CI:
- `make ci`
