### PR TITLE
Discrepancy: audit max-level residue/block-length APIs

### DIFF
--- a/MoltResearch/Discrepancy/SurfaceAudit.lean
+++ b/MoltResearch/Discrepancy/SurfaceAudit.lean
@@ -227,6 +227,20 @@ section
   #check discOffsetUpTo_le_succ
   #check exists_discOffset_eq_discOffsetUpTo
 
+  -- Max-level block-length / residue APIs (stable surface)
+  #check discOffsetUpTo_blockLen_mul_succ
+  #check discOffsetUpTo_blockLen_mul_succ_le_sum_range_sup_natAbs
+  #check discOffsetUpTo_residueTerm
+  #check discOffsetUpTo_blockLen_mul_succ_le_sum_range_residueTerm
+
+  -- One-line usage audit: max-level residue-class block-length bound (clean API surface).
+  example (q N : ℕ) (hq : q > 0) :
+      discOffsetUpTo_blockLen_mul_succ f d m q N ≤
+        (Finset.range q).sum (fun r => discOffsetUpTo_residueTerm f d m q r N) := by
+    simpa using
+      (discOffsetUpTo_blockLen_mul_succ_le_sum_range_residueTerm
+        (f := f) (d := d) (m := m) (q := q) (N := N) hq)
+
   -- Residue-class `UpTo` wrappers (max-level APIs): ensure the packaged definitions remain exported.
   #check discOffsetUpTo_modEq
   #check exists_discOffset_eq_discOffsetUpTo_modEq


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Stable-surface audit for max-level APIs: extend `MoltResearch/Discrepancy/SurfaceAudit.lean` with `#check`/`example` coverage for the max-level normal forms (`discOffsetUpTo_*` lemmas), ensuring the intended rewrite pipeline stays one-line usable.

Summary:
- Extend `MoltResearch/Discrepancy/SurfaceAudit.lean` to audit the exported max-level residue/block-length APIs:
  - `discOffsetUpTo_blockLen_mul_succ`
  - `discOffsetUpTo_blockLen_mul_succ_le_sum_range_sup_natAbs`
  - `discOffsetUpTo_residueTerm`
  - `discOffsetUpTo_blockLen_mul_succ_le_sum_range_residueTerm`
- Add a one-line `example` using `simpa` to validate direct usability under `import MoltResearch.Discrepancy`.

CI:
- `make ci`
