### PR TITLE
Discrepancy: Icc↔apSumOffset affine normal form

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -60,6 +60,11 @@ The goal is to pair verified artifacts with learning scaffolding.
   `(apSupport d m n).card = n` (the proof is by injectivity of `i ↦ (m+i+1)*d` when `d > 0`).
 - **API note (shift–dilation coherence):** when you both (i) push an offset shift into the summand and (ii) pull a factor `q` into the step, use the commutation lemma `apSumOffset_shift_mul_right_comm` (and the wrapper `discOffset_shift_mul_right_comm`) to avoid redoing index algebra. Conceptually: “shift then dilate” = “dilate then shift (with scaled offset)”.
 - **API note (paper interval normalization):** many downstream proofs naturally produce paper-style terms like `Int.natAbs ((Finset.Icc (m+1) (m+n)).sum ...)`. The stable surface exports simp lemmas rewriting these directly to `discOffset f d m n`, so endpoint algebra can be normalized by `simp` without manually rewriting `discOffset_eq_natAbs_sum_Icc` back and forth.
+- **API note (affine interval sum → `apSumOffset`):** if you have an interval sum with an extra affine offset in the summand,
+  `∑ i ∈ Finset.Icc (m+1) (m+n), f (a + i*d)`,
+  rewrite it in one shot using `sum_Icc_affine_eq_apSumOffset` to
+  `apSumOffset (fun k => f (a + k)) d m n`.
+  This is the “Icc↔offset sum normal form (affine endpoints)” Track B checklist item.
 - **API note (endpoint normalization):** when you have endpoint-style constraints in a `Finset.Icc` form, you can convert cleanly to the paper-style conjunction used by `discOffset_congr_endpoints`. Use `endpoints_lt_le_iff_mem_finset_Icc` to rewrite
   `m < i ∧ i ≤ m+n` ↔ `i ∈ Finset.Icc (m+1) (m+n)`, and `endpoints_lt_le_iff_succ_le_lt_succ` for the variant `m+1 ≤ i ∧ i < m+n+1`.
 - **API note (endpoint arithmetic normalization):** when your upper endpoint algebra is off by a “successor/pred” shim (common after `Nat.succ`/`Nat.pred` normalizations), use

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -2868,6 +2868,51 @@ lemma sum_Icc_eq_apSum (f : ℕ → ℤ) (d n : ℕ) :
   simpa using (apSum_eq_sum_Icc (f := f) (d := d) (n := n)).symm
 
 /-!
+### NEW (Track B): `Icc` ↔ `apSumOffset` normal form (affine endpoints)
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) —
+Icc↔offset sum normal form (affine endpoints).
+
+This lemma is designed to be a one-step rewrite from the common “paper notation”
+interval sum `∑ i ∈ Icc (m+1) (m+n), f (a + i*d)` to the nucleus API
+`apSumOffset (fun k => f (a + k)) d m n`.
+-/
+
+/-- Rewrite an affine-argument interval sum `∑ i ∈ Icc (m+1) (m+n), f (a + i*d)` as an
+offset arithmetic-progression sum `apSumOffset`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) —
+Icc↔offset sum normal form (affine endpoints).
+-/
+lemma sum_Icc_affine_eq_apSumOffset (f : ℕ → ℤ) (a d m n : ℕ) :
+    (Finset.Icc (m + 1) (m + n)).sum (fun i => f (a + i * d)) =
+      apSumOffset (fun k => f (a + k)) d m n := by
+  classical
+  unfold apSumOffset
+  -- Rewrite `Icc` as `Ico` and then use the standard `Ico`-to-`range` conversion.
+  have h :=
+    (Finset.sum_Ico_eq_sum_range (f := fun i => f (a + i * d)) (m := m + 1) (n := m + n + 1))
+  -- `m + n + 1 - (m + 1) = n`.
+  have hsub : m + n + 1 - (m + 1) = n := by
+    -- Use the canonical “subtract the same left addend” normal form.
+    simpa [Nat.add_assoc] using (Nat.add_sub_add_left m (n + 1) 1)
+  calc
+    (Finset.Icc (m + 1) (m + n)).sum (fun i => f (a + i * d)) =
+        (Finset.Ico (m + 1) (m + n + 1)).sum (fun i => f (a + i * d)) := by
+          simp [Finset.Ico_add_one_right_eq_Icc]
+    _ = (Finset.range (m + n + 1 - (m + 1))).sum (fun i => f (a + (m + 1 + i) * d)) := by
+          -- `h` is oriented from `Ico` to `range`.
+          simpa [Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using h
+    _ = (Finset.range n).sum (fun i => f (a + (m + i + 1) * d)) := by
+          -- Normalize the range length and reassociate `m+1+i`.
+          refine Finset.sum_congr (by simpa [hsub]) ?_
+          intro i hi
+          -- `m + 1 + i = m + i + 1`.
+          simp [Nat.add_assoc, Nat.add_left_comm, Nat.add_comm]
+    _ = (Finset.range n).sum (fun i => (fun k => f (a + k)) ((m + i + 1) * d)) := by
+          rfl
+
+/-!
 Note: deprecated `*_mul_left` paper-notation wrappers live in `MoltResearch.Discrepancy.Deprecated`.
 The stable surface uses the `i * d` convention (`apSum_eq_sum_Icc` / `sum_Icc_eq_apSum`).
 -/

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -65,6 +65,18 @@ example : discOffset (fun _ => (1 : ℤ)) d m n = n := by
   simpa [discOffset_const_one]
 
 /-!
+### NEW (Track B): `Icc` ↔ `apSumOffset` normal form (affine endpoints)
+
+Compile-only regression: paper-notation sums over `Finset.Icc (m+1) (m+n)` should rewrite to the
+offset nucleus API in a single step, without manual `Nat` endpoint algebra.
+-/
+
+example :
+    (Finset.Icc (m + 1) (m + n)).sum (fun i => f (a + i * d)) =
+      apSumOffset (fun k => f (a + k)) d m n := by
+  simpa using (sum_Icc_affine_eq_apSumOffset (f := f) (a := a) (d := d) (m := m) (n := n))
+
+/-!
 ### NEW (Track B): shift–dilation coherence (`apSumOffset`/`discOffset`)
 
 Compile-only regression: the nucleus normal-form pipeline should be able to reorder


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Icc↔offset sum normal form (affine endpoints): add simp-friendly rewrite lemmas converting

### What
- Adds `sum_Icc_affine_eq_apSumOffset` as a one-step rewrite from the paper-notation interval sum
  `∑ i ∈ Finset.Icc (m+1) (m+n), f (a + i*d)` to the nucleus API `apSumOffset`.
- Adds a stable-surface regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.

### Why
Downstream proofs often start from `Finset.Icc`-based sums with affine arguments; this packages the
endpoint bookkeeping into a single lemma.

### CI
- `make ci`
