### PR TITLE
Track C: export Stage3Output d/g projections

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
@@ -41,6 +41,14 @@ This is occasionally useful when later stages want access to the deterministic p
 @[simp] abbrev out1 (out : Stage3Output f) : Tao2015.ReductionOutput f :=
   out.out2.out1
 
+/-- Convenience projection: the reduced step size packaged in Stage 3. -/
+@[simp] abbrev d (out : Stage3Output f) : ℕ :=
+  out.out2.d
+
+/-- Convenience projection: the reduced sequence packaged in Stage 3. -/
+@[simp] abbrev g (out : Stage3Output f) : ℕ → ℤ :=
+  out.out2.g
+
 /-- Stage 3 already closes the global goal `¬ BoundedDiscrepancy f`.
 
 We intentionally do not store this as a field: it is derived from the Stage-2 output.

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Core.lean
@@ -36,19 +36,9 @@ We avoid re-declaring it here so that `TrackCStage3Core` can be imported alongsi
 `TrackCStage3` without name clashes.
 -/
 
-/-- Convenience projection: the reduced step size packaged in Stage 3.
-
-We intentionally route this through the Stage-2 boundary API (`Stage2Output.d`) so Stage 3 does not
-depend on Stage-1 record fields.
--/
-@[simp] abbrev d (out : Stage3Output f) : ℕ := out.out2.d
-
-/-- Convenience projection: the reduced sequence packaged in Stage 3.
-
-We intentionally route this through the Stage-2 boundary API (`Stage2Output.g`) so Stage 3 does not
-depend on Stage-1 record fields.
--/
-@[simp] abbrev g (out : Stage3Output f) : ℕ → ℤ := out.out2.g
+-- Note: the basic projections `Stage3Output.d` and `Stage3Output.g` live in
+-- `Conjectures.C0002_erdos_discrepancy.src.TrackCStage3` so that hard-gate consumers can access
+-- them without importing `TrackCStage3Core`.
 
 /-- The reduced sequence packaged in Stage 3 is a sign sequence. -/
 theorem hg (out : Stage3Output f) : IsSignSequence out.g := by


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Expose Stage3Output.d and Stage3Output.g directly from the hard-gate Stage 3 boundary module.
- Remove the duplicate definitions from TrackCStage3Core so downstream code can access these projections without importing the core file.
- No semantic change: these are definitional projections through the bundled Stage-2 output.
