### PR TITLE
Track C: Stage 3 core unboundedness wrapper

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
@@ -58,6 +58,15 @@ theorem unboundedDiscOffset (out : Stage3Output f) :
     UnboundedDiscOffset f out.out2.d out.out2.m := by
   exact out.out2.unboundedDiscOffset (f := f)
 
+/-- Stage 3 output also exposes the Stage-2 fixed-step unboundedness witness, phrased using the
+verified core predicate `MoltResearch.UnboundedDiscrepancyAlong`.
+
+This is a thin wrapper around `Stage2Output.unboundedDiscrepancyAlong_core`.
+-/
+theorem unboundedDiscrepancyAlong_core (out : Stage3Output f) :
+    MoltResearch.UnboundedDiscrepancyAlong out.out1.g out.out1.d := by
+  simpa [Stage3Output.out1] using out.out2.unboundedDiscrepancyAlong_core (f := f)
+
 /-- Stage 3 output implies there is no bundled offset bound at the deterministic Stage-2 parameters.
 
 This is the stable boundedness-negation normal form of `unboundedDiscOffset`.

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -93,9 +93,7 @@ theorem stage3_unboundedDiscrepancyAlong_core (f : ℕ → ℤ) (hf : IsSignSequ
     MoltResearch.UnboundedDiscrepancyAlong
       (stage3Out (f := f) (hf := hf)).out1.g
       (stage3Out (f := f) (hf := hf)).out1.d := by
-  -- Delegate to the Stage-2 core bridge lemma, then unfold the Stage-3 convenience projection.
-  simpa [Stage3Output.out1, Stage2Output.g, Stage2Output.d] using
-    (stage3Out (f := f) (hf := hf)).out2.unboundedDiscrepancyAlong_core (f := f)
+  simpa using (stage3Out (f := f) (hf := hf)).unboundedDiscrepancyAlong_core
 
 /-- Track C pipeline witness: Stage 3 yields an unbounded bundled offset discrepancy family
 `discOffset f d m` at the deterministic Stage-2 parameters stored in `stage3Out`.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Added Stage3Output.unboundedDiscrepancyAlong_core as a thin wrapper exposing the Stage-2 core unboundedness witness along the reduced sequence.
- Simplified stage3_unboundedDiscrepancyAlong_core in TrackCStage3EntryMinimal to use the new wrapper and reduce simp boilerplate.
