### PR TITLE
Track C: fix Stage 3 entry name collisions

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Entry.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Entry.lean
@@ -43,8 +43,13 @@ noncomputable abbrev stage3_d (f : ℕ → ℤ) (hf : IsSignSequence f) : ℕ :=
 theorem stage3_d_pos (f : ℕ → ℤ) (hf : IsSignSequence f) : stage3_d (f := f) (hf := hf) > 0 := by
   simpa [stage3_d] using stage2_d_pos (f := f) (hf := hf)
 
-/-- Convenience lemma: the reduced step size produced by Stage 3 is at least `1`. -/
-theorem stage3_one_le_d (f : ℕ → ℤ) (hf : IsSignSequence f) : 1 ≤ stage3_d (f := f) (hf := hf) := by
+/-- Convenience lemma: the reduced step size projection `stage3_d` is at least `1`.
+
+Note: the lemma with the canonical name `stage3_one_le_d` lives in the minimal entry-point module
+`TrackCStage3EntryMinimal` and states the same inequality for `(stage3Out ...).d`.
+-/
+theorem stage3_one_le_d_proj (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    1 ≤ stage3_d (f := f) (hf := hf) := by
   simpa [stage3_d] using stage2_one_le_d (f := f) (hf := hf)
 
 /-- Convenience lemma: the reduced step size produced by Stage 3 is nonzero. -/
@@ -200,7 +205,7 @@ theorem stage3_forall_exists_params_one_le_discOffset_gt'_witness_pos
   intro B
   rcases stage3_forall_exists_discOffset_gt'_witness_pos (f := f) (hf := hf) B with ⟨n, hn, hgt⟩
   refine ⟨stage3_d (f := f) (hf := hf), stage3_m (f := f) (hf := hf), n, ?_, hn, ?_⟩
-  · exact stage3_one_le_d (f := f) (hf := hf)
+  · exact stage3_one_le_d_proj (f := f) (hf := hf)
   · simpa using hgt
 
 /-!

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
@@ -38,10 +38,14 @@ Definitional rewrite simp lemmas for `stage3Out` live in the minimal module
 /-- Track C pipeline witness: Stage 3 yields unbounded fixed-step discrepancy along the reduced
 sequence, expressed using the verified core predicate `MoltResearch.UnboundedDiscrepancyAlong`.
 
-This lemma is a small convenience wrapper around the bridge equivalence
-`Tao2015.unboundedDiscrepancyAlong_iff_core`.
+The lemma with the canonical name `stage3_unboundedDiscrepancyAlong_core` lives in the minimal
+entry-point module `TrackCStage3EntryMinimal` (it uses the bundled projections `.g` and `.d`).
+
+This lemma is the same statement, but written using the explicit Stage-1 reduction fields
+`out1.g` and `out1.d`; it is occasionally convenient when shuttling between Stage-2 and Stage-3
+records.
 -/
-theorem stage3_unboundedDiscrepancyAlong_core (f : ℕ → ℤ) (hf : IsSignSequence f) :
+theorem stage3_unboundedDiscrepancyAlong_core_out1 (f : ℕ → ℤ) (hf : IsSignSequence f) :
     MoltResearch.UnboundedDiscrepancyAlong
       (stage3Out (f := f) (hf := hf)).out1.g
       (stage3Out (f := f) (hf := hf)).out1.d := by

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Proof.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Proof.lean
@@ -41,8 +41,13 @@ theorem stage3_hd (f : ℕ → ℤ) (hf : IsSignSequence f) : stage3_d (f := f) 
     (Stage3Output.hd (f := f) (stage3Out (f := f) (hf := hf)))
 
 /-!
-The convenience lemma `stage3_one_le_d` lives in `TrackCStage3Entry.lean`.
-We intentionally do not redeclare it here (this file imports `TrackCStage3Entry`).
+The convenience lemma `stage3_one_le_d_proj` (for the projection `stage3_d`) lives in
+`TrackCStage3Entry.lean`.
+
+(The lemma with the canonical name `stage3_one_le_d` lives in the minimal entry module
+`TrackCStage3EntryMinimal` and is phrased using `(stage3Out ...).d`.)
+
+We intentionally do not redeclare either lemma here (this file imports `TrackCStage3Entry`).
 -/
 
 /-


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Fix duplicate lemma-name collisions in the Stage-3 Track C entry modules (Minimal/Core/Entry).
- Rename the explicit out1-field variant to stage3_unboundedDiscrepancyAlong_core_out1.
- Rename the projection lemma to stage3_one_le_d_proj and update downstream uses/comments.
