### PR TITLE
Track B: discOffsetUpTo Lipschitz-by-K wrapper

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -254,6 +254,17 @@ example (hf : IsSignSequence f) :
   simpa using (discOffsetUpTo_succ_le_add_one (f := f) (hf := hf) (d := d) (m := m) (N := n))
 
 /-!
+### NEW (Track B): `discOffsetUpTo` Lipschitz-by-`K` in `N`
+
+Compile-only regression test ensuring the “extend the cutoff by `K`” inequality stays a one-liner.
+-/
+
+example (hf : IsSignSequence f) (K : ℕ) :
+    discOffsetUpTo f d m (n + K) ≤ discOffsetUpTo f d m n + K := by
+  simpa using
+    (discOffsetUpTo_add_le (f := f) (hf := hf) (d := d) (m := m) (N := n) (K := K))
+
+/-!
 ### NEW (Track B): `discOffsetUpTo` paper↔nucleus bridge (endpoint style)
 
 Regression tests ensuring `discOffsetUpTo` can be rewritten into the paper-interval endpoint

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -1115,8 +1115,9 @@ Definition of done:
 - [x] `discOffsetUpTo` monotone-in-`N` wrapper: package `discOffsetUpTo f d m N ≤ discOffsetUpTo f d m (N+K)` (and a `Nat.succ` corollary) without unfolding the `sup`/`max` definition.
   (Implemented as `discOffsetUpTo_le_add` + `discOffsetUpTo_le_succNat` (and `discOffsetUpTo_mono`) in `MoltResearch/Discrepancy/Basic.lean`, with stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
-- [ ] `discOffsetUpTo` Lipschitz-by-`K` wrapper: a bundled lemma of the form
+- [x] `discOffsetUpTo` Lipschitz-by-`K` wrapper: a bundled lemma of the form
   `discOffsetUpTo f d m (N+K) ≤ discOffsetUpTo f d m N + K` (or the repo’s preferred inequality), built from the existing length-Lipschitz lemma at the `discOffset` level.
+  (Implemented as `discOffsetUpTo_add_le` (and `discOffsetUpTo_succ_le_add_one` as the `K=1` corollary) in `MoltResearch/Discrepancy/Basic.lean`, with stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
 - [ ] Icc↔offset sum normal form (affine endpoints): add simp-friendly rewrite lemmas converting
   `∑ i ∈ Finset.Icc (m+1) (m+n), f (a + i*d)` ↔ `apSumOffset (fun k => f (a + k)) d m n` in a single step (matching the repo’s preferred endpoint conventions), with stable-surface regression examples.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `discOffsetUpTo` Lipschitz-by-`K` wrapper: a bundled lemma of the form

Summary:
- Checks off the Track B backlog item by pointing the checklist entry at the existing lemma `discOffsetUpTo_add_le` (with `discOffsetUpTo_succ_le_add_one` as the `K=1` corollary) in `MoltResearch/Discrepancy/Basic.lean`.
- Adds a stable-surface compile-only regression example showing the general `K` inequality is a one-liner via `discOffsetUpTo_add_le`.

CI:
- `make ci`
