### PR TITLE
Track C: refactor Stage 2 boundedness negation

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2ProofCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2ProofCore.lean
@@ -73,8 +73,8 @@ theorem stage2_notBoundedReducedAlong (f : ℕ → ℤ) (hf : IsSignSequence f) 
         (stage2_d (f := f) (hf := hf)) := by
   have hunb : Tao2015.UnboundedDiscrepancyAlong
       (stage2_g (f := f) (hf := hf))
-      (stage2_d (f := f) (hf := hf)) := by
-    simpa [stage2_g, stage2_d] using (stage2Out (f := f) (hf := hf)).unbounded
+      (stage2_d (f := f) (hf := hf)) :=
+    stage2_unboundedDiscrepancyAlong (f := f) (hf := hf)
   exact
     (Tao2015.UnboundedDiscrepancyAlong.iff_not_boundedDiscrepancyAlong
         (g := stage2_g (f := f) (hf := hf))


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Refactored stage2_notBoundedReducedAlong to reuse stage2_unboundedDiscrepancyAlong.
- Removes duplicated rewriting of stage2Out.unbounded while keeping the public API unchanged.
