### PR TITLE
Discrepancy: API-coherence aliases apSumOffset'/discOffset'

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -28,6 +28,8 @@ The goal is to pair verified artifacts with learning scaffolding.
   They are definitionally equal; use `discrepancy_eq_disc` / `disc_eq_discrepancy` when you want to normalize one spelling to the other without unfolding.
 
   For definitional unfolding, prefer the explicit lemmas `discrepancy_eq_natAbs_apSum` / `disc_eq_natAbs_apSum` over the shorter `*_def` aliases. Similarly, for offsets prefer `discOffset_eq_natAbs_apSumOffset` (the older `discOffset_def` alias is deprecated).
+
+  **Argument-order coherence:** `apSumFrom` uses `(a d n)` (“start, step, length”), while the historical offset nucleus uses `apSumOffset f d m n`. When you want to line up parameters across the affine/offset nuclei, use the definitional aliases `apSumOffset' f m d n` and `discOffset' f m d n`.
 - **API note (triangle vs reverse triangle):** for concatenation, `discOffset_add_le` is the forward triangle inequality. The reverse-triangle companions are `discOffset_left_le_add` / `discOffset_right_le_add`, proved by rewriting `S(n₁) = S(n₁+n₂) - S'(n₂)` and applying `Int.natAbs_sub_le`.
 - **API note (endpoint-algebra wrappers):** three-segment concatenation is available as `discOffset_add_add_le`, but downstream goals often appear with right-associated endpoints. Use `discOffset_add_add_le_assoc` when your goal has length `n₁ + (n₂ + n₃)` and/or third-start index `m + (n₁ + n₂)` so you can `simpa` without manual `Nat.add_assoc` reassociation.
 - **API note:** `discOffsetUpTo` is monotone in the cutoff. Use `discOffsetUpTo_mono` for an arbitrary `N ≤ N'`, or the convenience wrapper `discOffsetUpTo_le_add` for the common “extend by `K`” case `N ≤ N+K`.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -114,6 +114,31 @@ def apSumOffset (f : ℕ → ℤ) (d m n : ℕ) : ℤ :=
   (Finset.range n).sum (fun i => f ((m + i + 1) * d))
 
 /-!
+### `apSumOffset` argument-order coherence helper (API coherence)
+
+`apSumFrom` uses argument order `(a d n)`, i.e. “start, step, length”.
+
+For the offset nucleus `apSumOffset`, the historical order is `(d m n)`.
+This file keeps that order (it is used widely), but we also provide the alias
+`apSumOffset'` with the more uniform order `(m d n)`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — “Nucleus API coherence”.
+-/
+
+/-- Alias for `apSumOffset` with argument order `(m d n)`.
+
+This is purely an API-coherence convenience so that the “offset” parameter sits next to the
+“start” parameter of `apSumFrom` when you are switching between the two nuclei.
+-/
+def apSumOffset' (f : ℕ → ℤ) (m d n : ℕ) : ℤ :=
+  apSumOffset f d m n
+
+/-- Coherence lemma: `apSumOffset'` is definitionally `apSumOffset`. -/
+lemma apSumOffset'_eq (f : ℕ → ℤ) (m d n : ℕ) :
+    apSumOffset' f m d n = apSumOffset f d m n :=
+  rfl
+
+/-!
 ### Multiplicative dilation normal forms
 
 Checklist item: Problems/erdos_discrepancy.md (Track B) — Multiplicative dilation normal form.
@@ -692,6 +717,18 @@ It is defined as the natural absolute value of `apSumOffset f d m n`.
 -/
 def discOffset (f : ℕ → ℤ) (d m n : ℕ) : ℕ :=
   Int.natAbs (apSumOffset f d m n)
+
+/-- Alias for `discOffset` with argument order `(m d n)`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — “Nucleus API coherence”.
+-/
+def discOffset' (f : ℕ → ℤ) (m d n : ℕ) : ℕ :=
+  discOffset f d m n
+
+/-- Coherence lemma: `discOffset'` is definitionally `discOffset`. -/
+lemma discOffset'_eq (f : ℕ → ℤ) (m d n : ℕ) :
+    discOffset' f m d n = discOffset f d m n :=
+  rfl
 
 
 /-- Shift–dilation coherence for the discrepancy wrapper `discOffset`.

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -64,6 +64,13 @@ example : apSum (fun _ => (1 : ℤ)) d n = (n : ℤ) := by
 example : discOffset (fun _ => (1 : ℤ)) d m n = n := by
   simpa [discOffset_const_one]
 
+-- NEW (Track B): nucleus API coherence (argument order)
+example : apSumOffset' f m d n = apSumOffset f d m n := by
+  rfl
+
+example : discOffset' f m d n = discOffset f d m n := by
+  rfl
+
 /-!
 ### NEW (Track B): `Icc` ↔ `apSumOffset` normal form (affine endpoints)
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: “Nucleus API coherence” pass: audit naming / argument order consistency across `apSum`/`apSumOffset`/`apSumFrom` and `discrepancy`/`discOffset`/`discOffsetUpTo` wrappers; propose 1–2 targeted renames + deprecated aliases (not a mass rename), with a stable-surface regression example confirming imports don’t break.

Summary:
- Add `apSumOffset'` / `discOffset'` as argument-order-coherent aliases using `(m d n)` rather than `(d m n)`.
- Add compile-only regression examples under `import MoltResearch.Discrepancy` confirming the aliases reduce definitionally to the originals.

Notes:
- No behavior changes; `apSumOffset` and `discOffset` remain the canonical nuclei.
- This is a small API-coherence convenience for switching between the affine nucleus `apSumFrom (a d n)` and the offset nucleus.
