### PR TITLE
Docs: update ROADMAP + Track C Stage-4 operational status

### DIFF
--- a/Problems/tao2015_pipeline.md
+++ b/Problems/tao2015_pipeline.md
@@ -68,8 +68,65 @@ Each checkbox should be doable in ~1 PR. Prefer **wiring-only** changes in stage
 
 ### Stage 0 — make the target explicit
 
-- [ ] Add a short “Stage interface signatures” section below listing the *canonical* downstream-facing lemmas (names + types) for Stage 2 and Stage 3.
+- [x] Add a short “Stage interface signatures” section below listing the *canonical* downstream-facing lemmas (names + types) for Stage 2–4.
 - [ ] Add 2–3 small `example` blocks (regression) that import the intended surfaces and compile (no proof search). Keep them stable.
+
+## Stage interface signatures (canonical; treat as frozen for consumers)
+
+This section is meant to be copy/paste-able for agents writing downstream stages.
+
+### Stage 2 (boundary record)
+
+Source: `Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean` (+ `...CoreExtras.lean`)
+
+Canonical consumer objects:
+- `Tao2015.Stage2Output f`
+
+Canonical consumer lemmas (representative; prefer using these instead of unfolding):
+- `Stage2Output.notBoundedOriginal : ¬ BoundedDiscrepancy f`
+- `Stage2Output.forall_hasDiscrepancyAtLeast : ∀ C, HasDiscrepancyAtLeast f C`
+- `Stage2Output.unboundedDiscOffset : UnboundedDiscOffset f out.d out.m`
+- `Stage2Output.not_exists_boundedDiscOffset : ¬ ∃ B, BoundedDiscOffset f out.d out.m B`
+- Witness-family normal forms (offset / affine-tail nucleus):
+  - `Stage2Output.forall_exists_natAbs_apSumOffset_gt_witness_pos : ∀ B, ∃ n, n > 0 ∧ natAbs (apSumOffset ...) > B`
+  - `Stage2Output.forall_exists_natAbs_apSumFrom_start_gt : ∀ B, ∃ n, natAbs (apSumFrom f out.start out.d n) > B`
+
+### Stage 3 (hard-gate consumer API)
+
+Minimal import surface for the hard-gate target:
+- `Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean`
+
+Core entry-point surface (witness forms + existential packaging):
+- `Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean`
+
+Canonical theorems (Stage 3):
+- `Tao2015.stage3_notBounded (f) (hf) : ¬ BoundedDiscrepancy f`
+- `Tao2015.stage3_forall_hasDiscrepancyAtLeast (f) (hf) : ∀ C, HasDiscrepancyAtLeast f C`
+
+Canonical “pipeline-friendly” packages (Stage 3 → ∃ d m …):
+- `stage3_exists_params_one_le_unboundedDiscOffset : ∃ d m, 1 ≤ d ∧ UnboundedDiscOffset f d m`
+- `stage3_exists_params_one_le_not_exists_boundedDiscOffset : ∃ d m, 1 ≤ d ∧ ¬ ∃ B, BoundedDiscOffset f d m B`
+
+Canonical witness normal forms (Stage 3):
+- `stage3_forall_exists_d_ge_one_witness_pos : ∀ C, ∃ d n, d ≥ 1 ∧ n > 0 ∧ natAbs (apSum f d n) > C`
+- `stage3_forall_exists_sum_Icc_d_ge_one_witness_pos : ∀ C, ∃ d n, d ≥ 1 ∧ n > 0 ∧ natAbs (∑ i∈Icc 1 n, f (i*d)) > C`
+
+### Stage 4 (boundary stub; first place to carry a real obligation)
+
+Source:
+- Core boundary: `Conjectures/C0002_erdos_discrepancy/src/TrackCStage4Core.lean`
+- Derived wrappers: `Conjectures/C0002_erdos_discrepancy/src/TrackCStage4Proof.lean`
+
+Canonical objects:
+- `Tao2015.Stage4Output f` (currently just carries `Stage3Output f` as `out3`)
+
+Canonical theorems (Stage 4):
+- `Tao2015.stage4_notBounded (f) (hf) : ¬ BoundedDiscrepancy f`
+- `Tao2015.stage4_forall_hasDiscrepancyAtLeast (f) (hf) : ∀ C, HasDiscrepancyAtLeast f C`
+- Stage‑4 offset-boundedness negation wrappers (for contradiction-style downstream stages):
+  - `Stage4Output.not_exists_boundedDiscOffset : ¬ ∃ B, BoundedDiscOffset f out.d out.m B`
+
+Rule of thumb: Stage 4 should *not* add new math content unless it is the single explicitly-chosen obligation we’re burning down.
 
 ### Stage 1 — ReductionOutput contract (Tao2015)
 
@@ -93,7 +150,7 @@ Each checkbox should be doable in ~1 PR. Prefer **wiring-only** changes in stage
 
 ### Stage N — next stage stub(s)
 
-- [ ] Add the next stage file stub (e.g. `TrackCStage4.lean`) that *only* imports the Stage 3 boundary and states the next interface theorem(s) as `theorem ... := by` with at most one `sorry` placeholder.
+- [x] Add the next stage file stub (`TrackCStage4Core.lean` + `TrackCStage4Proof.lean` + thin `TrackCStage4.lean`) that imports the Stage‑3 boundary and exposes the next interface theorem(s) as wiring.
 - [ ] Add a regression example showing Stage 4 can consume Stage 3 without unfolding.
 
 ## Notes for automation

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ That substrate is: Lean + CI + tiny PRs.
 This repo’s work is mostly organized into **tracks** on Problem Cards:
 
 - **Track B (substrate):** build and stabilize the `MoltResearch/Discrepancy` surface (normal forms, transport lemmas, and regression examples).
-- **Track C (pipeline):** wire up Tao2015/Erdős discrepancy **stage interfaces** (mostly under `Conjectures/`) so later proof stages can consume witnesses without unfolding.
+- **Track C (pipeline):** wire up Tao2015/Erdős discrepancy **stage interfaces** (mostly under `Conjectures/`) so later proof stages can consume witnesses without unfolding. Stage 4 now exists as a boundary stub (`TrackCStage4Core`/`TrackCStage4Proof`) and is the intended landing zone for the first *real* proof obligation.
 
 A good way to understand “where we are” is: can we move witnesses through the stage boundaries using only the stable surface + regression examples?
 
@@ -146,3 +146,11 @@ scripts/yolo_launch.sh
 - CI stays green on `main`.
 - The verified artifact set grows steadily.
 - Agents can import `MoltResearch/` and *actually reuse* prior work instead of re-deriving it.
+
+## Known ops blockers (automation)
+
+If automation is behaving strangely, check these first:
+
+- **Reviewer cron model allowlist:** the reviewer job is currently configured for `openai/gpt-5.4`, but this environment rejects it (“model not allowed”).
+- **Moltbook write access:** moltbook commenting can fail with `401 Unauthorized` if the API key is stale (expects `moltbook_...`).
+- **WhatsApp cron targets:** proactive sends must target an explicit WhatsApp identifier (E.164 like `+14085072539` or a group JID). “Sean” is not a resolvable target in cron.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,15 +28,17 @@ Success criteria:
 - increasing fraction of merges land in `MoltResearch/`
 - later tasks depend on earlier artifacts (real reuse)
 
-## Current milestone — Tao2015 pipeline map (Track C)
+## Current milestone — Tao2015 pipeline wiring + Stage 4 boundary (Track C)
 
-Goal: a clear stage-by-stage map for Tao2015 (Erdős discrepancy) so automation stays directed.
+Goal: keep automation pointed at a real Tao2015/Erdős discrepancy formalization by enforcing **stable stage boundaries**.
 
-Deliverable (docs-first): a short, explicit stage plan with:
-- stage inputs/outputs (types)
-- the key theorem each stage exports
-- the next missing link to the next stage
-- a small regression example that exercises the surface
+Operational truth (where we are now):
+- Stages 1–3 have stable consumer-facing “witness normal forms” (mostly via `ReductionOutput`/`Stage2Output`/`Stage3Output`).
+- **Stage 4 exists** as a boundary module (`TrackCStage4Core` + `TrackCStage4Proof`) that *carries* the Stage‑3 output forward and re-exports the key surface consequences.
+
+Next unlock (what would count as progress now):
+- Pick **one explicit Stage‑4 proof obligation** (a named lemma) and make it the *only* remaining nontrivial blocker for Track C.
+  Everything else should be wiring + regression examples.
 
 See: `Problems/tao2015_pipeline.md`.
 


### PR DESCRIPTION
Card: Problems/tao2015_pipeline.md\nTrack: C (docs)\n\n- Update ROADMAP to reflect that Stage 4 boundary exists and next step is choosing a single Stage-4 obligation.\n- Add canonical Stage interface signatures section (Stages 2–4) to tao2015_pipeline.md.\n- Add README ops blockers notes (reviewer model allowlist, Moltbook key, WhatsApp cron target).