### PR TITLE
Discrepancy: discOffsetUpTo step-scaling rewrite wrappers

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -62,6 +62,8 @@ The goal is to pair verified artifacts with learning scaffolding.
   - if you want to pull a factor `q` into the step *at the wrapper level* (without unfolding the `Finset.sup`), use the rewrite lemmas
     `discOffsetUpTo_map_mul_right` / `discOffsetUpTo_map_mul_left` (and their `discOffset_*` analogues),
     which package the `((m+i+1)*d)*q = (m+i+1)*(d*q)` index normalization.
+    If your goal is oriented the other way (the step is already written as `d*q` / `q*d` and you want to push the multiplier into the input), use the non-simp orientation helpers:
+    `discOffsetUpTo_step_mul_right` / `discOffsetUpTo_step_mul_left`.
     For cutoff scaling bookkeeping, use `discOffsetUpTo_le_mul` (monotonicity under `N ↦ N*q`, assuming `q > 0`).
     If you just need to normalize the *orientation* of a scaled cutoff (so you can match another lemma’s statement), use:
     - `discOffsetUpTo_length_mul_comm` to rewrite `discOffsetUpTo f d m (q * N)` into `discOffsetUpTo f d m (N * q)`

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -868,6 +868,38 @@ lemma discOffsetUpTo_map_mul_left (f : ℕ → ℤ) (q d m N : ℕ) :
   simp [discOffset_map_mul_left]
 
 /-!
+#### Step-scaling rewrite wrappers (orientation helpers)
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) —
+`discOffsetUpTo` dilation/coarsening convenience wrappers.
+
+Downstream normal-form code often has the *step* written as `d*q`/`q*d` already and wants to
+rewrite the expression into a form where the step multiplier is pushed into the function
+argument (`k ↦ k*q` or `k ↦ q*k`).  The core lemmas above are oriented the other way, so we
+provide these tiny wrappers for ergonomic rewriting.
+
+These are **not** tagged `[simp]`.
+-/
+
+/-- Rewrite a multiplied step `d*q` into a multiplied input (`mul_right` convention).
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) —
+`discOffsetUpTo` dilation/coarsening convenience wrappers.
+-/
+lemma discOffsetUpTo_step_mul_right (f : ℕ → ℤ) (q d m N : ℕ) :
+    discOffsetUpTo f (d * q) m N = discOffsetUpTo (fun k => f (k * q)) d m N := by
+  simpa using (discOffsetUpTo_map_mul_right (f := f) (q := q) (d := d) (m := m) (N := N)).symm
+
+/-- Rewrite a multiplied step `q*d` into a multiplied input (`mul_left` convention).
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) —
+`discOffsetUpTo` dilation/coarsening convenience wrappers.
+-/
+lemma discOffsetUpTo_step_mul_left (f : ℕ → ℤ) (q d m N : ℕ) :
+    discOffsetUpTo f (q * d) m N = discOffsetUpTo (fun k => f (q * k)) d m N := by
+  simpa using (discOffsetUpTo_map_mul_left (f := f) (q := q) (d := d) (m := m) (N := N)).symm
+
+/-!
 ### `discOffsetUpTo` length-scaling normalization lemmas
 
 Checklist item: Problems/erdos_discrepancy.md (Track B) —

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -109,6 +109,14 @@ example : discOffset (fun k => f (k * q)) d m n = discOffset f (d * q) m n := by
 example : discOffsetUpTo (fun k => f (k * q)) d m n = discOffsetUpTo f (d * q) m n := by
   simpa using (discOffsetUpTo_map_mul_right (f := f) (q := q) (d := d) (m := m) (N := n))
 
+-- NEW (Track B): same rewrite, but oriented for when the *step* is already written as `d*q`.
+example : discOffsetUpTo f (d * q) m n = discOffsetUpTo (fun k => f (k * q)) d m n := by
+  simpa using (discOffsetUpTo_step_mul_right (f := f) (q := q) (d := d) (m := m) (N := n))
+
+-- NEW (Track B): `mul_left` convention (`q*d`).
+example : discOffsetUpTo f (q * d) m n = discOffsetUpTo (fun k => f (q * k)) d m n := by
+  simpa using (discOffsetUpTo_step_mul_left (f := f) (q := q) (d := d) (m := m) (N := n))
+
 example (hq : q > 0) : discOffsetUpTo f d m n ≤ discOffsetUpTo f d m (n * q) := by
   simpa using (discOffsetUpTo_le_mul (f := f) (d := d) (m := m) (N := n) (q := q) hq)
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `discOffsetUpTo` dilation/coarsening convenience wrappers: build a small lemma family for rewriting `discOffsetUpTo` under step scaling (`d ↦ d*q`) and length scaling (`N ↦ N*q`) with consistent naming and argument order, so later reductions don’t mix `disc_mul_step_le` with manual `Nat` algebra.

Summary:
- Add oriented rewrite wrappers `discOffsetUpTo_step_mul_right` / `discOffsetUpTo_step_mul_left` (non-`[simp]`) to ergonomically push a step multiplier into the input function.
- Add stable-surface compile regressions in `NormalFormExamples.lean`.

Notes:
- These are thin wrappers around existing `discOffsetUpTo_map_mul_{right,left}` and are intentionally not `[simp]` to avoid rewrite loops.
