### PR TITLE
Track C: thin Stage3EntryCore imports

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
@@ -1,5 +1,4 @@
 import Conjectures.C0002_erdos_discrepancy.src.TrackCStage3EntryMinimal
-import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Core
 
 /-!
 # Track C: Stage 3 entry point (hard-gate core)


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Remove a redundant import from TrackCStage3EntryCore (Stage-2 core is already pulled in transitively).
- Keeps the Stage-3 hard-gate core entry module slightly thinner and reduces unnecessary dependency noise.
