### PR TITLE
Track C: Stage 3 API uses .d/.m

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
@@ -29,28 +29,28 @@ theorem erdos_discrepancy_notBounded (f : ℕ → ℤ) (hf : IsSignSequence f) :
 /-- Stable boundedness-negation packaging of the Stage-3 offset-discrepancy witness.
 
 Normal form:
-`¬ ∃ B, BoundedDiscOffset f (stage3Out ...).out2.d (stage3Out ...).out2.m B`.
+`¬ ∃ B, BoundedDiscOffset f (stage3Out ...).d (stage3Out ...).m B`.
 
 This is a small convenience wrapper around `Tao2015.stage3_not_exists_boundedDiscOffset`.
 -/
 theorem erdos_discrepancy_not_exists_boundedDiscOffset (f : ℕ → ℤ) (hf : IsSignSequence f) :
     ¬ ∃ B : ℕ,
       BoundedDiscOffset f
-        (Tao2015.stage3Out (f := f) (hf := hf)).out2.d
-        (Tao2015.stage3Out (f := f) (hf := hf)).out2.m B := by
+        (Tao2015.stage3Out (f := f) (hf := hf)).d
+        (Tao2015.stage3Out (f := f) (hf := hf)).m B := by
   exact Tao2015.stage3_not_exists_boundedDiscOffset (f := f) (hf := hf)
 
 /-- Stable packaging of the Stage-3 offset-discrepancy unboundedness witness.
 
 Normal form:
-`UnboundedDiscOffset f (stage3Out ...).out2.d (stage3Out ...).out2.m`.
+`UnboundedDiscOffset f (stage3Out ...).d (stage3Out ...).m`.
 
 This is a small convenience wrapper around `Tao2015.stage3_unboundedDiscOffset`.
 -/
 theorem erdos_discrepancy_unboundedDiscOffset (f : ℕ → ℤ) (hf : IsSignSequence f) :
     Tao2015.UnboundedDiscOffset f
-      (Tao2015.stage3Out (f := f) (hf := hf)).out2.d
-      (Tao2015.stage3Out (f := f) (hf := hf)).out2.m := by
+      (Tao2015.stage3Out (f := f) (hf := hf)).d
+      (Tao2015.stage3Out (f := f) (hf := hf)).m := by
   exact Tao2015.stage3_unboundedDiscOffset (f := f) (hf := hf)
 
 /-- Track C pipeline witness: Stage 3 yields unbounded discrepancy along the reduced sequence,

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -83,29 +83,29 @@ theorem stage3_notBounded (f : ℕ → ℤ) (hf : IsSignSequence f) : ¬ Bounded
 /-- Stable boundedness-negation packaging of the Stage-3 offset-discrepancy witness.
 
 Normal form:
-`¬ ∃ B, BoundedDiscOffset f (stage3Out ...).out2.d (stage3Out ...).out2.m B`.
+`¬ ∃ B, BoundedDiscOffset f (stage3Out ...).d (stage3Out ...).m B`.
 
 This is a thin wrapper around `Stage3Output.not_exists_boundedDiscOffset`.
 -/
 theorem stage3_not_exists_boundedDiscOffset (f : ℕ → ℤ) (hf : IsSignSequence f) :
     ¬ ∃ B : ℕ,
       BoundedDiscOffset f
-        (stage3Out (f := f) (hf := hf)).out2.d
-        (stage3Out (f := f) (hf := hf)).out2.m B := by
+        (stage3Out (f := f) (hf := hf)).d
+        (stage3Out (f := f) (hf := hf)).m B := by
   simpa using
     (Stage3Output.not_exists_boundedDiscOffset (f := f) (stage3Out (f := f) (hf := hf)))
 
 /-- Stable witness packaging of the Stage-3 offset-discrepancy unboundedness statement.
 
 Normal form:
-`UnboundedDiscOffset f (stage3Out ...).out2.d (stage3Out ...).out2.m`.
+`UnboundedDiscOffset f (stage3Out ...).d (stage3Out ...).m`.
 
 This is a thin wrapper around `Stage3Output.unboundedDiscOffset`.
 -/
 theorem stage3_unboundedDiscOffset (f : ℕ → ℤ) (hf : IsSignSequence f) :
     UnboundedDiscOffset f
-      (stage3Out (f := f) (hf := hf)).out2.d
-      (stage3Out (f := f) (hf := hf)).out2.m := by
+      (stage3Out (f := f) (hf := hf)).d
+      (stage3Out (f := f) (hf := hf)).m := by
   exact (stage3Out (f := f) (hf := hf)).unboundedDiscOffset (f := f)
 
 /-- Existential packaging: Stage 3 yields concrete parameters `d, m` with `1 ≤ d` such that the
@@ -116,8 +116,8 @@ record fields of `stage3Out`.
 -/
 theorem stage3_exists_params_one_le_unboundedDiscOffset (f : ℕ → ℤ) (hf : IsSignSequence f) :
     ∃ d m : ℕ, 1 ≤ d ∧ UnboundedDiscOffset f d m := by
-  refine ⟨(stage3Out (f := f) (hf := hf)).out2.d, (stage3Out (f := f) (hf := hf)).out2.m, ?_, ?_⟩
-  · simpa using Stage2Output.one_le_d (out := (stage3Out (f := f) (hf := hf)).out2)
+  refine ⟨(stage3Out (f := f) (hf := hf)).d, (stage3Out (f := f) (hf := hf)).m, ?_, ?_⟩
+  · exact stage3_one_le_d (f := f) (hf := hf)
   · exact stage3_unboundedDiscOffset (f := f) (hf := hf)
 
 /-- Track-C pipeline witness: Stage 3 yields unbounded discrepancy along the reduced sequence,


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Stage-3 hard-gate minimal entry: express bounded/unbounded DiscOffset wrappers using Stage3Output projections d and m (instead of out2.d/out2.m).
- Keep ErdosDiscrepancy wrappers aligned with the minimal API so the hard-gate surface stays record-field-light.
