### PR TITLE
discrepancy: simp wrappers for discOffsetUpTo dilation

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -58,6 +58,7 @@ The goal is to pair verified artifacts with learning scaffolding.
   - `discOffsetUpTo f d m 0 = 0`
   - `discOffsetUpTo f d 0 N = discUpTo f d N`
   - step-one shift: `discOffsetUpTo f 1 m N = discUpTo (fun k => f (k + m)) 1 N`
+  - dilation/coarsening: `discOffsetUpTo (fun k => f (q*k)) d m N = discOffsetUpTo f (q*d) m N`
 - **API note (start-shift vs sequence-shift, max-level):** if you want to “advance the start” without pushing arithmetic through the `Finset.sup` definition, rewrite using
   `discOffsetUpTo_add_start`:
   `discOffsetUpTo f d (m + k) N = discOffsetUpTo (fun t => f (t + k*d)) d m N`.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -859,6 +859,36 @@ We are conservative here: these lemmas should be obviously terminating and orien
   simp [discOffset, disc, apSumOffset, apSum]
 
 /-!
+### Dilation/coarsening convenience wrappers
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) —
+`discOffsetUpTo` dilation/coarsening convenience wrappers.
+
+These lemmas let downstream code rewrite `discOffsetUpTo` under a multiplicative dilation
+`k ↦ q*k` of the underlying sequence, without mixing in manual `Nat` algebra.
+They are oriented and marked `[simp]` so `simp` can normalize the dilated form.
+-/
+
+/-- Pull a dilation factor `q` out of the step size argument of `apSumOffset`. -/
+@[simp] lemma apSumOffset_dilate_mul (f : ℕ → ℤ) (q d m n : ℕ) :
+    apSumOffset (fun k => f (q * k)) d m n = apSumOffset f (q * d) m n := by
+  unfold apSumOffset
+  simp [Nat.mul_assoc, Nat.mul_left_comm, Nat.mul_comm]
+
+/-- Pull a dilation factor `q` out of the step size argument of `discOffset`. -/
+@[simp] lemma discOffset_dilate_mul (f : ℕ → ℤ) (q d m n : ℕ) :
+    discOffset (fun k => f (q * k)) d m n = discOffset f (q * d) m n := by
+  unfold discOffset
+  simp [apSumOffset_dilate_mul]
+
+/-- Pull a dilation factor `q` out of the step size argument of `discOffsetUpTo`. -/
+@[simp] lemma discOffsetUpTo_dilate_mul (f : ℕ → ℤ) (q d m N : ℕ) :
+    discOffsetUpTo (fun k => f (q * k)) d m N = discOffsetUpTo f (q * d) m N := by
+  classical
+  unfold discOffsetUpTo
+  simp [discOffset_dilate_mul]
+
+/-!
 ### Degenerate-step (`d = 0`) normal forms
 
 Checklist item: Problems/erdos_discrepancy.md (Track B) —

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -25,6 +25,17 @@ section NormalFormExamples
 variable (f : ℕ → ℤ) (a b d k m n n₁ n₂ p C : ℕ)
 
 /-!
+### NEW (Track B): `discOffsetUpTo` dilation/coarsening convenience wrappers
+
+Compile-only regression test: `simp` should rewrite a dilated `discOffsetUpTo` by pulling the
+factor into the step.
+-/
+
+example (f : ℕ → ℤ) (q d m N : ℕ) :
+    discOffsetUpTo (fun k => f (q * k)) d m N = discOffsetUpTo f (q * d) m N := by
+  simp
+
+/-!
 ### NEW (Track B): step-positivity witness normal forms
 
 These are compile-only regression tests for the “reduce early to `d ≥ 1`” API.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `discOffsetUpTo` dilation/coarsening convenience wrappers: build a small lemma family for rewriting `discOffsetUpTo` under step scaling (`d ↦ d*q`) and length scaling (`N ↦ N*q`) with consistent naming and argument order, so later reductions don’t mix `disc_mul_step_le` with manual `Nat` algebra.

## What
- Added `[simp]` rewrite wrappers in `MoltResearch.Discrepancy.Basic`:
  - `apSumOffset_dilate_mul`
  - `discOffset_dilate_mul`
  - `discOffsetUpTo_dilate_mul`

These normalize
`discOffsetUpTo (fun k => f (q*k)) d m N` → `discOffsetUpTo f (q*d) m N`.

## Regression / stable surface
- Added a compile-only regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean` (imports `MoltResearch.Discrepancy`) that proves the rewrite via `simp`.

## CI
- `make ci`