### PR TITLE
Track C: fix duplicate declarations

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
@@ -137,15 +137,9 @@ theorem forall_exists_discOffset_gt (out : Stage2Output f) :
   simpa using
     ((out.out1.unboundedDiscrepancyAlong_iff_forall_exists_discOffset_gt (f := f)).1 out.unbounded)
 
-/-- Inequality-direction variant of `forall_exists_discOffset_gt`, written as `discOffset ... > B`.
+-- Note: `Stage2Output.forall_exists_discOffset_gt'` is part of the Stage-2 core API (see
+-- `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Core`).
 
-Many consumers prefer this normal form so they can `simp [gt_iff_lt]` at the call site.
--/
-theorem forall_exists_discOffset_gt' (out : Stage2Output f) :
-    ∀ B : ℕ, ∃ n : ℕ, discOffset f out.d out.m n > B := by
-  -- Delegate to the Stage-1 transport lemma (inequality-direction normal form).
-  simpa using
-    ((out.out1.unboundedDiscrepancyAlong_iff_forall_exists_discOffset_gt' (f := f)).1 out.unbounded)
 
 /-!
 Positive-length witness form of `forall_exists_discOffset_gt'` is part of the Stage-2 core API:
@@ -394,16 +388,9 @@ theorem forall_exists_natAbs_apSumOffset_gt' (out : Stage2Output f) :
     (Tao2015.UnboundedDiscOffset.iff_forall_exists_natAbs_apSumOffset_gt' (f := f)
       (d := out.d) (m := out.m)).1 hunb
 
-/-- Positive-length witness form of `forall_exists_natAbs_apSumOffset_gt'`.
+-- Note: `Stage2Output.forall_exists_natAbs_apSumOffset_gt_witness_pos` is part of the Stage-2
+-- core API (see `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Core`).
 
-The witness length `n` cannot be `0`, since `apSumOffset ... 0 = 0`.
--/
-theorem forall_exists_natAbs_apSumOffset_gt_witness_pos (out : Stage2Output f) :
-    ∀ B : ℕ, ∃ n : ℕ, n > 0 ∧ Int.natAbs (apSumOffset f out.d out.m n) > B := by
-  have hunb : UnboundedDiscOffset f out.d out.m := out.unboundedDiscOffset (f := f)
-  simpa [Stage2Output.d, Stage2Output.m] using
-    (Tao2015.UnboundedDiscOffset.forall_exists_natAbs_apSumOffset_gt_witness_pos
-      (f := f) (d := out.d) (m := out.m) hunb)
 
 /-- Paper-notation normal form of `forall_exists_natAbs_apSumOffset_gt'`.
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Proof.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Proof.lean
@@ -49,17 +49,10 @@ We intentionally do not redeclare it here (this file imports `TrackCStage3Entry`
 Note: the convenience lemma `stage3_d_ne_zero` lives in `TrackCStage3Entry.lean`.
 -/
 
-/-- Consumer-facing shortcut: Stage 3 yields unbounded discrepancy along the reduced sequence,
-stated using the verified core predicate `MoltResearch.UnboundedDiscrepancyAlong`.
+-- Note: `stage3_unboundedDiscrepancyAlong_core` is already provided by
+-- `Conjectures.C0002_erdos_discrepancy.src.TrackCStage3EntryMinimal` (imported via
+-- `Conjectures.C0002_erdos_discrepancy.src.TrackCStage3Entry`).
 
-This is a thin wrapper around the proved Stage-3 boundary lemma
-`Stage3Output.unboundedDiscrepancyAlong_core`.
--/
-theorem stage3_unboundedDiscrepancyAlong_core (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    MoltResearch.UnboundedDiscrepancyAlong (stage3_g (f := f) (hf := hf))
-      (stage3_d (f := f) (hf := hf)) := by
-  simpa [stage3_g, stage3_d] using
-    (Stage3Output.unboundedDiscrepancyAlong_core (f := f) (stage3Out (f := f) (hf := hf)))
 
 /-
 Note: `stage3_unboundedDiscOffset` is defined in `TrackCStage3Entry.lean` so hard-gate consumers
@@ -232,23 +225,10 @@ theorem stage3_exists_params_one_le_forall_exists_natAbs_apSumOffset_gt (f : ℕ
     (Stage3Output.exists_params_one_le_forall_exists_natAbs_apSumOffset_gt (f := f)
       (stage3Out (f := f) (hf := hf)))
 
-/-- Consumer-facing shortcut: Stage 3 yields concrete parameters `d, m` with `1 ≤ d` such that the
-bundled offset nucleus `apSumOffset f d m n` takes arbitrarily large absolute values, with a
-positive-length witness `n > 0`.
+-- Note: `stage3_exists_params_one_le_forall_exists_natAbs_apSumOffset_gt_witness_pos` is already
+-- provided by `Conjectures.C0002_erdos_discrepancy.src.TrackCStage3EntryCore` (imported via
+-- `Conjectures.C0002_erdos_discrepancy.src.TrackCStage3Entry`).
 
-Normal form:
-`∃ d m, 1 ≤ d ∧ ∀ B, ∃ n, n > 0 ∧ Int.natAbs (apSumOffset f d m n) > B`.
-
-This is a thin wrapper around the Stage-3 boundary API lemma
-`Stage3Output.exists_params_one_le_forall_exists_natAbs_apSumOffset_gt_witness_pos`.
--/
-theorem stage3_exists_params_one_le_forall_exists_natAbs_apSumOffset_gt_witness_pos (f : ℕ → ℤ)
-    (hf : IsSignSequence f) :
-    ∃ d m : ℕ, 1 ≤ d ∧
-      (∀ B : ℕ, ∃ n : ℕ, n > 0 ∧ Int.natAbs (apSumOffset f d m n) > B) := by
-  simpa using
-    (Stage3Output.exists_params_one_le_forall_exists_natAbs_apSumOffset_gt_witness_pos (f := f)
-      (stage3Out (f := f) (hf := hf)))
 
 end Tao2015
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Fix Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean failing to compile by removing two duplicate lemma redeclarations (now treated as part of the Stage-2 core API).
- Fix Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Proof.lean failing to compile by removing two duplicate theorem wrappers already provided by the Stage-3 hard-gate entry modules.
- Hard gate check: lake build Conjectures.C0002_erdos_discrepancy.src.ErdosDiscrepancy.
