### PR TITLE
Discrepancy: residue+max stable-surface pipeline example

### DIFF
--- a/MoltResearch/Discrepancy/ResidueMaxPipelineExample.lean
+++ b/MoltResearch/Discrepancy/ResidueMaxPipelineExample.lean
@@ -1,0 +1,40 @@
+import MoltResearch.Discrepancy
+
+/-!
+# Discrepancy: residue + max-level mini-pipeline (compile-only)
+
+Checklist item: `Problems/erdos_discrepancy.md` (Track B)
+
+This file is intentionally **compile-only**: it provides a tiny “paper-shaped” script that
+exercises the max-level residue-class inequality in its packaged stable-surface form.
+
+It must continue to compile under:
+
+```lean
+import MoltResearch.Discrepancy
+```
+-/
+
+namespace MoltResearch
+
+section
+  open scoped BigOperators
+
+  variable (f : ℕ → ℤ) (d m q N : ℕ)
+
+  /-!
+  ## Typical flow: block-length max → residue-term sum
+
+  Start from the max discrepancy restricted to block lengths `q*(n+1)` (for `n ≤ N`), and apply the
+  stable-surface residue-class bound expressed via the packaged `discOffsetUpTo_residueTerm`.
+  -/
+  example (hq : q > 0) :
+      discOffsetUpTo_blockLen_mul_succ f d m q N ≤
+        (Finset.range q).sum (fun r => discOffsetUpTo_residueTerm f d m q r N) := by
+    simpa using
+      (discOffsetUpTo_blockLen_mul_succ_le_sum_range_residueTerm
+        (f := f) (d := d) (m := m) (q := q) (N := N) hq)
+
+end
+
+end MoltResearch

--- a/MoltResearch/Discrepancy/SurfaceAudit.lean
+++ b/MoltResearch/Discrepancy/SurfaceAudit.lean
@@ -1,6 +1,7 @@
 import MoltResearch.Discrepancy
 import MoltResearch.Discrepancy.NormalFormPipelineExample
 import MoltResearch.Discrepancy.MiniPipelineMaxExample
+import MoltResearch.Discrepancy.ResidueMaxPipelineExample
 import MoltResearch.Discrepancy.SupportEditPipelineExample
 
 /-!


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Stable-surface audit for residue + max pipelines: add 1 compile-only example under `import MoltResearch.Discrepancy` showing a typical flow

Adds `MoltResearch.Discrepancy.ResidueMaxPipelineExample` and wires it into `MoltResearch.Discrepancy.SurfaceAudit`.

The example is compile-only and exercises the packaged max-level residue inequality:
`discOffsetUpTo_blockLen_mul_succ ≤ ∑ r, discOffsetUpTo_residueTerm`.
