### PR TITLE
Track C: Stage 3 hasDiscrepancyAtLeast

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
@@ -83,6 +83,13 @@ theorem forall_hasDiscrepancyAtLeast (out : Stage3Output f) :
   refine (forall_hasDiscrepancyAtLeast_iff_not_boundedDiscrepancy f).2 ?_
   exact out.notBounded (f := f)
 
+/-- Specialization of `forall_hasDiscrepancyAtLeast` at a fixed threshold `C`.
+
+This is a tiny convenience lemma: it avoids an extra application at the call site.
+-/
+theorem hasDiscrepancyAtLeast (out : Stage3Output f) (C : ℕ) : HasDiscrepancyAtLeast f C := by
+  exact (out.forall_hasDiscrepancyAtLeast (f := f)) C
+
 end Stage3Output
 
 /-!


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add Stage3Output.hasDiscrepancyAtLeast as a one-line specialization of Stage3Output.forall_hasDiscrepancyAtLeast.
- Keeps Stage 3 boundary API ergonomic while remaining Conjectures-only glue.
