### PR TITLE
Track C: expose stage3_one_le_d

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -60,6 +60,14 @@ output produced by Stage 2.
     (stage3Out (f := f) (hf := hf)).out1 = (stage2Out (f := f) (hf := hf)).out1 := by
   rfl
 
+/-- Convenience lemma: the Stage-3 reduced step size is at least `1`.
+
+This is a tiny wrapper around the Stage-2 projection lemma `Stage2Output.one_le_d`.
+-/
+theorem stage3_one_le_d (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    1 ≤ (stage3Out (f := f) (hf := hf)).d := by
+  simpa using (Stage2Output.one_le_d (out := (stage3Out (f := f) (hf := hf)).out2))
+
 -- Note: the simp lemma `stage3Out_out2` is enough to rewrite projections like
 -- `(stage3Out ...).out2.d` to `(stage2Out ...).d`, so we avoid duplicating simp lemmas for
 -- `.d/.m/.g` here.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a tiny Stage-3 convenience lemma stage3_one_le_d to the hard-gate minimal entry module.
- This exposes the common side condition 1 ≤ (stage3Out ...).d without importing the larger Stage-3 entry convenience layer.
