### PR TITLE
Track C: trim redundant Stage-3 simp lemma

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -54,15 +54,6 @@ This lemma is tiny but useful for rewriting when shuttling statements between St
 We keep it in the hard-gate minimal module so `ErdosDiscrepancy.lean` can stay minimal.
 -/
 @[simp] theorem stage3Out_out1 (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    (stage3Out (f := f) (hf := hf)).out2.out1 = (stage2Out (f := f) (hf := hf)).out1 := by
-  rfl
-
-/-- The Stage-1 reduction output stored inside `stage3Out` can also be accessed through the
-convenience projection `Stage3Output.out1`.
-
-This lemma is a tiny wrapper around `stage3Out_out1`.
--/
-@[simp] theorem stage3Out_out1' (f : ℕ → ℤ) (hf : IsSignSequence f) :
     (stage3Out (f := f) (hf := hf)).out1 = (stage2Out (f := f) (hf := hf)).out1 := by
   rfl
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Simplified the Stage-3 minimal entrypoint API by removing a redundant simp lemma for Stage-1 output projections.
- Kept a single simp lemma stage3Out_out1 for rewriting Stage-1 reduction output across Stage 2 and Stage 3.
