### PR TITLE
Track C: package Stage-3 params for bounded discOffset

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -144,6 +144,18 @@ theorem stage3_hasDiscrepancyAtLeast (f : ℕ → ℤ) (hf : IsSignSequence f) (
     HasDiscrepancyAtLeast f C := by
   exact (stage3_forall_hasDiscrepancyAtLeast (f := f) (hf := hf)) C
 
+/-- Existential packaging: Stage 3 yields concrete parameters `d, m` with `d > 0` such that there
+is no bound `B` with `BoundedDiscOffset f d m B`.
+
+This is the stable boundedness-negation normal form packaged with explicit parameters.
+-/
+theorem stage3_exists_params_not_exists_boundedDiscOffset (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    ∃ d m : ℕ, d > 0 ∧ ¬ ∃ B : ℕ, BoundedDiscOffset f d m B := by
+  refine ⟨(stage3Out (f := f) (hf := hf)).out2.d,
+    (stage3Out (f := f) (hf := hf)).out2.m,
+    (stage3Out (f := f) (hf := hf)).out2.hd, ?_⟩
+  simpa using (stage3_not_exists_boundedDiscOffset (f := f) (hf := hf))
+
 /-- Existential packaging: Stage 3 yields concrete parameters `d, m` with `d > 0` such that the
 bundled offset discrepancy family `discOffset f d m` is unbounded.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a Stage-3 convenience lemma packaging the deterministic parameters d, m with the normal-form statement that no bounded discOffset witness exists.
- This is Conjectures-only wiring on top of the existing Stage-3 entrypoint; no changes to MoltResearch/ or Solutions/.
