### PR TITLE
Discrepancy nucleus: wrapper coherence + tiny deprecations

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -22,6 +22,10 @@ The goal is to pair verified artifacts with learning scaffolding.
 - **Intuition:** foundational discrepancy definitions and small bounds let later modules reuse a common vocabulary.
 - **Proof sketch pattern:** normalize definitions first, then prove small local inequalities and compose.
 - **Common pitfalls:** jumping into advanced lemmas before reducing to canonical definitions.
+- **API note (wrapper naming coherence):** there are two homogeneous discrepancy wrappers:
+  - `discrepancy f d n` (readable name), and
+  - `disc f d n` (matches the `discOffset` / `discOffsetUpTo` family).
+  They are definitionally equal; use `discrepancy_eq_disc` / `disc_eq_discrepancy` when you want to normalize one spelling to the other without unfolding. For definitional unfolding, prefer the explicit lemmas `discrepancy_eq_natAbs_apSum` / `disc_eq_natAbs_apSum` over the shorter `*_def` aliases.
 - **API note (triangle vs reverse triangle):** for concatenation, `discOffset_add_le` is the forward triangle inequality. The reverse-triangle companions are `discOffset_left_le_add` / `discOffset_right_le_add`, proved by rewriting `S(n₁) = S(n₁+n₂) - S'(n₂)` and applying `Int.natAbs_sub_le`.
 - **API note (endpoint-algebra wrappers):** three-segment concatenation is available as `discOffset_add_add_le`, but downstream goals often appear with right-associated endpoints. Use `discOffset_add_add_le_assoc` when your goal has length `n₁ + (n₂ + n₃)` and/or third-start index `m + (n₁ + n₂)` so you can `simpa` without manual `Nat.add_assoc` reassociation.
 - **API note:** `discOffsetUpTo` is monotone in the cutoff. Use `discOffsetUpTo_mono` for an arbitrary `N ≤ N'`, or the convenience wrapper `discOffsetUpTo_le_add` for the common “extend by `K`” case `N ≤ N+K`.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -39,6 +39,7 @@ lemma discrepancy_eq_natAbs_apSum (f : ℕ → ℤ) (d n : ℕ) :
   rfl
 
 /-- Alias for the definitional lemma. -/
+@[deprecated "Use `discrepancy_eq_natAbs_apSum`." (since := "2026-04-17")]
 lemma discrepancy_def (f : ℕ → ℤ) (d n : ℕ) :
     discrepancy f d n = Int.natAbs (apSum f d n) :=
   rfl
@@ -57,6 +58,10 @@ This direction avoids simp loops with `discrepancy_def`.
 This is a homogeneous analogue of `discOffset` with the same naming convention.
 
 It intentionally duplicates `discrepancy` as a more symmetric counterpart to `discOffset`.
+
+Naming guidance:
+- Prefer `disc`/`discOffset`/`discOffsetUpTo` when you want a uniform family of wrappers.
+- `discrepancy` is kept as a readable synonym for the homogeneous case.
 -/
 
 /-- Homogeneous discrepancy wrapper: `disc f d n = |apSum f d n|`. -/
@@ -69,6 +74,7 @@ lemma disc_eq_natAbs_apSum (f : ℕ → ℤ) (d n : ℕ) :
   rfl
 
 /-- Alias for the definitional lemma. -/
+@[deprecated "Use `disc_eq_natAbs_apSum`." (since := "2026-04-17")]
 lemma disc_def (f : ℕ → ℤ) (d n : ℕ) :
     disc f d n = Int.natAbs (apSum f d n) :=
   rfl
@@ -80,6 +86,16 @@ This direction avoids simp loops with `disc_def`.
 @[simp] lemma natAbs_apSum_eq_disc (f : ℕ → ℤ) (d n : ℕ) :
     Int.natAbs (apSum f d n) = disc f d n :=
   rfl
+
+/-- Coherence lemma: the two homogeneous wrappers are definitionally the same.
+
+This exists purely for API consistency; prefer rewriting goals to the `disc`-family wrappers when
+working with `discOffset` / `discOffsetUpTo` pipelines.
+-/
+lemma discrepancy_eq_disc (f : ℕ → ℤ) (d n : ℕ) : discrepancy f d n = disc f d n := rfl
+
+/-- Coherence lemma: the two homogeneous wrappers are definitionally the same. -/
+lemma disc_eq_discrepancy (f : ℕ → ℤ) (d n : ℕ) : disc f d n = discrepancy f d n := rfl
 
 /-- The discrepancy of an empty progression is zero. -/
 @[simp] lemma disc_zero (f : ℕ → ℤ) (d : ℕ) : disc f d 0 = 0 := by

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -2295,6 +2295,16 @@ example (hmn : m ≤ n)
 example : discrepancy f d n = Int.natAbs (apSum f d n) := by
   rfl
 
+example : disc f d n = Int.natAbs (apSum f d n) := by
+  rfl
+
+-- Regression: coherence between the two homogeneous wrapper spellings.
+example : discrepancy f d n = disc f d n := by
+  simpa using (discrepancy_eq_disc (f := f) (d := d) (n := n))
+
+example : disc f d n = discrepancy f d n := by
+  simpa using (disc_eq_discrepancy (f := f) (d := d) (n := n))
+
 example : affineDiscrepancy f a d n = Int.natAbs (apSumFrom f a d n) := by
   rfl
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: “Nucleus API coherence” pass: audit naming / argument order consistency across `apSum`/`apSumOffset`/`apSumFrom` and `discrepancy`/`discOffset`/`discOffsetUpTo` wrappers; propose 1–2 targeted renames + deprecated aliases (not a mass rename), with a stable-surface regression example confirming imports don’t break.

Summary:
- Add explicit coherence lemmas `discrepancy_eq_disc` / `disc_eq_discrepancy` (definitional `rfl`), so downstream code can normalize to the `disc`-family wrappers when working alongside `discOffset` / `discOffsetUpTo`.
- Add naming guidance in the `disc` section docstring (prefer `disc`/`discOffset`/`discOffsetUpTo` for a uniform wrapper family; keep `discrepancy` as a readable synonym).
- Mark the `*_def` alias lemmas (`discrepancy_def`, `disc_def`) as deprecated in favor of the more explicit `*_eq_natAbs_apSum` names.
- Extend `MoltResearch.Discrepancy.NormalFormExamples` with compile-only regression examples exercising:
  - definitional exposure for both `discrepancy` and `disc`
  - the new coherence lemmas, confirming the stable surface still compiles cleanly.

Notes:
- No new “opportunistic” Discrepancy lemmas beyond the coherence shim; no `[simp]` changes.
