### PR TITLE
Track C: core lemma for discOffset witnesses

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
@@ -133,6 +133,17 @@ theorem forall_exists_discOffset_gt_witness_pos (out : Stage2Output f) :
   rcases out.forall_exists_discOffset_gt'_witness_pos (f := f) B with ⟨n, hnpos, hn⟩
   exact ⟨n, hnpos, (gt_iff_lt).1 hn⟩
 
+/-- Witness-family form: Stage 2 yields arbitrarily large bundled offset discrepancies, written as
+`B < discOffset ...`.
+
+This is `forall_exists_discOffset_gt_witness_pos` with the positivity side condition dropped.
+-/
+theorem forall_exists_discOffset_gt (out : Stage2Output f) :
+    ∀ B : ℕ, ∃ n : ℕ, B < discOffset f out.d out.m n := by
+  intro B
+  rcases out.forall_exists_discOffset_gt_witness_pos (f := f) B with ⟨n, _hnpos, hn⟩
+  exact ⟨n, hn⟩
+
 /-- Positive-length witness form: Stage 2 yields arbitrarily large bundled offset nuclei
 `Int.natAbs (apSumOffset f out.d out.m n)`, with witnesses `n > 0`.
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
@@ -123,22 +123,8 @@ theorem notBoundedReducedAlong (out : Stage2Output f) : ¬ BoundedDiscrepancyAlo
 
 -- Note: downstream hard-gate stages should prefer the smaller API in `TrackCStage2Core.lean`.
 
-/-- Consumer-facing form: Stage 2 unboundedness transferred back to the original sequence as an
-unbounded **offset discrepancy** witness.
-
-This is just a wrapper around
-`Tao2015.ReductionOutput.unboundedDiscrepancyAlong_iff_forall_exists_discOffset_gt`.
-
-Note the inequality direction: this produces witnesses of the form `B < discOffset ...`.
--/
-theorem forall_exists_discOffset_gt (out : Stage2Output f) :
-    ∀ B : ℕ, ∃ n : ℕ, B < discOffset f out.d out.m n := by
-  -- Unfold the Stage-2 witness form and transport it through the Stage-1 contract.
-  simpa using
-    ((out.out1.unboundedDiscrepancyAlong_iff_forall_exists_discOffset_gt (f := f)).1 out.unbounded)
-
--- Note: `Stage2Output.forall_exists_discOffset_gt'` is part of the Stage-2 core API (see
--- `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Core`).
+-- Note: `Stage2Output.forall_exists_discOffset_gt` and `Stage2Output.forall_exists_discOffset_gt'`
+-- are part of the Stage-2 core API (see `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Core`).
 
 
 /-!


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Move Stage2Output.forall_exists_discOffset_gt into TrackCStage2Core so it is available from the small Stage-2 core import surface
- TrackCStage2Output no longer re-declares the lemma (no behavior change)
