### PR TITLE
Track B: close degenerate-step normal forms item

### DIFF
--- a/MoltResearch/Discrepancy/Deprecated.lean
+++ b/MoltResearch/Discrepancy/Deprecated.lean
@@ -19,46 +19,16 @@ If you need older names (e.g. `*_map_add` wrappers), import this file explicitly
 namespace MoltResearch
 
 /-!
-## Degenerate-step (`d = 0`) simp normal forms (corner-case surface)
+## Degenerate-step (`d = 0`) simp normal forms
 
-These lemmas are oriented for `simp` and keep the `d = 0` corner case from unfolding `apSum`/
-`apSumOffset` into `Finset` sums.
+These were historically provided by this module, but they are now part of the stable surface
+(`import MoltResearch.Discrepancy`) as the simp lemmas:
+- `apSum_zero_step`
+- `apSumOffset_zero_step`
+- `discOffset_zero_step`
 
-They used to be part of the stable surface (`import MoltResearch.Discrepancy`) but are now behind
-this deprecated surface module.
+So we do not redeclare them here.
 -/
-
-/-- Degenerate step (`d = 0`): the sampled index is always `0`, so the sum is a constant sum. -/
-@[simp] lemma apSum_zero_step (f : ℕ → ℤ) (n : ℕ) :
-    apSum f 0 n = (n : ℤ) * f 0 := by
-  classical
-  unfold apSum
-  simp
-
-/-- Degenerate step (`d = 0`) at the homogeneous discrepancy wrapper `disc` level. -/
-@[simp] lemma disc_zero_step (f : ℕ → ℤ) (n : ℕ) :
-    disc f 0 n = Int.natAbs ((n : ℤ) * f 0) := by
-  unfold disc
-  simp [apSum_zero_step]
-
-/-- Degenerate step (`d = 0`) at the homogeneous discrepancy wrapper `discrepancy` level. -/
-@[simp] lemma discrepancy_zero_step (f : ℕ → ℤ) (n : ℕ) :
-    discrepancy f 0 n = Int.natAbs ((n : ℤ) * f 0) := by
-  unfold discrepancy
-  simp [apSum_zero_step]
-
-/-- Degenerate step (`d = 0`): the sampled index is always `0`, so the offset sum is constant. -/
-@[simp] lemma apSumOffset_zero_step (f : ℕ → ℤ) (m n : ℕ) :
-    apSumOffset f 0 m n = (n : ℤ) * f 0 := by
-  classical
-  unfold apSumOffset
-  simp
-
-/-- Degenerate step (`d = 0`) at the `discOffset` level. -/
-@[simp] lemma discOffset_zero_step (f : ℕ → ℤ) (m n : ℕ) :
-    discOffset f 0 m n = Int.natAbs ((n : ℤ) * f 0) := by
-  unfold discOffset
-  simp
 
 
 /-- Deprecated name for `IsSignSequence.shift_add`. -/

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -1141,7 +1141,8 @@ Definition of done:
 
 #### Auto-generated backlog (needs triage)
 
-- [ ] Degenerate-step normal forms (`d = 0`): add a preferred simp/rewrite API for `apSum`/`apSumOffset`/`discOffset` when the step is zero (everything hits index 0), so downstream code can safely normalize or rule out `d=0` without ad-hoc arithmetic.
+- [x] Degenerate-step normal forms (`d = 0`): add a preferred simp/rewrite API for `apSum`/`apSumOffset`/`discOffset` when the step is zero (everything hits index 0), so downstream code can safely normalize or rule out `d=0` without ad-hoc arithmetic.
+  (Implemented as `[simp]` lemmas `apSum_zero_step` / `apSumOffset_zero_step` / `discOffset_zero_step` in `MoltResearch/Discrepancy/Basic.lean`, with stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
 - [ ] Homogeneous Icc↔offset bridge: add a one-line rewrite lemma specializing the affine endpoint normal form to `a=0`, e.g.
   `∑ i ∈ Finset.Icc (m+1) (m+n), f (i*d) = apSumOffset (fun k => f (k*d)) d m n` (or repo’s preferred shape), with a stable-surface regression example.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Degenerate-step normal forms (`d = 0`): add a preferred simp/rewrite API for `apSum`/`apSumOffset`/`discOffset` when the step is zero (everything hits index 0), so downstream code can safely normalize or rule out `d=0` without ad-hoc arithmetic.

What this PR does
- Marks the above checklist item as completed, with pointers to the existing `[simp]` lemmas (`apSum_zero_step`, `apSumOffset_zero_step`, `discOffset_zero_step`) and the stable-surface regression examples.
- Fixes a CI failure: `MoltResearch/Discrepancy/Deprecated.lean` was redeclaring the same degenerate-step lemmas that now live in the stable surface, causing duplicate-definition errors.

Notes
- No new lemmas added; this is checklist bookkeeping + deprecation-surface hygiene.
