### PR TITLE
Discrepancy: apSupport = range image (Track B)

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -69,6 +69,7 @@ The goal is to pair verified artifacts with learning scaffolding.
   `apSupport_add_left_zero` and `apSupport_mul_right_one` so `simp` can discharge trivial `m+0` / `d*1` noise without unfolding.
   For unfold-free membership reasoning, use `mem_apSupport_iff`, or the binder-notation variant `mem_apSupport` when you want to feed the result directly to `simp`/`rcases` as `∃ i < n, ...`.
   If you want the *paper endpoint convention* (`m < i ∧ i ≤ m+n` with accessed index `i*d`), use `mem_apSupport_iff_exists_endpoints`.
+  If you want to expose the underlying `Finset.range` image form of the support (to map/filter/count over it) without unfolding the definition, rewrite via `apSupport_eq_image_range`.
 - **API note (`apSupport` canonical membership):** if your membership goal is already in the normal form
   `((m + i + 1) * d) ∈ apSupport d m n`, and you have `hd : d > 0`, then `simp [mem_apSupport_index_iff (m := m) (n := n) (i := i) hd]` reduces it to the expected bound `i < n`.
 - **API note (`apSupport` size / no collisions):** if you need a cardinality statement, use `card_apSupport (m := m) (n := n) (hd := hd)` to rewrite

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -282,6 +282,18 @@ the support still contains that index just once).
 def apSupport (d m n : ℕ) : Finset ℕ :=
   (Finset.range n).image (fun i => (m + i + 1) * d)
 
+/-!
+### “Offset is just tail” packaging lemma (Track B)
+
+Downstream, we often want to push `apSupport d m n` into the explicit `Finset.range` image form
+without unfolding the definition. This lemma is a stable, simp-friendly rewrite target.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — “Offset is just tail” for `apSupport`.
+-/
+lemma apSupport_eq_image_range (d m n : ℕ) :
+    apSupport d m n = (Finset.range n).image (fun i => (m + i + 1) * d) := by
+  rfl
+
 /-- Degenerate case: no indices are accessed when `n = 0`. -/
 @[simp] lemma apSupport_zero (d m : ℕ) : apSupport d m 0 = ∅ := by
   unfold apSupport

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -162,6 +162,10 @@ start-shift bookkeeping.
 example : apSupport d (m + 0) n = apSupport d m n := by
   simp
 
+-- NEW (Track B): “offset is just tail” packaging for `apSupport`.
+example : apSupport d m n = (Finset.range n).image (fun i => (m + i + 1) * d) := by
+  simpa using (apSupport_eq_image_range (d := d) (m := m) (n := n))
+
 example :
     apSumOffset f d (m + (n₁ + n₂)) n =
       apSumOffset (fun t => f (t + (n₁ + n₂) * d)) d m n := by


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: “Offset is just tail” for `apSupport`: package a lemma rewriting `apSupport f d m n` into the image of a `Finset.range n` map (or equivalent), so support-level congruence proofs can be done by `simp` instead of unfolding.

Adds `apSupport_eq_image_range` as a stable interface lemma (no definitional unfolding needed), plus a compile-only regression example under `import MoltResearch.Discrepancy`.
