### PR TITLE
Discrepancy: endpoint-algebra wrapper for 3-segment concat

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -23,6 +23,7 @@ The goal is to pair verified artifacts with learning scaffolding.
 - **Proof sketch pattern:** normalize definitions first, then prove small local inequalities and compose.
 - **Common pitfalls:** jumping into advanced lemmas before reducing to canonical definitions.
 - **API note (triangle vs reverse triangle):** for concatenation, `discOffset_add_le` is the forward triangle inequality. The reverse-triangle companions are `discOffset_left_le_add` / `discOffset_right_le_add`, proved by rewriting `S(n₁) = S(n₁+n₂) - S'(n₂)` and applying `Int.natAbs_sub_le`.
+- **API note (endpoint-algebra wrappers):** three-segment concatenation is available as `discOffset_add_add_le`, but downstream goals often appear with right-associated endpoints. Use `discOffset_add_add_le_assoc` when your goal has length `n₁ + (n₂ + n₃)` and/or third-start index `m + (n₁ + n₂)` so you can `simpa` without manual `Nat.add_assoc` reassociation.
 - **API note:** `discOffsetUpTo` is monotone in the cutoff. Use `discOffsetUpTo_mono` for an arbitrary `N ≤ N'`, or the convenience wrapper `discOffsetUpTo_le_add` for the common “extend by `K`” case `N ≤ N+K`.
   If your goal is stated with `Nat.succ N` instead of `N+1`, use the wrapper `discOffsetUpTo_le_succNat`.
 - **API note (tail concatenation, max-level):** for later Tao2015 bookkeeping, prefer the wrapper

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -2124,6 +2124,21 @@ lemma discOffset_add_add_le (f : ℕ → ℤ) (d m n₁ n₂ n₃ : ℕ) :
   -- Put both sides in the advertised normal form.
   simpa [Nat.add_assoc] using h
 
+/-- Endpoint-algebra wrapper for `discOffset_add_add_le`.
+
+This variant uses the right-associated length `n₁ + (n₂ + n₃)` and the right-associated
+third-segment start index `m + (n₁ + n₂)`, so downstream proofs can `simpa` without manual
+`Nat.add_assoc` bookkeeping.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — Endpoint algebra helpers.
+-/
+lemma discOffset_add_add_le_assoc (f : ℕ → ℤ) (d m n₁ n₂ n₃ : ℕ) :
+    discOffset f d m (n₁ + (n₂ + n₃)) ≤
+      discOffset f d m n₁ + discOffset f d (m + n₁) n₂ + discOffset f d (m + (n₁ + n₂)) n₃ := by
+  -- Reassociate to match `discOffset_add_add_le`, then reassociate the conclusion back.
+  simpa [Nat.add_assoc] using (discOffset_add_add_le (f := f) (d := d) (m := m)
+    (n₁ := n₁) (n₂ := n₂) (n₃ := n₃))
+
 /-! ### Degenerate start simp lemmas
 
 These mirror the “degenerate length” simp lemmas (`apSumOffset_zero` / `apSumOffset_one`) but for the

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -2648,6 +2648,13 @@ example :
   simpa using
     (discOffset_add_add_le (f := f) (d := d) (m := m) (n₁ := n₁) (n₂ := n₂) (n₃ := n₃))
 
+-- Endpoint-algebra wrapper regression: no manual `Nat.add_assoc` needed.
+example :
+    discOffset f d m (n₁ + (n₂ + n₃)) ≤
+      discOffset f d m n₁ + discOffset f d (m + n₁) n₂ + discOffset f d (m + (n₁ + n₂)) n₃ := by
+  simpa using
+    (discOffset_add_add_le_assoc (f := f) (d := d) (m := m) (n₁ := n₁) (n₂ := n₂) (n₃ := n₃))
+
 -- `disc` triangle inequality regression (homogeneous analogue of `discOffset_add_le`).
 example : disc f d (n₁ + n₂) ≤ disc f d n₁ + discOffset f d n₁ n₂ := by
   simpa using (disc_add_le (f := f) (d := d) (n₁ := n₁) (n₂ := n₂))


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Endpoint algebra helpers for `m+(n+k)` shapes: add a small family of `simp`/`rw` wrappers that normalize common `Nat` expressions (e.g. `m + (n + k)` / `(m+n)+k` / `m+n+k`) into the exact shapes expected by the offset concatenation / cut lemmas, so downstream proofs don’t need manual `Nat` reassociation.

## What
- Add `discOffset_add_add_le_assoc`: a right-associated endpoint-algebra wrapper around `discOffset_add_add_le`.
  - Accepts length `n₁ + (n₂ + n₃)` and start index `m + (n₁ + n₂)`.
- Add a stable-surface regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean` showing one-line `simpa` usage without manual `Nat.add_assoc`.

## Why
Downstream normal-form proofs frequently produce `m + (n₁ + n₂)` / `n₁ + (n₂ + n₃)` shapes; this wrapper avoids ad-hoc reassociation steps and keeps proofs aligned with the offset concatenation pipeline.

## Checks
- `make ci`
