### PR TITLE
Track B: apSupport ‘offset is just tail’ packaging

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -89,6 +89,16 @@ example : discOffsetUpTo' f m d n = discOffsetUpTo f d m n := by
 example : disc f d n = discrepancy f d n := by
   rfl
 
+/-!
+### NEW (Track B): “Offset is just tail” for `apSupport`
+
+Compile-only regression: we can rewrite `apSupport d m n` to its `range`-image normal form using a
+named lemma (so downstream proofs can do `simp [apSupport_eq_image_range]` instead of unfolding).
+-/
+
+example : apSupport d m n = (Finset.range n).image (fun i => (m + i + 1) * d) := by
+  simp [apSupport_eq_image_range]
+
 example : Int.natAbs (apSum f d n) = disc f d n := by
   rfl
 

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -1147,7 +1147,7 @@ Definition of done:
 - [x] Homogeneous Icc↔offset bridge: add a one-line rewrite lemma specializing the affine endpoint normal form to `a=0`, e.g.
   `∑ i ∈ Finset.Icc (m+1) (m+n), f (i*d) = apSumOffset f d m n` (or repo’s preferred shape), with a stable-surface regression example.
 
-- [ ] “Offset is just tail” for `apSupport`: package a lemma rewriting `apSupport f d m n` into the image of a `Finset.range n` map (or equivalent), so support-level congruence proofs can be done by `simp` instead of unfolding.
+- [x] “Offset is just tail” for `apSupport`: package a lemma rewriting `apSupport f d m n` into the image of a `Finset.range n` map (or equivalent), so support-level congruence proofs can be done by `simp` instead of unfolding. (`apSupport_eq_image_range`)
 
 - [ ] Max-level subadditivity: prove a clean inequality like
   `discOffsetUpTo f d m (N+K) ≤ discOffsetUpTo f d m N + discOffsetUpTo f d (m+N) K`


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: “Offset is just tail” for `apSupport`: package a lemma rewriting `apSupport f d m n` into the image of a `Finset.range n` map (or equivalent), so support-level congruence proofs can be done by `simp` instead of unfolding.

What changed:
- Marked the checklist item complete.
- Added a stable-surface regression example (`MoltResearch/Discrepancy/NormalFormExamples.lean`) showing `apSupport d m n` rewrites to the `Finset.range`-image normal form via `simp [apSupport_eq_image_range]`.

Notes:
- We deliberately did **not** add `[simp]` to `apSupport_eq_image_range`, since doing so caused simp to rewrite aggressively and broke existing proofs in `Basic.lean`.
