### PR TITLE
Discrepancy: regression examples for disc/discrepancy coherence

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -75,6 +75,19 @@ example : discOffset' f m d n = discOffset f d m n := by
 example : discOffsetUpTo' f m d n = discOffsetUpTo f d m n := by
   rfl
 
+-- NEW (Track B): nucleus API coherence (disc/discrepancy wrappers)
+example : disc f d n = discrepancy f d n := by
+  rfl
+
+example : Int.natAbs (apSum f d n) = disc f d n := by
+  rfl
+
+example : Int.natAbs (apSum f d n) = discrepancy f d n := by
+  rfl
+
+example : discFrom f 0 d n = disc f d n := by
+  simpa using (discFrom_zero_start (f := f) (d := d) (n := n))
+
 /-!
 ### NEW (Track B): `Icc` ↔ `apSumOffset` normal form (affine endpoints)
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: “Nucleus API coherence” pass: audit naming / argument order consistency across `apSum`/`apSumOffset`/`apSumFrom` and `discrepancy`/`discOffset`/`discOffsetUpTo` wrappers; propose 1–2 targeted renames + deprecated aliases (not a mass rename), with a stable-surface regression example confirming imports don’t break.

What this PR does
- Adds compile-only regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean` confirming that:
  - the new homogeneous wrapper `disc` is definitionally coherent with `discrepancy`,
  - the `Int.natAbs (apSum …)` simp bridges land on both wrappers,
  - the affine wrapper `discFrom` coheres with `disc` at start index `a = 0`.

Why
- The renames/aliases for nucleus API coherence live in the core files (e.g. `disc`, `apSumOffset'`, etc.).
  This PR provides the “stable-surface regression examples” requested by the checklist item so CI will catch
  accidental breakage of those wrappers under `import MoltResearch.Discrepancy`.

CI
- `make ci`
