### PR TITLE
Track C: dedupe Stage-3 packaging lemma

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -157,18 +157,16 @@ theorem stage3_exists_params_unboundedDiscOffset (f : ℕ → ℤ) (hf : IsSignS
     (stage3Out (f := f) (hf := hf)).out2.hd, ?_⟩
   simpa using (stage3Out (f := f) (hf := hf)).unboundedDiscOffset (f := f)
 
-/-- Existential packaging: Stage 3 yields concrete parameters `d, m` with `1 ≤ d` such that the
-bundled offset discrepancy family `discOffset f d m` is unbounded.
+/-!
+Note: the existential packaging lemma
 
-This is a small convenience variant of `stage3_exists_params_unboundedDiscOffset`: many downstream
-stages prefer the side condition `1 ≤ d` rather than `d > 0`.
+  stage3_exists_params_one_le_unboundedDiscOffset
+
+lives in `Conjectures.C0002_erdos_discrepancy.src.TrackCStage3EntryCore`.
+
+We intentionally keep this hard-gate minimal module free of additional packaging to avoid
+duplicating core lemmas.
 -/
-theorem stage3_exists_params_one_le_unboundedDiscOffset (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    ∃ d m : ℕ, 1 ≤ d ∧ UnboundedDiscOffset f d m := by
-  refine ⟨(stage3Out (f := f) (hf := hf)).out2.d,
-    (stage3Out (f := f) (hf := hf)).out2.m,
-    (stage3Out (f := f) (hf := hf)).out2.one_le_d (f := f), ?_⟩
-  simpa using (stage3Out (f := f) (hf := hf)).unboundedDiscOffset (f := f)
 
 end Tao2015
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Remove duplicate declaration of stage3_exists_params_one_le_unboundedDiscOffset from TrackCStage3EntryMinimal
- Keep the hard-gate minimal module focused, and point packaging users to TrackCStage3EntryCore
- Fixes lake build failure for Conjectures.C0002_erdos_discrepancy.src.TrackCStage3EntryCore
