### PR TITLE
Track B: Nucleus API coherence checklist item

### DIFF
--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -1136,7 +1136,8 @@ Definition of done:
   paper sum → nucleus → residue split → `discOffsetUpTo` bound → clean inequality, and wire it into `SurfaceAudit` so the intended pipeline stays one-line usable.
   (Implemented as `MoltResearch/Discrepancy/ResidueMaxPipelineExample.lean`, imported by `MoltResearch/Discrepancy/SurfaceAudit.lean`.)
 
-- [ ] “Nucleus API coherence” pass: audit naming / argument order consistency across `apSum`/`apSumOffset`/`apSumFrom` and `discrepancy`/`discOffset`/`discOffsetUpTo` wrappers; propose 1–2 targeted renames + deprecated aliases (not a mass rename), with a stable-surface regression example confirming imports don’t break.
+- [x] “Nucleus API coherence” pass: audit naming / argument order consistency across `apSum`/`apSumOffset`/`apSumFrom` and `discrepancy`/`discOffset`/`discOffsetUpTo` wrappers; propose 1–2 targeted renames + deprecated aliases (not a mass rename), with a stable-surface regression example confirming imports don’t break.
+  (Implemented via coherence aliases `apSumOffset'` / `discOffset'` / `discOffsetUpTo'` and the homogeneous `disc` wrapper in `MoltResearch/Discrepancy/Basic.lean`, with stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
 ### Track C - Conjecture stub + equivalences (backlog)
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: “Nucleus API coherence” pass

This marks the Track B checklist item as complete now that the nucleus/coherence wrappers are in place:
- `apSumOffset'` / `discOffset'` / `discOffsetUpTo'` argument-order aliases
- homogeneous `disc` wrapper (coherent with `discrepancy`)

Stable-surface regression coverage lives in `MoltResearch/Discrepancy/NormalFormExamples.lean` (importing `MoltResearch.Discrepancy`).

CI: `make ci`