### PR TITLE
Track C: Stage3Output.m projection

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
@@ -49,6 +49,10 @@ This is occasionally useful when later stages want access to the deterministic p
 @[simp] abbrev g (out : Stage3Output f) : ℕ → ℤ :=
   out.out2.g
 
+/-- Convenience projection: the bundled offset parameter packaged in Stage 3. -/
+@[simp] abbrev m (out : Stage3Output f) : ℕ :=
+  out.out2.m
+
 /-- Stage 3 already closes the global goal `¬ BoundedDiscrepancy f`.
 
 We intentionally do not store this as a field: it is derived from the Stage-2 output.

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Core.lean
@@ -75,13 +75,11 @@ theorem notBoundedReducedAlong (out : Stage3Output f) : ¬ BoundedDiscrepancyAlo
 Note: `Stage3Output.unboundedDiscrepancyAlong_core` is already defined in
 `Conjectures.C0002_erdos_discrepancy.src.TrackCStage3`.
 
-This file focuses on additional projections (`d`, `g`, `m`, etc.) that are convenient for later
-stages, without re-declaring boundary lemmas.
+This file focuses on additional projections (such as `start`) and tiny arithmetic rewrites that are
+convenient for later stages, without re-declaring boundary lemmas.
 -/
 
-/-- Convenience projection: the bundled offset parameter packaged in Stage 3. -/
-@[simp] abbrev m (out : Stage3Output f) : ℕ := out.out2.m
-
+-- Note: the basic projection `Stage3Output.m` lives in `TrackCStage3.lean` alongside `d` and `g`.
 -- Note: `Stage3Output.unboundedDiscOffset` is defined in `TrackCStage3.lean`.
 
 /-- Convenience projection: the affine-tail start index `m*d` packaged in Stage 3. -/


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add Stage3Output.m as a basic projection alongside Stage3Output.d and Stage3Output.g.
- Move the existing m projection out of TrackCStage3Core so hard-gate consumers can access it without importing the core arithmetic layer.
- Keep downstream Stage3Core lemmas using Stage3Output.m unchanged (it now comes from the Stage3 API module).
