### PR TITLE
Track C: one_le discOffset witness_pos packaging

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
@@ -289,6 +289,16 @@ theorem exists_params_one_le_forall_exists_discOffset_gt (out : Stage2Output f) 
   intro B
   simpa using out.forall_exists_discOffset_gt (f := f) B
 
+/-- Positive-length witness form of `exists_params_one_le_forall_exists_discOffset_gt`.
+
+The witness length `n` cannot be `0`, since `discOffset ... 0 = 0`.
+-/
+theorem exists_params_one_le_forall_exists_discOffset_gt_witness_pos (out : Stage2Output f) :
+    ∃ d m : ℕ, 1 ≤ d ∧ (∀ B : ℕ, ∃ n : ℕ, n > 0 ∧ B < discOffset f d m n) := by
+  refine ⟨out.d, out.m, out.one_le_d (f := f), ?_⟩
+  intro B
+  simpa using out.forall_exists_discOffset_gt_witness_pos (f := f) B
+
 /-- Inequality-direction variant of `exists_params_one_le_forall_exists_discOffset_gt`, written as
 `discOffset f d m n > B`.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Added a Stage-2 packaging lemma that keeps the side condition in the normal form 1 ≤ d.
- Strengthened the packaging with positive-length witnesses (n > 0) for discOffset growth.
