### PR TITLE
Track B: homogeneous Icc↔offset bridge

### DIFF
--- a/MoltResearch/Discrepancy/Offset.lean
+++ b/MoltResearch/Discrepancy/Offset.lean
@@ -888,10 +888,12 @@ lemma apSumOffset_one_d_range_add_left (f : ℕ → ℤ) (m n : ℕ) :
     apSumOffset f 1 m n = (Finset.range n).sum (fun i => f ((m + 1) + i)) := by
   simpa [Nat.add_comm] using (apSumOffset_one_d_range (f := f) (m := m) (n := n))
 
-/-- Normal form: rewrite the “paper notation” interval sum `∑ i ∈ Icc (m+1) (m+n), f (i*d)` back
-to `apSumOffset`.
+/-- Normal form: rewrite the “paper notation” interval sum
+`∑ i ∈ Icc (m+1) (m+n), f (i*d)` back to `apSumOffset`.
 
 This is useful when starting from a surface statement and normalizing into the nucleus API.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — Homogeneous Icc↔offset bridge.
 -/
 lemma sum_Icc_eq_apSumOffset (f : ℕ → ℤ) (d m n : ℕ) :
     (Finset.Icc (m + 1) (m + n)).sum (fun i => f (i * d)) = apSumOffset f d m n := by

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -1144,8 +1144,8 @@ Definition of done:
 - [x] Degenerate-step normal forms (`d = 0`): add a preferred simp/rewrite API for `apSum`/`apSumOffset`/`discOffset` when the step is zero (everything hits index 0), so downstream code can safely normalize or rule out `d=0` without ad-hoc arithmetic.
   (Implemented as `[simp]` lemmas `apSum_zero_step` / `apSumOffset_zero_step` / `discOffset_zero_step` in `MoltResearch/Discrepancy/Basic.lean`, with stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
-- [ ] Homogeneous Icc↔offset bridge: add a one-line rewrite lemma specializing the affine endpoint normal form to `a=0`, e.g.
-  `∑ i ∈ Finset.Icc (m+1) (m+n), f (i*d) = apSumOffset (fun k => f (k*d)) d m n` (or repo’s preferred shape), with a stable-surface regression example.
+- [x] Homogeneous Icc↔offset bridge: add a one-line rewrite lemma specializing the affine endpoint normal form to `a=0`, e.g.
+  `∑ i ∈ Finset.Icc (m+1) (m+n), f (i*d) = apSumOffset f d m n` (or repo’s preferred shape), with a stable-surface regression example.
 
 - [ ] “Offset is just tail” for `apSupport`: package a lemma rewriting `apSupport f d m n` into the image of a `Finset.range n` map (or equivalent), so support-level congruence proofs can be done by `simp` instead of unfolding.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Homogeneous Icc↔offset bridge

What this does
- Marks the Track B backlog item as complete (the bridge lemma already exists on the stable surface as `sum_Icc_eq_apSumOffset`).
- Adds an explicit checklist tag to the lemma’s docstring to make future audits easier.

Notes
- Stable-surface regression already lives in `MoltResearch/Discrepancy/NormalFormExamples.lean` (paper tail interval sum → `apSumOffset`).
