### PR TITLE
Track C: Stage4 core unboundedness witness

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage4Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage4Core.lean
@@ -73,6 +73,15 @@ This is a tiny convenience lemma, matching the Stage-2/Stage-3 boundary API styl
 theorem hasDiscrepancyAtLeast (out : Stage4Output f) (C : ℕ) : HasDiscrepancyAtLeast f C := by
   exact (out.forall_hasDiscrepancyAtLeast (f := f)) C
 
+/-- Stage 4 output retains the Stage-3 fixed-step unboundedness witness for the reduced sequence,
+phrased using the verified core predicate `MoltResearch.UnboundedDiscrepancyAlong`.
+
+This is a thin wrapper around `Stage3Output.unboundedDiscrepancyAlong_core`.
+-/
+theorem unboundedDiscrepancyAlong_core (out : Stage4Output f) :
+    MoltResearch.UnboundedDiscrepancyAlong out.out1.g out.out1.d := by
+  simpa [Stage4Output.out1] using out.out3.unboundedDiscrepancyAlong_core (f := f)
+
 end Stage4Output
 
 /-- Stage 4 main constructor (stub).


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add Stage4Output.unboundedDiscrepancyAlong_core, a thin wrapper re-exporting the Stage-3 core unboundedness witness at the Stage-4 boundary.
- Keeps Stage-4 core API consistent with the Stage-3 boundary style, so downstream stages can consume Stage 4 without reaching back into out3.
