### PR TITLE
Track C: Stage-3 unboundedDiscOffset wrapper

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
@@ -40,6 +40,19 @@ theorem erdos_discrepancy_not_exists_boundedDiscOffset (f : ℕ → ℤ) (hf : I
         (Tao2015.stage3Out (f := f) (hf := hf)).out2.m B := by
   exact Tao2015.stage3_not_exists_boundedDiscOffset (f := f) (hf := hf)
 
+/-- Stable packaging of the Stage-3 offset-discrepancy unboundedness witness.
+
+Normal form:
+`UnboundedDiscOffset f (stage3Out ...).out2.d (stage3Out ...).out2.m`.
+
+This is a small convenience wrapper around `Tao2015.stage3_unboundedDiscOffset`.
+-/
+theorem erdos_discrepancy_unboundedDiscOffset (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    Tao2015.UnboundedDiscOffset f
+      (Tao2015.stage3Out (f := f) (hf := hf)).out2.d
+      (Tao2015.stage3Out (f := f) (hf := hf)).out2.m := by
+  exact Tao2015.stage3_unboundedDiscOffset (f := f) (hf := hf)
+
 /-- Erdős discrepancy theorem.
 
 Every ±1 sequence has unbounded discrepancy on homogeneous arithmetic progressions.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add erdos_discrepancy_unboundedDiscOffset: stable packaging of the Stage-3 offset-discrepancy unboundedness witness.
- Keeps the hard-gate target unchanged (imports unchanged; just a thin wrapper around the existing Stage-3 lemma).
