### PR TITLE
Discrepancy: Nat.succ monotonicity wrapper for discOffsetUpTo

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -24,6 +24,7 @@ The goal is to pair verified artifacts with learning scaffolding.
 - **Common pitfalls:** jumping into advanced lemmas before reducing to canonical definitions.
 - **API note (triangle vs reverse triangle):** for concatenation, `discOffset_add_le` is the forward triangle inequality. The reverse-triangle companions are `discOffset_left_le_add` / `discOffset_right_le_add`, proved by rewriting `S(n₁) = S(n₁+n₂) - S'(n₂)` and applying `Int.natAbs_sub_le`.
 - **API note:** `discOffsetUpTo` is monotone in the cutoff. Use `discOffsetUpTo_mono` for an arbitrary `N ≤ N'`, or the convenience wrapper `discOffsetUpTo_le_add` for the common “extend by `K`” case `N ≤ N+K`.
+  If your goal is stated with `Nat.succ N` instead of `N+1`, use the wrapper `discOffsetUpTo_le_succNat`.
 - **API note (tail concatenation, max-level):** for later Tao2015 bookkeeping, prefer the wrapper
   `discOffsetUpTo_tail_concat_le`:
   `discOffsetUpTo f d m (N+K) ≤ discOffsetUpTo f d m N + discOffsetUpTo f d (m+N) K`.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -926,12 +926,19 @@ lemma discOffsetUpTo_le_add (f : ℕ → ℤ) (d m N K : ℕ) :
 
 /-- Convenience: `discOffsetUpTo` is monotone under `N ↦ N+1`.
 
-Checklist item: Problems/erdos_discrepancy.md (Track B) — `discOffsetUpTo` Lipschitz-by-1 in `N`
-(reverse inequality direction).
+Checklist item: Problems/erdos_discrepancy.md (Track B) — `discOffsetUpTo` monotone in the cutoff.
 -/
 lemma discOffsetUpTo_le_succ (f : ℕ → ℤ) (d m N : ℕ) :
     discOffsetUpTo f d m N ≤ discOffsetUpTo f d m (N + 1) := by
   simpa using (discOffsetUpTo_le_add (f := f) (d := d) (m := m) (N := N) (K := 1))
+
+/-- Convenience: `discOffsetUpTo` is monotone under `N ↦ Nat.succ N`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — `discOffsetUpTo` monotone in the cutoff.
+-/
+lemma discOffsetUpTo_le_succNat (f : ℕ → ℤ) (d m N : ℕ) :
+    discOffsetUpTo f d m N ≤ discOffsetUpTo f d m (Nat.succ N) := by
+  simpa [Nat.succ_eq_add_one] using (discOffsetUpTo_le_succ (f := f) (d := d) (m := m) (N := N))
 
 /-- The maximum in `discOffsetUpTo` is attained by some `n ≤ N`.
 

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -281,6 +281,9 @@ example :
 example : discOffsetUpTo f d m n ≤ discOffsetUpTo f d m (n + 1) := by
   simpa using (discOffsetUpTo_le_succ (f := f) (d := d) (m := m) (N := n))
 
+example : discOffsetUpTo f d m n ≤ discOffsetUpTo f d m (Nat.succ n) := by
+  simpa using (discOffsetUpTo_le_succNat (f := f) (d := d) (m := m) (N := n))
+
 /-!
 ### NEW (Track B): Max-attainment wrapper for `discOffsetUpTo`
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `discOffsetUpTo` monotone in length: prove a clean wrapper `discOffsetUpTo f d m N ≤ discOffsetUpTo f d m (N+K)` (and the `N ≤ N'` variant),

Summary:
- Add `discOffsetUpTo_le_succNat` as a `Nat.succ`-shaped convenience lemma (goal written with `Nat.succ N` instead of `N+1`).
- Add a stable-surface regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean` showing it stays a one-line `simpa` under `import MoltResearch.Discrepancy`.
- Update `Learning/EDUCATIONAL_OVERLAYS.md` (canonical module overlay hygiene).

CI:
- `~/.elan/bin/lake env make ci`