### PR TITLE
EDP: endpoint algebra helpers regression + checklist

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -77,6 +77,21 @@ example :
   simpa using (sum_Icc_affine_eq_apSumOffset (f := f) (a := a) (d := d) (m := m) (n := n))
 
 /-!
+### NEW (Track B): start-index reassociation coherence (`m+n+k` vs `m+(n+k)`)
+
+Compile-only regression: the stable surface simp set should normalize start-index parenthesization
+so downstream proofs can feed the `*_shift_start_add` coherence rules without manual `Nat.add_assoc`.
+-/
+
+variable (t : ℕ)
+
+example : apSumOffset f d (m + n + k) t = apSumOffset f d (m + (n + k)) t := by
+  simp
+
+example : discOffset f d (m + n + k) t = discOffset f d (m + (n + k)) t := by
+  simp
+
+/-!
 ### NEW (Track B): shift–dilation coherence (`apSumOffset`/`discOffset`)
 
 Compile-only regression: the nucleus normal-form pipeline should be able to reorder

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -1123,7 +1123,8 @@ Definition of done:
   `∑ i ∈ Finset.Icc (m+1) (m+n), f (a + i*d)` ↔ `apSumOffset (fun k => f (a + k)) d m n` in a single step (matching the repo’s preferred endpoint conventions), with stable-surface regression examples.
   (Implemented as `sum_Icc_affine_eq_apSumOffset` in `MoltResearch/Discrepancy/Basic.lean`, with stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
-- [ ] Endpoint algebra helpers for `m+(n+k)` shapes: add a small family of `simp`/`rw` wrappers that normalize common `Nat` expressions (e.g. `m + (n + k)` / `(m+n)+k` / `m+n+k`) into the exact shapes expected by the offset concatenation / cut lemmas, so downstream proofs don’t need manual `Nat` reassociation.
+- [x] Endpoint algebra helpers for `m+(n+k)` shapes: add a small family of `simp`/`rw` wrappers that normalize common `Nat` expressions (e.g. `m + (n + k)` / `(m+n)+k` / `m+n+k`) into the exact shapes expected by the offset concatenation / cut lemmas, so downstream proofs don’t need manual `Nat` reassociation.
+  (Implemented as `[simp]` reassociation wrappers `apSumOffset_start_add_assoc` / `discOffset_start_add_assoc` in `MoltResearch/Discrepancy/CoherenceSimp.lean`, with a stable-surface regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
 - [ ] “Block-length” rewrite surface for residue splitting: provide a canonical lemma rewriting an offset sum over length `r*k` into a sum over `k` blocks (or `r` residue classes—pick one normal form) with consistent parameter ordering, so later residue arguments can start from a one-line `rw` rather than ad-hoc reindexing.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Endpoint algebra helpers for `m+(n+k)` shapes

This PR marks the checklist item as done and adds a stable-surface regression example showing that the `CoherenceSimp` simp surface normalizes start-index parenthesization:
- `apSumOffset f d (m + n + k) t = apSumOffset f d (m + (n + k)) t`
- `discOffset f d (m + n + k) t = discOffset f d (m + (n + k)) t`

Implemented in `MoltResearch/Discrepancy/CoherenceSimp.lean`; regression example added to `MoltResearch/Discrepancy/NormalFormExamples.lean`.
