### PR TITLE
Track C: Stage-3 discOffset witness packaging

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
@@ -75,6 +75,23 @@ theorem stage3_exists_params_one_le_forall_exists_natAbs_apSumOffset_gt_witness_
   intro B
   simpa using out.out2.forall_exists_natAbs_apSumOffset_gt_witness_pos (f := f) B
 
+/-- Stage 3 yields concrete parameters `d, m` (with `1 ≤ d`) such that the bundled offset discrepancy
+family `discOffset f d m n` takes arbitrarily large values, with positive-length witnesses.
+
+Normal form:
+`∃ d m, 1 ≤ d ∧ ∀ B, ∃ n, n > 0 ∧ discOffset f d m n > B`.
+
+This is the most pipeline-friendly witness-family normal form for consuming the Stage-2 output
+without importing the larger Stage-2 convenience-lemma layer.
+-/
+theorem stage3_exists_params_one_le_forall_exists_discOffset_gt'_witness_pos (f : ℕ → ℤ)
+    (hf : IsSignSequence f) :
+    ∃ d m : ℕ, 1 ≤ d ∧ (∀ B : ℕ, ∃ n : ℕ, n > 0 ∧ discOffset f d m n > B) := by
+  let out := stage3Out (f := f) (hf := hf)
+  refine ⟨out.out2.d, out.out2.m, out.out2.one_le_d (f := f), ?_⟩
+  intro B
+  simpa using out.out2.forall_exists_discOffset_gt'_witness_pos (f := f) B
+
 /-- Consumer-facing shortcut: Stage 3 yields the discrepancy witness form
 
 `∀ C, ∃ d n, d > 0 ∧ discrepancy f d n > C`.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a Stage-3 entry-core lemma packaging discOffset witness families with positive-length witnesses
- Keeps the hard-gate minimal import surface unchanged; provides a pipeline-friendly normal form for downstream stages
