### PR TITLE
Track C: Stage3 start-index NNF wrapper

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Output.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Output.lean
@@ -441,6 +441,15 @@ theorem not_exists_forall_natAbs_apSumFrom_mul_le (out : Stage3Output f) :
   simpa [Stage3Output.d, Stage3Output.m] using
     (Stage2Output.not_exists_forall_natAbs_apSumFrom_mul_le (f := f) out.out2)
 
+/-- Start-index phrasing of `not_exists_forall_natAbs_apSumFrom_mul_le`.
+
+This replaces the explicit arithmetic form `out.m * out.d` with the bundled start index
+`out.start = out.m * out.d` to reduce noise in downstream stages.
+-/
+theorem not_exists_forall_natAbs_apSumFrom_start_le (out : Stage3Output f) :
+    ¬ ∃ B : ℕ, ∀ n : ℕ, Int.natAbs (apSumFrom f out.start out.d n) ≤ B := by
+  simpa [Stage3Output.start] using out.not_exists_forall_natAbs_apSumFrom_mul_le (f := f)
+
 end Stage3Output
 
 end Tao2015


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Added Stage3Output.not_exists_forall_natAbs_apSumFrom_start_le as a start-index phrasing of the existing affine-tail negation normal form.
- This reduces downstream arithmetic noise by using out.start = out.m * out.d.
- Hard gate build: lake build Conjectures.C0002_erdos_discrepancy.src.ErdosDiscrepancy