### PR TITLE
Track C: move Stage-2 witness wrappers out of hard-gate core

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
@@ -99,76 +99,6 @@ theorem unboundedDiscOffset (out : Stage2Output f) : UnboundedDiscOffset f out.d
   simpa using
     ((out.out1.unboundedDiscrepancyAlong_iff_unboundedDiscOffset (f := f))).1 out.unbounded
 
-/-- Positive-length witness form: Stage 2 yields arbitrarily large bundled offset discrepancies
-`discOffset f out.d out.m n`, with witnesses `n > 0`.
-
-This is a thin wrapper around
-`Tao2015.UnboundedDiscOffset.forall_exists_discOffset_gt'_witness_pos`.
--/
-theorem forall_exists_discOffset_gt'_witness_pos (out : Stage2Output f) :
-    ∀ B : ℕ, ∃ n : ℕ, n > 0 ∧ discOffset f out.d out.m n > B := by
-  have hunb : UnboundedDiscOffset f out.d out.m := out.unboundedDiscOffset (f := f)
-  simpa using
-    (Tao2015.UnboundedDiscOffset.forall_exists_discOffset_gt'_witness_pos
-      (f := f) (d := out.d) (m := out.m) hunb)
-
-/-- Witness form: Stage 2 yields arbitrarily large bundled offset discrepancies `discOffset ... > B`.
-
-This is just `forall_exists_discOffset_gt'_witness_pos` with the positivity side condition dropped.
--/
-theorem forall_exists_discOffset_gt' (out : Stage2Output f) :
-    ∀ B : ℕ, ∃ n : ℕ, discOffset f out.d out.m n > B := by
-  intro B
-  rcases out.forall_exists_discOffset_gt'_witness_pos (f := f) B with ⟨n, _hnpos, hn⟩
-  exact ⟨n, hn⟩
-
-/-- Positive-length witness form: Stage 2 yields arbitrarily large bundled offset discrepancies
-`discOffset f out.d out.m n`, with witnesses `n > 0`.
-
-This is `forall_exists_discOffset_gt'_witness_pos` rewritten using `gt_iff_lt`.
--/
-theorem forall_exists_discOffset_gt_witness_pos (out : Stage2Output f) :
-    ∀ B : ℕ, ∃ n : ℕ, n > 0 ∧ B < discOffset f out.d out.m n := by
-  intro B
-  rcases out.forall_exists_discOffset_gt'_witness_pos (f := f) B with ⟨n, hnpos, hn⟩
-  exact ⟨n, hnpos, (gt_iff_lt).1 hn⟩
-
-/-- Witness-family form: Stage 2 yields arbitrarily large bundled offset discrepancies, written as
-`B < discOffset ...`.
-
-This is `forall_exists_discOffset_gt_witness_pos` with the positivity side condition dropped.
--/
-theorem forall_exists_discOffset_gt (out : Stage2Output f) :
-    ∀ B : ℕ, ∃ n : ℕ, B < discOffset f out.d out.m n := by
-  intro B
-  rcases out.forall_exists_discOffset_gt_witness_pos (f := f) B with ⟨n, _hnpos, hn⟩
-  exact ⟨n, hn⟩
-
-/-- Positive-length witness form: Stage 2 yields arbitrarily large bundled offset nuclei
-`Int.natAbs (apSumOffset f out.d out.m n)`, with witnesses `n > 0`.
-
-This is a thin wrapper around
-`Tao2015.UnboundedDiscOffset.forall_exists_natAbs_apSumOffset_gt_witness_pos`.
--/
-theorem forall_exists_natAbs_apSumOffset_gt_witness_pos (out : Stage2Output f) :
-    ∀ B : ℕ, ∃ n : ℕ, n > 0 ∧ Int.natAbs (apSumOffset f out.d out.m n) > B := by
-  have hunb : UnboundedDiscOffset f out.d out.m := out.unboundedDiscOffset (f := f)
-  simpa using
-    (Tao2015.UnboundedDiscOffset.forall_exists_natAbs_apSumOffset_gt_witness_pos
-      (f := f) (d := out.d) (m := out.m) hunb)
-
-/-- Witness form: Stage 2 yields arbitrarily large bundled offset nuclei
-`Int.natAbs (apSumOffset f out.d out.m n)`.
-
-This is `forall_exists_natAbs_apSumOffset_gt_witness_pos` with the positivity side condition
-dropped.
--/
-theorem forall_exists_natAbs_apSumOffset_gt (out : Stage2Output f) :
-    ∀ B : ℕ, ∃ n : ℕ, Int.natAbs (apSumOffset f out.d out.m n) > B := by
-  intro B
-  rcases out.forall_exists_natAbs_apSumOffset_gt_witness_pos (f := f) B with ⟨n, _hnpos, hn⟩
-  exact ⟨n, hn⟩
-
 /-- Stage 2 implies there is no uniform bound on the bundled offset discrepancy family
 `discOffset f out.d out.m`.
 
@@ -182,22 +112,10 @@ theorem not_exists_boundedDiscOffset (out : Stage2Output f) :
         (d := out.d) (m := out.m)).1
       hunb
 
-/-- Negation-normal-form unboundedness statement for the bundled offset discrepancies
-`discOffset f out.d out.m`.
-
-Negation-normal form:
-`¬ ∃ B, ∀ n, discOffset f out.d out.m n ≤ B`.
-
-This is a thin wrapper around
-`Tao2015.unboundedDiscOffset_iff_not_exists_forall_discOffset_le`.
--/
-theorem not_exists_forall_discOffset_le (out : Stage2Output f) :
-    ¬ ∃ B : ℕ, ∀ n : ℕ, discOffset f out.d out.m n ≤ B := by
-  have hunb : UnboundedDiscOffset f out.d out.m := out.unboundedDiscOffset (f := f)
-  exact
-    (Tao2015.unboundedDiscOffset_iff_not_exists_forall_discOffset_le (f := f)
-        (d := out.d) (m := out.m)).1
-      hunb
+-- Note: additional witness-form wrappers (e.g. `forall_exists_discOffset_gt'_witness_pos`,
+-- `forall_exists_natAbs_apSumOffset_gt_witness_pos`, and the negation-normal-form
+-- `not_exists_forall_discOffset_le`) live in
+-- `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2CoreExtras`.
 
 /-!
 ## Core-predicate bridge

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2CoreExtras.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2CoreExtras.lean
@@ -88,8 +88,8 @@ theorem boundedDiscOffset_iff_forall_natAbs_apSumFrom_start_le (out : Stage2Outp
     have hn : Int.natAbs (apSumFrom f out.start out.d n) ≤ B := h n
     simpa [out.discOffset_eq_natAbs_apSumFrom_start (f := f) (n := n)] using hn
 
--- Note: `Stage2Output.forall_exists_discOffset_gt_witness_pos` now lives in
--- `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Core`.
+-- Note: additional witness/negation-normal-form wrappers for `discOffset` and `apSumOffset`
+-- live near the end of this file.
 
 /-- The affine-tail start index `out.start` is a multiple of the reduced step size `out.d`. -/
 theorem d_dvd_start (out : Stage2Output f) : out.d ∣ out.start := by
@@ -215,6 +215,103 @@ theorem forall_exists_natAbs_apSumFrom_start_gt (out : Stage2Output f) :
   intro B
   rcases out.forall_exists_natAbs_apSumFrom_mul_gt_witness_pos (f := f) B with ⟨n, _hnpos, hgt⟩
   exact ⟨n, hgt⟩
+
+/-!
+## Offset-discrepancy witness forms (non-hard-gate)
+
+These are convenient witness/negation-normal-form wrappers derived from the proved core lemma
+`Stage2Output.unboundedDiscOffset`.
+
+They are intentionally kept out of `TrackCStage2Core.lean` so the Track-C hard-gate build does not
+compile them.
+-/
+
+/-- Positive-length witness form: Stage 2 yields arbitrarily large bundled offset discrepancies
+`discOffset f out.d out.m n`, with witnesses `n > 0`.
+
+This is a thin wrapper around
+`Tao2015.UnboundedDiscOffset.forall_exists_discOffset_gt'_witness_pos`.
+-/
+theorem forall_exists_discOffset_gt'_witness_pos (out : Stage2Output f) :
+    ∀ B : ℕ, ∃ n : ℕ, n > 0 ∧ discOffset f out.d out.m n > B := by
+  have hunb : UnboundedDiscOffset f out.d out.m := out.unboundedDiscOffset (f := f)
+  simpa using
+    (Tao2015.UnboundedDiscOffset.forall_exists_discOffset_gt'_witness_pos
+      (f := f) (d := out.d) (m := out.m) hunb)
+
+/-- Witness form: Stage 2 yields arbitrarily large bundled offset discrepancies `discOffset ... > B`.
+
+This is just `forall_exists_discOffset_gt'_witness_pos` with the positivity side condition dropped.
+-/
+theorem forall_exists_discOffset_gt' (out : Stage2Output f) :
+    ∀ B : ℕ, ∃ n : ℕ, discOffset f out.d out.m n > B := by
+  intro B
+  rcases out.forall_exists_discOffset_gt'_witness_pos (f := f) B with ⟨n, _hnpos, hn⟩
+  exact ⟨n, hn⟩
+
+/-- Positive-length witness form: Stage 2 yields arbitrarily large bundled offset discrepancies
+`discOffset f out.d out.m n`, with witnesses `n > 0`.
+
+This is `forall_exists_discOffset_gt'_witness_pos` rewritten using `gt_iff_lt`.
+-/
+theorem forall_exists_discOffset_gt_witness_pos (out : Stage2Output f) :
+    ∀ B : ℕ, ∃ n : ℕ, n > 0 ∧ B < discOffset f out.d out.m n := by
+  intro B
+  rcases out.forall_exists_discOffset_gt'_witness_pos (f := f) B with ⟨n, hnpos, hn⟩
+  exact ⟨n, hnpos, (gt_iff_lt).1 hn⟩
+
+/-- Witness-family form: Stage 2 yields arbitrarily large bundled offset discrepancies, written as
+`B < discOffset ...`.
+
+This is `forall_exists_discOffset_gt_witness_pos` with the positivity side condition dropped.
+-/
+theorem forall_exists_discOffset_gt (out : Stage2Output f) :
+    ∀ B : ℕ, ∃ n : ℕ, B < discOffset f out.d out.m n := by
+  intro B
+  rcases out.forall_exists_discOffset_gt_witness_pos (f := f) B with ⟨n, _hnpos, hn⟩
+  exact ⟨n, hn⟩
+
+/-- Positive-length witness form: Stage 2 yields arbitrarily large bundled offset nuclei
+`Int.natAbs (apSumOffset f out.d out.m n)`, with witnesses `n > 0`.
+
+This is a thin wrapper around
+`Tao2015.UnboundedDiscOffset.forall_exists_natAbs_apSumOffset_gt_witness_pos`.
+-/
+theorem forall_exists_natAbs_apSumOffset_gt_witness_pos (out : Stage2Output f) :
+    ∀ B : ℕ, ∃ n : ℕ, n > 0 ∧ Int.natAbs (apSumOffset f out.d out.m n) > B := by
+  have hunb : UnboundedDiscOffset f out.d out.m := out.unboundedDiscOffset (f := f)
+  simpa using
+    (Tao2015.UnboundedDiscOffset.forall_exists_natAbs_apSumOffset_gt_witness_pos
+      (f := f) (d := out.d) (m := out.m) hunb)
+
+/-- Witness form: Stage 2 yields arbitrarily large bundled offset nuclei
+`Int.natAbs (apSumOffset f out.d out.m n)`.
+
+This is `forall_exists_natAbs_apSumOffset_gt_witness_pos` with the positivity side condition
+dropped.
+-/
+theorem forall_exists_natAbs_apSumOffset_gt (out : Stage2Output f) :
+    ∀ B : ℕ, ∃ n : ℕ, Int.natAbs (apSumOffset f out.d out.m n) > B := by
+  intro B
+  rcases out.forall_exists_natAbs_apSumOffset_gt_witness_pos (f := f) B with ⟨n, _hnpos, hn⟩
+  exact ⟨n, hn⟩
+
+/-- Negation-normal-form unboundedness statement for the bundled offset discrepancies
+`discOffset f out.d out.m`.
+
+Negation-normal form:
+`¬ ∃ B, ∀ n, discOffset f out.d out.m n ≤ B`.
+
+This is a thin wrapper around
+`Tao2015.unboundedDiscOffset_iff_not_exists_forall_discOffset_le`.
+-/
+theorem not_exists_forall_discOffset_le (out : Stage2Output f) :
+    ¬ ∃ B : ℕ, ∀ n : ℕ, discOffset f out.d out.m n ≤ B := by
+  have hunb : UnboundedDiscOffset f out.d out.m := out.unboundedDiscOffset (f := f)
+  exact
+    (Tao2015.unboundedDiscOffset_iff_not_exists_forall_discOffset_le (f := f)
+        (d := out.d) (m := out.m)).1
+      hunb
 
 end Stage2Output
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
@@ -160,12 +160,13 @@ theorem notBoundedReducedAlong (out : Stage2Output f) : ¬ BoundedDiscrepancyAlo
 -- Note: downstream hard-gate stages should prefer the smaller API in `TrackCStage2Core.lean`.
 
 -- Note: `Stage2Output.forall_exists_discOffset_gt` and `Stage2Output.forall_exists_discOffset_gt'`
--- are part of the Stage-2 core API (see `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Core`).
+-- live in `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2CoreExtras`.
 
 
 /-!
-Positive-length witness form of `forall_exists_discOffset_gt'` is part of the Stage-2 core API:
-see `Stage2Output.forall_exists_discOffset_gt'_witness_pos` in `TrackCStage2Core.lean`.
+Positive-length witness form of `forall_exists_discOffset_gt'` lives in
+`Conjectures.C0002_erdos_discrepancy.src.TrackCStage2CoreExtras` as
+`Stage2Output.forall_exists_discOffset_gt'_witness_pos`.
 -/
 
 /-!
@@ -179,8 +180,8 @@ convenience-lemma file.
 
 -- Note: downstream hard-gate stages should prefer the smaller API in `TrackCStage2Core.lean`.
 
--- Note: `Stage2Output.not_exists_forall_discOffset_le` is part of the Stage-2 core API:
--- see `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Core`.
+-- Note: `Stage2Output.not_exists_forall_discOffset_le` lives in
+-- `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2CoreExtras`.
 
 /-- Negation-normal-form unboundedness statement for the bundled offset nuclei
 `Int.natAbs (apSumOffset f out.d out.m n)`.

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
@@ -1,4 +1,5 @@
 import Conjectures.C0002_erdos_discrepancy.src.TrackCStage3EntryMinimal
+import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2CoreExtras
 
 /-!
 # Track C: Stage 3 entry point (hard-gate core)


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Slim down TrackCStage2Core by moving non-hard-gate witness/NNF wrappers (discOffset/apSumOffset) into TrackCStage2CoreExtras.
- Keep the hard-gate Stage-2 API focused on unboundedDiscOffset and not_exists_boundedDiscOffset, with a pointer to the extras file for witness forms.
- Update Stage2Output documentation notes and import Stage2CoreExtras in Stage3EntryCore so existing witness packaging continues to work.
