### PR TITLE
Discrepancy: add discFrom wrapper (affine)

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -25,7 +25,9 @@ The goal is to pair verified artifacts with learning scaffolding.
 - **API note (wrapper naming coherence):** there are two homogeneous discrepancy wrappers:
   - `discrepancy f d n` (readable name), and
   - `disc f d n` (matches the `discOffset` / `discOffsetUpTo` family).
-  They are definitionally equal; use `discrepancy_eq_disc` / `disc_eq_discrepancy` when you want to normalize one spelling to the other without unfolding. For definitional unfolding, prefer the explicit lemmas `discrepancy_eq_natAbs_apSum` / `disc_eq_natAbs_apSum` over the shorter `*_def` aliases.
+  They are definitionally equal; use `discrepancy_eq_disc` / `disc_eq_discrepancy` when you want to normalize one spelling to the other without unfolding.
+
+  For definitional unfolding, prefer the explicit lemmas `discrepancy_eq_natAbs_apSum` / `disc_eq_natAbs_apSum` over the shorter `*_def` aliases. Similarly, for offsets prefer `discOffset_eq_natAbs_apSumOffset` (the older `discOffset_def` alias is deprecated).
 - **API note (triangle vs reverse triangle):** for concatenation, `discOffset_add_le` is the forward triangle inequality. The reverse-triangle companions are `discOffset_left_le_add` / `discOffset_right_le_add`, proved by rewriting `S(n₁) = S(n₁+n₂) - S'(n₂)` and applying `Int.natAbs_sub_le`.
 - **API note (endpoint-algebra wrappers):** three-segment concatenation is available as `discOffset_add_add_le`, but downstream goals often appear with right-associated endpoints. Use `discOffset_add_add_le_assoc` when your goal has length `n₁ + (n₂ + n₃)` and/or third-start index `m + (n₁ + n₂)` so you can `simpa` without manual `Nat.add_assoc` reassociation.
 - **API note:** `discOffsetUpTo` is monotone in the cutoff. Use `discOffsetUpTo_mono` for an arbitrary `N ≤ N'`, or the convenience wrapper `discOffsetUpTo_le_add` for the common “extend by `K`” case `N ≤ N+K`.

--- a/MoltResearch/Discrepancy/Affine.lean
+++ b/MoltResearch/Discrepancy/Affine.lean
@@ -20,6 +20,33 @@ namespace MoltResearch
 def apSumFrom (f : ℕ → ℤ) (a d n : ℕ) : ℤ :=
   (Finset.range n).sum (fun i => f (a + (i + 1) * d))
 
+/-! ### Discrepancy wrapper for affine AP sums (`apSumFrom`) -/
+
+/-- Affine discrepancy wrapper: `discFrom f a d n = |apSumFrom f a d n|`.
+
+This is the affine analogue of `disc` / `discOffset`.
+-/
+def discFrom (f : ℕ → ℤ) (a d n : ℕ) : ℕ :=
+  Int.natAbs (apSumFrom f a d n)
+
+/-- Definitional lemma exposing the definition. -/
+lemma discFrom_eq_natAbs_apSumFrom (f : ℕ → ℤ) (a d n : ℕ) :
+    discFrom f a d n = Int.natAbs (apSumFrom f a d n) :=
+  rfl
+
+/-- `simp` bridge: `Int.natAbs (apSumFrom …)` simplifies to the `discFrom` wrapper.
+
+This direction avoids simp loops with `discFrom_eq_natAbs_apSumFrom`.
+-/
+@[simp] lemma natAbs_apSumFrom_eq_discFrom (f : ℕ → ℤ) (a d n : ℕ) :
+    Int.natAbs (apSumFrom f a d n) = discFrom f a d n :=
+  rfl
+
+/-- Coherence: `a = 0` recovers the homogeneous wrapper `disc`. -/
+lemma discFrom_zero_start (f : ℕ → ℤ) (d n : ℕ) : discFrom f 0 d n = disc f d n := by
+  -- unfold both wrappers and discharge the `0 + …` normalisation.
+  simp [discFrom, disc, apSumFrom, apSum]
+
 /-!
 ### Multiplicative dilation normal forms (affine nucleus)
 

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -1055,6 +1055,7 @@ lemma discOffset_restrict_support (f : ℕ → ℤ) (d m n : ℕ) :
   simp [apSumOffset_restrict_support]
 
 /-- Alias for the definitional lemma. -/
+@[deprecated "Use `discOffset_eq_natAbs_apSumOffset`." (since := "2026-04-17")]
 lemma discOffset_def (f : ℕ → ℤ) (d m n : ℕ) :
     discOffset f d m n = Int.natAbs (apSumOffset f d m n) :=
   rfl

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -406,9 +406,10 @@ example : apSumFrom f a d (n + k) = apSumFrom f a d n + apSumFrom f (a + n * d) 
   simpa using (apSumFrom_add_length (f := f) (a := a) (d := d) (m := n) (n := k))
 
 -- (1.6) Immediate triangle-inequality corollary (still at the nucleus level).
-example : Int.natAbs (apSumFrom f a d (n + k)) ≤
-    Int.natAbs (apSumFrom f a d n) + Int.natAbs (apSumFrom f (a + n * d) d k) := by
-  simpa using (natAbs_apSumFrom_add_length_le (f := f) (a := a) (d := d) (n₁ := n) (n₂ := k))
+example : discFrom f a d (n + k) ≤ discFrom f a d n + discFrom f (a + n * d) d k := by
+  -- Use the underlying `natAbs` lemma and rewrite via the `discFrom` wrapper.
+  simpa [discFrom] using
+    (natAbs_apSumFrom_add_length_le (f := f) (a := a) (d := d) (n₁ := n) (n₂ := k))
 
 -- (2) Difference of affine partial sums → nucleus offset-tail normal form on the shifted sequence.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: “Nucleus API coherence” pass: audit naming / argument order consistency across `apSum`/`apSumOffset`/`apSumFrom` and `discrepancy`/`discOffset`/`discOffsetUpTo` wrappers; propose 1–2 targeted renames + deprecated aliases (not a mass rename), with a stable-surface regression example confirming imports don’t break.

### What changed
- Added `discFrom f a d n := |apSumFrom f a d n|` (affine discrepancy wrapper) in `MoltResearch.Discrepancy.Affine`.
  - Includes definitional lemma + simp bridge `natAbs_apSumFrom_eq_discFrom`.
  - Added coherence lemma `discFrom_zero_start` (affine start `a=0` recovers homogeneous `disc`).
- Deprecated `discOffset_def` in favor of the consistent `…_eq_natAbs_…` lemma name `discOffset_eq_natAbs_apSumOffset`.
- Updated `MoltResearch.Discrepancy.NormalFormExamples` to use `discFrom` in one representative place (stable-surface regression).

### Why
- This makes the discrepancy wrappers match the sum nuclei more uniformly:
  - `apSum` ↔ `disc`
  - `apSumOffset` ↔ `discOffset`
  - `apSumFrom` ↔ `discFrom`
- Keeps changes small (no mass rename), while giving downstream code a cleaner “nucleus → wrapper” path.

### Tests
- `make ci`
