### PR TITLE
Track C: Stage 4 discrepancy witnesses with d≥1

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage4Proof.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage4Proof.lean
@@ -134,6 +134,31 @@ theorem forall_exists_discrepancy_gt (out : Stage4Output f) :
     (HasDiscrepancyAtLeast_iff_exists_discrepancy (f := f) (C := C)).1
       (out.forall_hasDiscrepancyAtLeast (f := f) C)
 
+/-- Variant of `forall_exists_discrepancy_gt` writing the step-size side condition as `d ≥ 1`.
+
+Many consumers prefer `d ≥ 1` rather than `d > 0` when working with `Nat` step sizes.
+-/
+theorem forall_exists_discrepancy_gt_d_ge_one (out : Stage4Output f) :
+    ∀ C : ℕ, ∃ d n : ℕ, d ≥ 1 ∧ discrepancy f d n > C := by
+  intro C
+  rcases out.forall_exists_discrepancy_gt (f := f) C with ⟨d, n, hd, hdisc⟩
+  refine ⟨d, n, ?_, hdisc⟩
+  exact Nat.succ_le_iff.2 hd
+
+/-- Strengthened witness form of `forall_exists_discrepancy_gt_d_ge_one` with a positive-length witness.
+
+Normal form:
+`∀ C, ∃ d n, d ≥ 1 ∧ n > 0 ∧ discrepancy f d n > C`.
+-/
+theorem forall_exists_discrepancy_gt_d_ge_one_witness_pos (out : Stage4Output f) :
+    ∀ C : ℕ, ∃ d n : ℕ, d ≥ 1 ∧ n > 0 ∧ discrepancy f d n > C := by
+  intro C
+  rcases out.forall_exists_d_ge_one_witness_pos (f := f) C with ⟨d, n, hd, hn, hw⟩
+  refine ⟨d, n, hd, hn, ?_⟩
+  -- `discrepancy f d n` is definitionally `Int.natAbs (apSum f d n)`.
+  change Int.natAbs (apSum f d n) > C
+  exact hw
+
 /-- Strengthened witness form of `forall_exists_discrepancy_gt` with a positive-length witness.
 
 This is sometimes convenient when downstream stages want to rule out the degenerate case `n = 0`.
@@ -242,6 +267,21 @@ This is the witness-form normal form of `stage4_forall_hasDiscrepancyAtLeast`.
 theorem stage4_forall_exists_discrepancy_gt (f : ℕ → ℤ) (hf : IsSignSequence f) :
     ∀ C : ℕ, ∃ d n : ℕ, d > 0 ∧ discrepancy f d n > C := by
   exact (stage4Out (f := f) (hf := hf)).forall_exists_discrepancy_gt (f := f)
+
+/-- Variant of `stage4_forall_exists_discrepancy_gt` writing the step-size side condition as `d ≥ 1`.
+-/
+theorem stage4_forall_exists_discrepancy_gt_d_ge_one (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    ∀ C : ℕ, ∃ d n : ℕ, d ≥ 1 ∧ discrepancy f d n > C := by
+  exact (stage4Out (f := f) (hf := hf)).forall_exists_discrepancy_gt_d_ge_one (f := f)
+
+/-- Strengthened witness form of `stage4_forall_exists_discrepancy_gt_d_ge_one` with a positive-length witness.
+
+Normal form:
+`∀ C, ∃ d n, d ≥ 1 ∧ n > 0 ∧ discrepancy f d n > C`.
+-/
+theorem stage4_forall_exists_discrepancy_gt_d_ge_one_witness_pos (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    ∀ C : ℕ, ∃ d n : ℕ, d ≥ 1 ∧ n > 0 ∧ discrepancy f d n > C := by
+  exact (stage4Out (f := f) (hf := hf)).forall_exists_discrepancy_gt_d_ge_one_witness_pos (f := f)
 
 /-- Strengthened witness form of `stage4_forall_exists_discrepancy_gt` with a positive-length witness.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add Stage4Output witness wrappers for discrepancy with step-size side condition d ≥ 1.
- Add consumer-facing Stage-4 shortcuts for the new witness forms.
