### PR TITLE
Track C: apSumFrom witness packaging in Stage-3 core

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
@@ -87,6 +87,48 @@ theorem stage3_exists_params_one_le_forall_exists_natAbs_apSumOffset_gt_witness_
   intro B
   simpa using out.out2.forall_exists_natAbs_apSumOffset_gt_witness_pos (f := f) B
 
+/-- Stage 3 yields concrete parameters `d, m` (with `1 ≤ d`) such that the affine-tail nuclei
+`apSumFrom f (m*d) d n` take arbitrarily large absolute values.
+
+Normal form:
+`∃ d m, 1 ≤ d ∧ ∀ C, ∃ n, Int.natAbs (apSumFrom f (m*d) d n) > C`.
+
+This is a pipeline-friendly normal form derived directly from the Stage-2 offset-unboundedness
+witness.
+-/
+theorem stage3_exists_params_one_le_forall_exists_natAbs_apSumFrom_mul_gt (f : ℕ → ℤ)
+    (hf : IsSignSequence f) :
+    ∃ d m : ℕ, 1 ≤ d ∧
+      (∀ C : ℕ, ∃ n : ℕ, Int.natAbs (apSumFrom f (m * d) d n) > C) := by
+  let out := stage3Out (f := f) (hf := hf)
+  refine ⟨out.out2.d, out.out2.m, out.out2.one_le_d (f := f), ?_⟩
+  have hunb : UnboundedDiscOffset f out.out2.d out.out2.m := out.out2.unboundedDiscOffset (f := f)
+  intro C
+  rcases
+      (UnboundedDiscOffset.forall_exists_natAbs_apSumFrom_mul_gt_witness_pos
+            (f := f) (d := out.out2.d) (m := out.out2.m) hunb)
+          C with
+    ⟨n, _hnpos, hgt⟩
+  exact ⟨n, hgt⟩
+
+/-- Positive-length witness variant of `stage3_exists_params_one_le_forall_exists_natAbs_apSumFrom_mul_gt`.
+
+Normal form:
+`∃ d m, 1 ≤ d ∧ ∀ C, ∃ n, n > 0 ∧ Int.natAbs (apSumFrom f (m*d) d n) > C`.
+-/
+theorem stage3_exists_params_one_le_forall_exists_natAbs_apSumFrom_mul_gt_witness_pos (f : ℕ → ℤ)
+    (hf : IsSignSequence f) :
+    ∃ d m : ℕ, 1 ≤ d ∧
+      (∀ C : ℕ, ∃ n : ℕ, n > 0 ∧ Int.natAbs (apSumFrom f (m * d) d n) > C) := by
+  let out := stage3Out (f := f) (hf := hf)
+  refine ⟨out.out2.d, out.out2.m, out.out2.one_le_d (f := f), ?_⟩
+  have hunb : UnboundedDiscOffset f out.out2.d out.out2.m := out.out2.unboundedDiscOffset (f := f)
+  intro C
+  simpa using
+    (UnboundedDiscOffset.forall_exists_natAbs_apSumFrom_mul_gt_witness_pos
+          (f := f) (d := out.out2.d) (m := out.out2.m) hunb)
+      C
+
 /-- Paper-notation variant of `stage3_exists_params_one_le_forall_exists_natAbs_apSumOffset_gt_witness_pos`.
 
 Normal form:

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Proof.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Proof.lean
@@ -178,35 +178,15 @@ use them without importing this larger convenience-lemma file.
 Since this module imports `TrackCStage3Entry`, those lemmas are available automatically here.
 -/
 
-/-- Consumer-facing shortcut: Stage 3 yields concrete parameters `d, m` with `1 ≤ d` such that the
-affine-tail nucleus `apSumFrom f (m*d) d n` takes arbitrarily large absolute values.
+/-
+Note: the lemmas
 
-This is a thin wrapper around the Stage-3 boundary API lemma
-`Stage3Output.exists_params_one_le_forall_exists_natAbs_apSumFrom_mul_gt`.
+  stage3_exists_params_one_le_forall_exists_natAbs_apSumFrom_mul_gt
+  stage3_exists_params_one_le_forall_exists_natAbs_apSumFrom_mul_gt_witness_pos
+
+live in `TrackCStage3EntryCore.lean` so pipeline consumers can access them without importing this
+larger convenience-lemma file.
 -/
-theorem stage3_exists_params_one_le_forall_exists_natAbs_apSumFrom_mul_gt (f : ℕ → ℤ)
-    (hf : IsSignSequence f) :
-    ∃ d m : ℕ, 1 ≤ d ∧
-      (∀ C : ℕ, ∃ n : ℕ, Int.natAbs (apSumFrom f (m * d) d n) > C) := by
-  simpa using
-    (Stage3Output.exists_params_one_le_forall_exists_natAbs_apSumFrom_mul_gt (f := f)
-      (stage3Out (f := f) (hf := hf)))
-
-/-- Positive-length witness variant of `stage3_exists_params_one_le_forall_exists_natAbs_apSumFrom_mul_gt`.
-
-Normal form:
-`∃ d m, 1 ≤ d ∧ ∀ C, ∃ n, n > 0 ∧ Int.natAbs (apSumFrom f (m*d) d n) > C`.
-
-This is a thin wrapper around the Stage-3 boundary API lemma
-`Stage3Output.exists_params_one_le_forall_exists_natAbs_apSumFrom_mul_gt_witness_pos`.
--/
-theorem stage3_exists_params_one_le_forall_exists_natAbs_apSumFrom_mul_gt_witness_pos (f : ℕ → ℤ)
-    (hf : IsSignSequence f) :
-    ∃ d m : ℕ, 1 ≤ d ∧
-      (∀ C : ℕ, ∃ n : ℕ, n > 0 ∧ Int.natAbs (apSumFrom f (m * d) d n) > C) := by
-  simpa using
-    (Stage3Output.exists_params_one_le_forall_exists_natAbs_apSumFrom_mul_gt_witness_pos (f := f)
-      (stage3Out (f := f) (hf := hf)))
 
 /-- Consumer-facing shortcut: Stage 3 yields concrete parameters `d, m` with `1 ≤ d` such that the
 bundled offset nucleus `apSumOffset f d m n` takes arbitrarily large absolute values.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Moved the affine-tail apSumFrom witness packaging into TrackCStage3EntryCore so pipeline consumers can access it without importing the larger TrackCStage3Proof layer.
- TrackCStage3Proof now just notes that these lemmas live in the core entry module (no duplicate definitions).
