### PR TITLE
Track C: Stage-3 unboundedDiscrepancyAlong shortcut

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
@@ -63,9 +63,7 @@ theorem erdos_discrepancy_unboundedDiscrepancyAlong_core (f : ℕ → ℤ) (hf :
     UnboundedDiscrepancyAlong
       (Tao2015.stage3Out (f := f) (hf := hf)).g
       (Tao2015.stage3Out (f := f) (hf := hf)).d := by
-  -- Use the stable Stage-3 boundary record field, avoiding additional entry-point imports.
-  simpa using
-    (Tao2015.stage3Out (f := f) (hf := hf)).unboundedDiscrepancyAlong_core (f := f)
+  exact Tao2015.stage3_unboundedDiscrepancyAlong_core (f := f) (hf := hf)
 
 /-- Erdős discrepancy theorem.
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -108,6 +108,17 @@ theorem stage3_unboundedDiscOffset (f : ℕ → ℤ) (hf : IsSignSequence f) :
       (stage3Out (f := f) (hf := hf)).out2.m := by
   exact (stage3Out (f := f) (hf := hf)).unboundedDiscOffset (f := f)
 
+/-- Track-C pipeline witness: Stage 3 yields unbounded discrepancy along the reduced sequence,
+phrased using the verified core predicate `MoltResearch.UnboundedDiscrepancyAlong`.
+
+This is a thin wrapper around `Stage3Output.unboundedDiscrepancyAlong_core`.
+-/
+theorem stage3_unboundedDiscrepancyAlong_core (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    MoltResearch.UnboundedDiscrepancyAlong
+      (stage3Out (f := f) (hf := hf)).g
+      (stage3Out (f := f) (hf := hf)).d := by
+  simpa using (stage3Out (f := f) (hf := hf)).unboundedDiscrepancyAlong_core (f := f)
+
 /-- Consumer-facing shortcut: the Stage-3 pipeline yields the usual surface statement
 `∀ C, HasDiscrepancyAtLeast f C`.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a hard-gate minimal Stage-3 entry-point lemma packaging unbounded discrepancy along the reduced sequence (UnboundedDiscrepancyAlong).
- Update ErdosDiscrepancy.lean to use the new shortcut, keeping the proof as a direct API call.
