### PR TITLE
Discrepancy: discOffsetUpTo congruence wrappers

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -50,6 +50,9 @@ The goal is to pair verified artifacts with learning scaffolding.
 - **API note (start-shift vs sequence-shift, max-level):** if you want to “advance the start” without pushing arithmetic through the `Finset.sup` definition, rewrite using
   `discOffsetUpTo_add_start`:
   `discOffsetUpTo f d (m + k) N = discOffsetUpTo (fun t => f (t + k*d)) d m N`.
+- **API note (max-level congruence wrappers):** when you have pointwise agreement of two sequences on the tail indices that can occur up to cutoff `N`, you can rewrite `discOffsetUpTo` without unfolding the outer `Finset.range`/`Finset.sup` using:
+  - `discOffsetUpTo_congr` (hypothesis over `i < N+1` on indices `(m+i+1)*d`)
+  - `discOffsetUpTo_congr_le` (hypothesis over `i ≤ N+1` on indices `(m+i)*d`)
 - **API note (degenerate length for `apSupport`):** when writing support-form hypotheses (agreement on `apSupport d m n`), the base case `n = 0` should reduce immediately. Use the simp lemma `apSupport_zero` to rewrite `apSupport d m 0` to `∅`.
 - **API note (`apSupport` bookkeeping helpers):** for common “no-op” shifts/dilations, the stable surface provides simp lemmas
   `apSupport_add_left_zero` and `apSupport_mul_right_one` so `simp` can discharge trivial `m+0` / `d*1` noise without unfolding.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -1701,6 +1701,87 @@ lemma discOffset_congr_le (f g : ℕ → ℤ) (d m n : ℕ)
   exact apSumOffset_congr_le (f := f) (g := g) (d := d) (m := m) (n := n) h
 
 /-!
+### Congruence wrappers for `discOffsetUpTo`
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) —
+“Max-level congruence wrapper: `discOffsetUpTo_congr` / `discOffsetUpTo_congr_le`”.
+
+These mirror the existing `discOffset_congr` / `discOffset_congr_le` wrappers, but lift them
+through the outer `Finset.sup` so callers don’t have to manually manage `n ∈ range (N+1)`.
+-/
+
+/-- Pointwise congruence wrapper for `discOffsetUpTo`, expressed over `i < N + 1`.
+
+If `f` and `g` agree on every tail index that can appear in any length `n ≤ N`, then the
+corresponding max-offset discrepancies up to `N` agree.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — Max-level congruence wrappers.
+-/
+lemma discOffsetUpTo_congr (f g : ℕ → ℤ) (d m N : ℕ)
+    (h : ∀ i, i < N + 1 → f ((m + i + 1) * d) = g ((m + i + 1) * d)) :
+    discOffsetUpTo f d m N = discOffsetUpTo g d m N := by
+  classical
+  unfold discOffsetUpTo
+  refine le_antisymm ?_ ?_
+  · refine Finset.sup_le ?_
+    intro n hn
+    have hnlt : n < N + 1 := Finset.mem_range.1 hn
+    have hfg : discOffset f d m n = discOffset g d m n := by
+      apply discOffset_congr (f := f) (g := g) (d := d) (m := m) (n := n)
+      intro i hi
+      exact h i (lt_trans hi hnlt)
+    -- transport the pointwise equality into the `sup` bound
+    simpa [hfg] using
+      (Finset.le_sup (s := Finset.range (N + 1)) (f := fun t => discOffset g d m t) hn)
+  · refine Finset.sup_le ?_
+    intro n hn
+    have hnlt : n < N + 1 := Finset.mem_range.1 hn
+    have hgf : discOffset g d m n = discOffset f d m n := by
+      apply discOffset_congr (f := g) (g := f) (d := d) (m := m) (n := n)
+      intro i hi
+      simpa using (h i (lt_trans hi hnlt)).symm
+    simpa [hgf] using
+      (Finset.le_sup (s := Finset.range (N + 1)) (f := fun t => discOffset f d m t) hn)
+
+/-- Translation-invariance wrapper for `discOffsetUpTo`.
+
+If `f` and `g` agree on the affine tail indices `(m+i)*d` for `i ≤ N+1`, then the corresponding
+max-offset discrepancies up to `N` agree.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — Max-level congruence wrappers.
+-/
+lemma discOffsetUpTo_congr_le (f g : ℕ → ℤ) (d m N : ℕ)
+    (h : ∀ i, i ≤ N + 1 → f ((m + i) * d) = g ((m + i) * d)) :
+    discOffsetUpTo f d m N = discOffsetUpTo g d m N := by
+  classical
+  unfold discOffsetUpTo
+  refine le_antisymm ?_ ?_
+  · refine Finset.sup_le ?_
+    intro n hn
+    have hnlt : n < N + 1 := Finset.mem_range.1 hn
+    have hfg : discOffset f d m n = discOffset g d m n := by
+      apply discOffset_congr_le (f := f) (g := g) (d := d) (m := m) (n := n)
+      intro i hi
+      -- `i ≤ n` and `n < N+1` gives `i ≤ N+1`.
+      have hin : i ≤ N := le_trans hi (Nat.le_of_lt_succ hnlt)
+      have hiN1 : i ≤ N + 1 := le_trans hin (Nat.le_succ N)
+      exact h i hiN1
+    simpa [hfg] using
+      (Finset.le_sup (s := Finset.range (N + 1)) (f := fun t => discOffset g d m t) hn)
+  · refine Finset.sup_le ?_
+    intro n hn
+    have hnlt : n < N + 1 := Finset.mem_range.1 hn
+    have hgf : discOffset g d m n = discOffset f d m n := by
+      apply discOffset_congr_le (f := g) (g := f) (d := d) (m := m) (n := n)
+      intro i hi
+      have hin : i ≤ N := le_trans hi (Nat.le_of_lt_succ hnlt)
+      have hiN1 : i ≤ N + 1 := le_trans hin (Nat.le_succ N)
+      have : f ((m + i) * d) = g ((m + i) * d) := h i hiN1
+      simpa using this.symm
+    simpa [hgf] using
+      (Finset.le_sup (s := Finset.range (N + 1)) (f := fun t => discOffset f d m t) hn)
+
+/-!
 Deprecated `discOffset` congruence variants over explicit `Icc` index sets have been moved behind
 `import MoltResearch.Discrepancy.Deprecated`.
 

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -283,6 +283,23 @@ example : discOffsetUpTo f 1 m n = discUpTo (fun k => f (k + m)) 1 n := by
   simp
 
 /-!
+### NEW (Track B): max-level congruence wrappers for `discOffsetUpTo`
+
+Regression tests ensuring `discOffsetUpTo` can be rewritten by pointwise tail agreement without
+unfolding the outer `Finset.range`/`Finset.sup`.
+-/
+
+example (g : ℕ → ℤ)
+    (h : ∀ i, i < n + 1 → f ((m + i + 1) * d) = g ((m + i + 1) * d)) :
+    discOffsetUpTo f d m n = discOffsetUpTo g d m n := by
+  simpa using (discOffsetUpTo_congr (f := f) (g := g) (d := d) (m := m) (N := n) h)
+
+example (g : ℕ → ℤ)
+    (h : ∀ i, i ≤ n + 1 → f ((m + i) * d) = g ((m + i) * d)) :
+    discOffsetUpTo f d m n = discOffsetUpTo g d m n := by
+  simpa using (discOffsetUpTo_congr_le (f := f) (g := g) (d := d) (m := m) (N := n) h)
+
+/-!
 ### NEW (Track B): `discOffsetUpTo` Lipschitz-by-1 in `N`
 
 Compile-only regression tests ensuring the “extend the cutoff by 1” inequalities stay one-liners.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Max-level congruence wrapper: `discOffsetUpTo_congr` / `discOffsetUpTo_congr_le` lemmas mirroring the existing `discOffset_congr(_le)` style, so max-level rewrite steps can avoid `Finset.range` bookkeeping.

Summary:
- Adds `discOffsetUpTo_congr` and `discOffsetUpTo_congr_le` wrappers, lifting `discOffset_congr(_le)` through the outer `Finset.sup` in `discOffsetUpTo`.
- Adds stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean` under `import MoltResearch.Discrepancy`.

CI:
- `make ci`
