### PR TITLE
Track C: fix Stage3 core name clashes

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Core.lean
@@ -28,13 +28,13 @@ consistent name at both boundaries.
 abbrev notBoundedOriginal (out : Stage3Output f) : ¬ BoundedDiscrepancy f :=
   out.notBounded
 
-/-- Specialization of `Stage3Output.forall_hasDiscrepancyAtLeast` at a fixed threshold `C`.
+/-!
+Note: `Stage3Output.hasDiscrepancyAtLeast` is already defined in
+`Conjectures.C0002_erdos_discrepancy.src.TrackCStage3`.
 
-This is a tiny convenience lemma, matching the Stage-2 API name
-`Stage2Output.hasDiscrepancyAtLeast`.
+We avoid re-declaring it here so that `TrackCStage3Core` can be imported alongside
+`TrackCStage3` without name clashes.
 -/
-theorem hasDiscrepancyAtLeast (out : Stage3Output f) (C : ℕ) : HasDiscrepancyAtLeast f C := by
-  exact (out.forall_hasDiscrepancyAtLeast (f := f)) C
 
 /-- Convenience projection: the reduced step size packaged in Stage 3.
 
@@ -81,16 +81,13 @@ theorem notBoundedReducedAlong (out : Stage3Output f) : ¬ BoundedDiscrepancyAlo
     (Tao2015.UnboundedDiscrepancyAlong.iff_not_boundedDiscrepancyAlong (g := out.g) (d := out.d)).1
       out.unboundedReducedAlong
 
-/-- Stage 3 yields unbounded fixed-step discrepancy for the reduced sequence, expressed using the
-verified core predicate `MoltResearch.UnboundedDiscrepancyAlong`.
+/-!
+Note: `Stage3Output.unboundedDiscrepancyAlong_core` is already defined in
+`Conjectures.C0002_erdos_discrepancy.src.TrackCStage3`.
 
-This is a small convenience wrapper around the Stage-2 bridge lemma
-`Stage2Output.unboundedDiscrepancyAlong_core`.
+This file focuses on additional projections (`d`, `g`, `m`, etc.) that are convenient for later
+stages, without re-declaring boundary lemmas.
 -/
-theorem unboundedDiscrepancyAlong_core (out : Stage3Output f) :
-    MoltResearch.UnboundedDiscrepancyAlong out.g out.d := by
-  simpa [Stage3Output.g, Stage3Output.d] using
-    (Stage2Output.unboundedDiscrepancyAlong_core (f := f) out.out2)
 
 /-- Convenience projection: the bundled offset parameter packaged in Stage 3. -/
 @[simp] abbrev m (out : Stage3Output f) : ℕ := out.out2.m

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Output.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Output.lean
@@ -277,6 +277,19 @@ theorem exists_params_forall_exists_natAbs_sum_Icc_offset_gt (out : Stage3Output
   intro B
   exact out.forall_exists_natAbs_sum_Icc_offset_gt (f := f) B
 
+/-- Existential packaging variant of `exists_params_forall_exists_natAbs_sum_Icc_offset_gt`
+with a positive-length witness `n > 0`.
+
+The witness length `n` cannot be `0`, since the interval `Icc (m+1) (m+n)` is empty when `n = 0`.
+-/
+theorem exists_params_forall_exists_natAbs_sum_Icc_offset_gt_witness_pos (out : Stage3Output f) :
+    ∃ d m : ℕ, d > 0 ∧
+      (∀ B : ℕ, ∃ n : ℕ, n > 0 ∧
+        Int.natAbs ((Finset.Icc (m + 1) (m + n)).sum (fun i => f (i * d))) > B) := by
+  refine ⟨out.d, out.m, out.hd, ?_⟩
+  intro B
+  simpa using out.forall_exists_natAbs_sum_Icc_offset_gt_witness_pos (f := f) B
+
 /-- Existential packaging: Stage 3 yields concrete parameters `d, m` with `1 ≤ d` such that the
 paper-notation offset sum witness `∑ i ∈ Icc (m+1) (m+n), f (i*d)` takes arbitrarily large absolute
 values.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Fix compilation failure in TrackCStage3Core by removing duplicate declarations that clashed with TrackCStage3.
- Add the missing Stage-3 paper-notation packaging lemma with a positive-length witness (exists_params_forall_exists_natAbs_sum_Icc_offset_gt_witness_pos).