### PR TITLE
Track C: stage2 discOffset NNF lemma in core

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
@@ -182,6 +182,23 @@ theorem not_exists_boundedDiscOffset (out : Stage2Output f) :
         (d := out.d) (m := out.m)).1
       hunb
 
+/-- Negation-normal-form unboundedness statement for the bundled offset discrepancies
+`discOffset f out.d out.m`.
+
+Negation-normal form:
+`¬ ∃ B, ∀ n, discOffset f out.d out.m n ≤ B`.
+
+This is a thin wrapper around
+`Tao2015.unboundedDiscOffset_iff_not_exists_forall_discOffset_le`.
+-/
+theorem not_exists_forall_discOffset_le (out : Stage2Output f) :
+    ¬ ∃ B : ℕ, ∀ n : ℕ, discOffset f out.d out.m n ≤ B := by
+  have hunb : UnboundedDiscOffset f out.d out.m := out.unboundedDiscOffset (f := f)
+  exact
+    (Tao2015.unboundedDiscOffset_iff_not_exists_forall_discOffset_le (f := f)
+        (d := out.d) (m := out.m)).1
+      hunb
+
 /-!
 ## Core-predicate bridge
 -/

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
@@ -143,22 +143,8 @@ convenience-lemma file.
 
 -- Note: downstream hard-gate stages should prefer the smaller API in `TrackCStage2Core.lean`.
 
-/-- Negation-normal-form unboundedness statement for the bundled offset discrepancies
-`discOffset f out.d out.m`.
-
-Negation-normal form:
-`¬ ∃ B, ∀ n, discOffset f out.d out.m n ≤ B`.
-
-This is a thin wrapper around
-`Tao2015.unboundedDiscOffset_iff_not_exists_forall_discOffset_le`.
--/
-theorem not_exists_forall_discOffset_le (out : Stage2Output f) :
-    ¬ ∃ B : ℕ, ∀ n : ℕ, discOffset f out.d out.m n ≤ B := by
-  have hunb : UnboundedDiscOffset f out.d out.m := out.unboundedDiscOffset (f := f)
-  exact
-    (Tao2015.unboundedDiscOffset_iff_not_exists_forall_discOffset_le (f := f)
-        (d := out.d) (m := out.m)).1
-      hunb
+-- Note: `Stage2Output.not_exists_forall_discOffset_le` is part of the Stage-2 core API:
+-- see `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Core`.
 
 /-- Negation-normal-form unboundedness statement for the bundled offset nuclei
 `Int.natAbs (apSumOffset f out.d out.m n)`.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Moved Stage2Output.not_exists_forall_discOffset_le into TrackCStage2Core so later stages can access the negation-normal-form discOffset statement without importing the larger Stage-2 output-lemma file.
- TrackCStage2Output now just points to the core location for that lemma (no behavioral change).
