### PR TITLE
Discrepancy: discOffsetUpTo length-scaling normalization lemmas

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -63,6 +63,9 @@ The goal is to pair verified artifacts with learning scaffolding.
     `discOffsetUpTo_map_mul_right` / `discOffsetUpTo_map_mul_left` (and their `discOffset_*` analogues),
     which package the `((m+i+1)*d)*q = (m+i+1)*(d*q)` index normalization.
     For cutoff scaling bookkeeping, use `discOffsetUpTo_le_mul` (monotonicity under `N ↦ N*q`, assuming `q > 0`).
+    If you just need to normalize the *orientation* of a scaled cutoff (so you can match another lemma’s statement), use:
+    - `discOffsetUpTo_length_mul_comm` to rewrite `discOffsetUpTo f d m (q * N)` into `discOffsetUpTo f d m (N * q)`
+    - `discOffsetUpTo_length_mul_succ_comm` for the common `q * (N+1)` case.
 - **API note (start-shift vs sequence-shift, max-level):** if you want to “advance the start” without pushing arithmetic through the `Finset.sup` definition, rewrite using
   `discOffsetUpTo_add_start`:
   `discOffsetUpTo f d (m + k) N = discOffsetUpTo (fun t => f (t + k*d)) d m N`.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -868,6 +868,28 @@ lemma discOffsetUpTo_map_mul_left (f : ℕ → ℤ) (q d m N : ℕ) :
   simp [discOffset_map_mul_left]
 
 /-!
+### `discOffsetUpTo` length-scaling normalization lemmas
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) —
+`discOffsetUpTo` dilation/coarsening convenience wrappers.
+
+These are intentionally tiny rewrite lemmas: they normalize the *length* argument when it is
+written as `q * N` (or `q * (N+1)`), so downstream code doesn’t need to do ad-hoc `Nat` algebra.
+
+They are **not** tagged `[simp]` to avoid rewrite loops.
+-/
+
+lemma discOffsetUpTo_length_mul_comm (f : ℕ → ℤ) (d m q N : ℕ) :
+    discOffsetUpTo f d m (q * N) = discOffsetUpTo f d m (N * q) := by
+  simpa [Nat.mul_comm] using
+    (rfl : discOffsetUpTo f d m (q * N) = discOffsetUpTo f d m (q * N))
+
+lemma discOffsetUpTo_length_mul_succ_comm (f : ℕ → ℤ) (d m q N : ℕ) :
+    discOffsetUpTo f d m (q * (N + 1)) = discOffsetUpTo f d m ((N + 1) * q) := by
+  simpa [Nat.mul_comm] using
+    (rfl : discOffsetUpTo f d m (q * (N + 1)) = discOffsetUpTo f d m (q * (N + 1)))
+
+/-!
 ### `discOffsetUpTo` argument-order coherence helper (API coherence)
 
 The historical argument order for the offset-up-to wrapper is `(d m N)`, matching `discOffset`.

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -112,6 +112,13 @@ example : discOffsetUpTo (fun k => f (k * q)) d m n = discOffsetUpTo f (d * q) m
 example (hq : q > 0) : discOffsetUpTo f d m n ≤ discOffsetUpTo f d m (n * q) := by
   simpa using (discOffsetUpTo_le_mul (f := f) (d := d) (m := m) (N := n) (q := q) hq)
 
+-- NEW (Track B): length-scaling normalization (avoid ad-hoc `Nat` algebra).
+example : discOffsetUpTo f d m (q * n) = discOffsetUpTo f d m (n * q) := by
+  simpa using (discOffsetUpTo_length_mul_comm (f := f) (d := d) (m := m) (q := q) (N := n))
+
+example : discOffsetUpTo f d m (q * (n + 1)) = discOffsetUpTo f d m ((n + 1) * q) := by
+  simpa using (discOffsetUpTo_length_mul_succ_comm (f := f) (d := d) (m := m) (q := q) (N := n))
+
 -- NEW (Track B): nucleus API coherence (disc/discrepancy wrappers)
 example : disc f d n = discrepancy f d n := by
   rfl


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `discOffsetUpTo` dilation/coarsening convenience wrappers: build a small lemma family for rewriting `discOffsetUpTo` under step scaling (`d ↦ d*q`) and length scaling (`N ↦ N*q`) with consistent naming and argument order, so later reductions don’t mix `disc_mul_step_le` with manual `Nat` algebra.

What changed:
- Added tiny non-[simp] normalization lemmas for the length argument of discOffsetUpTo:
  - discOffsetUpTo_length_mul_comm
  - discOffsetUpTo_length_mul_succ_comm
  These normalize q * N / q * (N+1) to the N * q / (N+1) * q orientation.
- Added stable-surface compile-only regression examples in MoltResearch/Discrepancy/NormalFormExamples.lean exercising the new rewrites.
- Updated Learning/EDUCATIONAL_OVERLAYS.md with a short API note.

CI:
- make ci
