### PR TITLE
Track C: expose reduced-sequence core witness

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
@@ -53,6 +53,20 @@ theorem erdos_discrepancy_unboundedDiscOffset (f : ℕ → ℤ) (hf : IsSignSequ
       (Tao2015.stage3Out (f := f) (hf := hf)).out2.m := by
   exact Tao2015.stage3_unboundedDiscOffset (f := f) (hf := hf)
 
+/-- Track C pipeline witness: Stage 3 yields unbounded discrepancy along the reduced sequence,
+stated using the verified core predicate `MoltResearch.UnboundedDiscrepancyAlong`.
+
+This is a small convenience wrapper around
+`Tao2015.Stage3Output.unboundedDiscrepancyAlong_core`.
+-/
+theorem erdos_discrepancy_unboundedDiscrepancyAlong_core (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    UnboundedDiscrepancyAlong
+      (Tao2015.stage3Out (f := f) (hf := hf)).g
+      (Tao2015.stage3Out (f := f) (hf := hf)).d := by
+  -- Use the stable Stage-3 boundary record field, avoiding additional entry-point imports.
+  simpa using
+    (Tao2015.stage3Out (f := f) (hf := hf)).unboundedDiscrepancyAlong_core (f := f)
+
 /-- Erdős discrepancy theorem.
 
 Every ±1 sequence has unbounded discrepancy on homogeneous arithmetic progressions.

--- a/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancyWitnesses.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancyWitnesses.lean
@@ -13,21 +13,6 @@ Track-C hard-gate build compiles quickly.
 
 namespace MoltResearch
 
-/-- Track C pipeline witness: Stage 3 yields unbounded discrepancy along the reduced sequence,
-stated using the verified core predicate `MoltResearch.UnboundedDiscrepancyAlong`.
-
-This is a small convenience wrapper around
-`Tao2015.Stage3Output.unboundedDiscrepancyAlong_core`.
--/
-theorem erdos_discrepancy_unboundedDiscrepancyAlong_core (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    MoltResearch.UnboundedDiscrepancyAlong
-      (Tao2015.stage3Out (f := f) (hf := hf)).g
-      (Tao2015.stage3Out (f := f) (hf := hf)).d := by
-  -- Use the stable Stage-3 boundary API (avoids reaching into the hard-gate entry point lemma).
-  simpa using
-    (Tao2015.Stage3Output.unboundedDiscrepancyAlong_core (f := f)
-      (Tao2015.stage3Out (f := f) (hf := hf)))
-
 /-- Paper-notation witness form for the concrete Stage-3 offset parameters.
 
 Normal form:


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Move the core-predicate reduced-sequence witness into the hard-gate ErdosDiscrepancy module.
- Keep the witness-corollaries file focused on heavier downstream wrappers.
- No change to the Stage-3 pipeline: this is a packaging-only refactor.
