### PR TITLE
Track C: remove sorry mentions in docs

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/Tao2015.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/Tao2015.lean
@@ -4,7 +4,7 @@ import MoltResearch.Discrepancy.AffineTail
 /-!
 # Tao 2015: Erdős discrepancy theorem (Track C skeleton)
 
-This module is **Conjectures-only**: it may contain axiom stubs (and, if needed, `sorry`).
+This module is **Conjectures-only**: it may contain axiom stubs and temporary placeholders.
 
 At present, the only non-verified assumption is the Stage-2 axiom in
 `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Stub`.

--- a/Conjectures/C0002_erdos_discrepancy/src/Tao2015Extras.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/Tao2015Extras.lean
@@ -3,7 +3,7 @@ import Conjectures.C0002_erdos_discrepancy.src.Tao2015
 /-!
 # Tao 2015 (Track C): small interface extras
 
-This module is **Conjectures-only**: it may contain axiom stubs (and, if needed, `sorry`), but the intent here is to add tiny
+This module is **Conjectures-only**: it may contain axiom stubs and temporary placeholders, but the intent here is to add tiny
 helper lemmas that make the stage interfaces easier to consume.
 
 Nothing in this file should edit or depend on implementation details under `MoltResearch/`.

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
@@ -69,7 +69,7 @@ theorem not_exists_boundedDiscOffset (out : Stage3Output f) :
 /-- Deterministic Stage-3 completion: a Stage-2 output already contains enough information to
 contradict any global boundedness hypothesis.
 
-This is the main “stage boundary” lemma: it is *proved* (no `sorry`) and should remain stable.
+This is the main “stage boundary” lemma: it is proved (no placeholders) and should remain stable.
 -/
 def ofStage2Output (out2 : Tao2015.Stage2Output f) : Stage3Output f :=
   ⟨out2⟩


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Rephrased Track C Conjectures-only module headers to avoid the word sorry in doc text.
- This makes simple searches for actual sorry placeholders in Track C files signal-only.
