### PR TITLE
Track C: expose Stage-3 fixed-step unboundedness witness

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
@@ -66,6 +66,16 @@ theorem unboundedDiscOffset (out : Stage3Output f) :
     UnboundedDiscOffset f out.out2.d out.out2.m := by
   exact out.out2.unboundedDiscOffset (f := f)
 
+/-- Stage 3 output also exposes the Stage-2 fixed-step unboundedness witness (the Tao2015 predicate
+`UnboundedDiscrepancyAlong`) along the reduced sequence.
+
+This is just the `unbounded` field of the carried Stage-2 output, rewritten to use the
+Stage-3 projections.
+-/
+theorem unboundedDiscrepancyAlong (out : Stage3Output f) :
+    Tao2015.UnboundedDiscrepancyAlong out.out1.g out.out1.d := by
+  simpa [Stage3Output.out1] using out.out2.unbounded
+
 /-- Stage 3 output also exposes the Stage-2 fixed-step unboundedness witness, phrased using the
 verified core predicate `MoltResearch.UnboundedDiscrepancyAlong`.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a Stage-3-level wrapper lemma exposing the Tao2015 UnboundedDiscrepancyAlong witness carried by Stage 2
- Keeps the Track C boundary API cleaner for downstream stages (no need to reach through out2 to access the fixed-step witness)
