### PR TITLE
Track C: discAlong normal form for HasDiscrepancyAtLeastAlong

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/Tao2015.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/Tao2015.lean
@@ -229,6 +229,19 @@ theorem hasDiscrepancyAtLeastAlong_iff_exists_discrepancy_gt' (g : ℕ → ℤ) 
   · rintro ⟨n, hn⟩
     exact ⟨n, hn⟩
 
+/-- Stable-wrapper normal form for `HasDiscrepancyAtLeastAlong`.
+
+Normal form:
+`∃ n, discAlong g d n > C`.
+
+This is `hasDiscrepancyAtLeastAlong_iff_exists_discrepancy_gt'` rewritten using
+`discAlong_eq_discrepancy`.
+-/
+theorem hasDiscrepancyAtLeastAlong_iff_exists_discAlong_gt' (g : ℕ → ℤ) (d C : ℕ) :
+    HasDiscrepancyAtLeastAlong g d C ↔ (∃ n : ℕ, discAlong g d n > C) := by
+  simpa [discAlong_eq_discrepancy] using
+    (hasDiscrepancyAtLeastAlong_iff_exists_discrepancy_gt' (g := g) (d := d) (C := C))
+
 /-- Nucleus normal form for `HasDiscrepancyAtLeastAlong`.
 
 Normal form:


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Added a stable-wrapper normal form lemma for HasDiscrepancyAtLeastAlong using discAlong.
- Keeps downstream Stage-2/Stage-3 statements phrased in terms of the stable wrapper rather than raw discrepancy.
