### PR TITLE
Discrepancy: endpoint algebra helpers for start-index reassociation

### DIFF
--- a/MoltResearch/Discrepancy/CoherenceSimp.lean
+++ b/MoltResearch/Discrepancy/CoherenceSimp.lean
@@ -31,4 +31,25 @@ attribute [simp] apSumOffset_shift_start_add_mul_left
 attribute [simp] discOffset_shift_start_add
 attribute [simp] discOffset_shift_start_add_mul_left
 
+/-!
+## Endpoint/start-index associativity helpers
+
+Downstream proofs often produce start indices with different parenthesizations, e.g.
+`(m + n) + k` vs `m + (n + k)`. Our core coherence simp lemmas (like
+`discOffset_shift_start_add`) are keyed to the syntactic shape `m + k`, so we provide a
+*minimal* family of simp wrappers that reassociate the start index into the convenient form
+`m + (n + k)`.
+
+Checklist item: `Problems/erdos_discrepancy.md` (Track B) — endpoint algebra helpers.
+-/
+
+@[simp] lemma apSumOffset_start_add_assoc (f : ℕ → ℤ) (d m n k t : ℕ) :
+    apSumOffset f d (m + n + k) t = apSumOffset f d (m + (n + k)) t := by
+  -- `m + n + k` parses as `(m + n) + k`.
+  simpa [Nat.add_assoc]
+
+@[simp] lemma discOffset_start_add_assoc (f : ℕ → ℤ) (d m n k t : ℕ) :
+    discOffset f d (m + n + k) t = discOffset f d (m + (n + k)) t := by
+  simpa [Nat.add_assoc]
+
 end MoltResearch

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -118,8 +118,20 @@ example :
       apSumOffset (fun t => f (t + (n₁ + n₂) * d)) d m n := by
   simp
 
+-- NEW (Track B): endpoint algebra helpers should let `simp` see through reassociation.
+example :
+    apSumOffset f d (m + n₁ + n₂) n =
+      apSumOffset (fun t => f (t + (n₁ + n₂) * d)) d m n := by
+  simp
+
 example :
     discOffset f d (m + (n₁ + n₂)) n =
+      discOffset (fun t => f (t + (n₁ + n₂) * d)) d m n := by
+  simp
+
+-- NEW (Track B): same reassociation helper at the `discOffset` level.
+example :
+    discOffset f d (m + n₁ + n₂) n =
       discOffset (fun t => f (t + (n₁ + n₂) * d)) d m n := by
   simp
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Endpoint algebra helpers for `m+(n+k)` shapes: add a small family of `simp`/`rw` wrappers that normalize common `Nat` expressions (e.g. `m + (n + k)` / `(m+n)+k` / `m+n+k`) into the exact shapes expected by the offset concatenation / cut lemmas, so downstream proofs don’t need manual `Nat` reassociation.

Summary:
- Add stable-surface simp wrappers `apSumOffset_start_add_assoc` and `discOffset_start_add_assoc` in `MoltResearch.Discrepancy.CoherenceSimp`.
- Add regression examples in `MoltResearch.Discrepancy.NormalFormExamples` showing reassociated starts (`m+n₁+n₂`) simp through to the shift-start normal form.

Notes:
- Kept the simp surface minimal and oriented to avoid loops; no new opt-in simp bundles were expanded.
