### PR TITLE
Track B: discOffsetUpTo monotone-in-N wrapper regression

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -284,6 +284,10 @@ example : discOffsetUpTo f d m n ≤ discOffsetUpTo f d m (n + 1) := by
 example : discOffsetUpTo f d m n ≤ discOffsetUpTo f d m (Nat.succ n) := by
   simpa using (discOffsetUpTo_le_succNat (f := f) (d := d) (m := m) (N := n))
 
+-- Regression (Track B / `discOffsetUpTo` monotone-in-`N` wrapper): `N ↦ N + k` form.
+example : discOffsetUpTo f d m n ≤ discOffsetUpTo f d m (n + k) := by
+  simpa using (discOffsetUpTo_le_add (f := f) (d := d) (m := m) (N := n) (K := k))
+
 /-!
 ### NEW (Track B): Max-attainment wrapper for `discOffsetUpTo`
 

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -1112,7 +1112,8 @@ Definition of done:
 
 #### Auto-generated backlog (needs triage)
 
-- [ ] `discOffsetUpTo` monotone-in-`N` wrapper: package `discOffsetUpTo f d m N ≤ discOffsetUpTo f d m (N+K)` (and a `Nat.succ` corollary) without unfolding the `sup`/`max` definition.
+- [x] `discOffsetUpTo` monotone-in-`N` wrapper: package `discOffsetUpTo f d m N ≤ discOffsetUpTo f d m (N+K)` (and a `Nat.succ` corollary) without unfolding the `sup`/`max` definition.
+  (Implemented as `discOffsetUpTo_le_add` + `discOffsetUpTo_le_succNat` (and `discOffsetUpTo_mono`) in `MoltResearch/Discrepancy/Basic.lean`, with stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
 - [ ] `discOffsetUpTo` Lipschitz-by-`K` wrapper: a bundled lemma of the form
   `discOffsetUpTo f d m (N+K) ≤ discOffsetUpTo f d m N + K` (or the repo’s preferred inequality), built from the existing length-Lipschitz lemma at the `discOffset` level.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `discOffsetUpTo` monotone-in-`N` wrapper: package `discOffsetUpTo f d m N ≤ discOffsetUpTo f d m (N+K)` (and a `Nat.succ` corollary) without unfolding the `sup`/`max` definition.

What changed:
- Marked the backlog item as done, pointing to existing lemmas (`discOffsetUpTo_le_add`, `discOffsetUpTo_le_succNat`, `discOffsetUpTo_mono`) in `MoltResearch/Discrepancy/Basic.lean`.
- Added a stable-surface compile-only regression example for the `N ↦ N + k` form in `MoltResearch/Discrepancy/NormalFormExamples.lean`.

CI:
- `make ci`
