### PR TITLE
Track C: Stage 2 discOffset witness lemma

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
@@ -112,6 +112,16 @@ theorem forall_exists_discOffset_gt'_witness_pos (out : Stage2Output f) :
     (Tao2015.UnboundedDiscOffset.forall_exists_discOffset_gt'_witness_pos
       (f := f) (d := out.d) (m := out.m) hunb)
 
+/-- Witness form: Stage 2 yields arbitrarily large bundled offset discrepancies `discOffset ... > B`.
+
+This is just `forall_exists_discOffset_gt'_witness_pos` with the positivity side condition dropped.
+-/
+theorem forall_exists_discOffset_gt' (out : Stage2Output f) :
+    ∀ B : ℕ, ∃ n : ℕ, discOffset f out.d out.m n > B := by
+  intro B
+  rcases out.forall_exists_discOffset_gt'_witness_pos (f := f) B with ⟨n, _hnpos, hn⟩
+  exact ⟨n, hn⟩
+
 /-- Positive-length witness form: Stage 2 yields arbitrarily large bundled offset discrepancies
 `discOffset f out.d out.m n`, with witnesses `n > 0`.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add Stage2Output.forall_exists_discOffset_gt' to the core Stage 2 API (drops the n > 0 side condition).
- Derive it from the existing witness-positivity lemma so Stage 3 consumers can avoid importing the larger Stage 2 convenience layer.
- Conjectures-only change; no edits to MoltResearch/ or Solutions/.
