### PR TITLE
Discrepancy: d=0 normal-form simp API

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -47,7 +47,10 @@ The goal is to pair verified artifacts with learning scaffolding.
   This is the bridge that lets later steps rewrite boundedness hypotheses into a one-line max bound.
 - **API note (max recursion):** when you need to peel the last case off a cutoff, rewrite `discOffsetUpTo f d m (N+1)` using `discOffsetUpTo_succ` to get a clean `max (discOffsetUpTo … N) (discOffset … (N+1))` normal form.
 - **API note (step positivity):** when extracting unboundedness witnesses, prefer the `Nat.succ` normal forms (`HasDiscrepancyAtLeast.exists_witness_succ(_pos)` and the affine analogue) so you can work with a concrete positive step without carrying a separate `d ≥ 1` side condition.
-  The corner case `d = 0` has `simp` normal forms too, but those are now behind `import MoltResearch.Discrepancy.Deprecated` to keep the stable surface focused on the `d ≥ 1` workflow.
+  The degenerate corner case `d = 0` also has stable-surface simp normal forms:
+  - `apSum_zero_step`: `apSum f 0 n = (n : ℤ) * f 0`
+  - `apSumOffset_zero_step`: `apSumOffset f 0 m n = (n : ℤ) * f 0`
+  - `discOffset_zero_step`: `discOffset f 0 m n = Int.natAbs ((n : ℤ) * f 0)`
 - **API note (monotone-in-`C`):** `HasDiscrepancyAtLeast f C` is **antitone** in `C` (the witness inequality is `> C`).
   Use `HasDiscrepancyAtLeast.mono` to *lower* the bound, and the contrapositive lemma
   `HasDiscrepancyAtLeast.not_mono` to *raise* bounds under negation (useful for boundedness normal forms).

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -847,6 +847,36 @@ We are conservative here: these lemmas should be obviously terminating and orien
   simp [discOffset, disc, apSumOffset, apSum]
 
 /-!
+### Degenerate-step (`d = 0`) normal forms
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) —
+Degenerate-step normal forms (`d = 0`).
+
+When the step is `0`, every index in the progression is `0`.
+These lemmas provide a preferred simp/rewrite API so downstream code can normalize the `d = 0`
+case without ad-hoc arithmetic.
+
+We keep these lemmas forward-oriented and obviously terminating.
+-/
+
+@[simp] lemma apSum_zero_step (f : ℕ → ℤ) (n : ℕ) :
+    apSum f 0 n = (n : ℤ) * f 0 := by
+  unfold apSum
+  -- `(i+1) * 0 = 0`, so this is a constant-sum over `range n`.
+  simp
+
+@[simp] lemma apSumOffset_zero_step (f : ℕ → ℤ) (m n : ℕ) :
+    apSumOffset f 0 m n = (n : ℤ) * f 0 := by
+  unfold apSumOffset
+  -- `(m+i+1) * 0 = 0`, so this is also a constant-sum.
+  simp
+
+@[simp] lemma discOffset_zero_step (f : ℕ → ℤ) (m n : ℕ) :
+    discOffset f 0 m n = Int.natAbs ((n : ℤ) * f 0) := by
+  unfold discOffset
+  simp
+
+/-!
 ### Step-one (`d = 1`) coherence simp lemmas
 
 Checklist item: Problems/erdos_discrepancy.md (Track B) —

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -64,6 +64,16 @@ example : apSum (fun _ => (1 : ℤ)) d n = (n : ℤ) := by
 example : discOffset (fun _ => (1 : ℤ)) d m n = n := by
   simpa [discOffset_const_one]
 
+-- NEW (Track B): degenerate-step normal forms (`d = 0`)
+example : apSum f 0 n = (n : ℤ) * f 0 := by
+  simp
+
+example : apSumOffset f 0 m n = (n : ℤ) * f 0 := by
+  simp
+
+example : discOffset f 0 m n = Int.natAbs ((n : ℤ) * f 0) := by
+  simp
+
 -- NEW (Track B): nucleus API coherence (argument order)
 example : apSumOffset' f m d n = apSumOffset f d m n := by
   rfl


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Degenerate-step normal forms (`d = 0`): add a preferred simp/rewrite API for `apSum`/`apSumOffset`/`discOffset` when the step is zero (everything hits index 0), so downstream code can safely normalize or rule out `d=0` without ad-hoc arithmetic.

Summary:
- Add forward-oriented simp lemmas normalizing the `d = 0` case:
  - `apSum f 0 n = (n : ℤ) * f 0`
  - `apSumOffset f 0 m n = (n : ℤ) * f 0`
  - `discOffset f 0 m n = Int.natAbs ((n : ℤ) * f 0)`
- Add stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean` to ensure these are available via `import MoltResearch.Discrepancy`.

Notes:
- Lemmas are intentionally forward-oriented and terminating; no reverse rewrite lemmas are introduced.
