### PR TITLE
Track C: tighten Stage2Light imports

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Light.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Light.lean
@@ -1,4 +1,3 @@
-import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Entry
 import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2ProofCore
 
 /-!


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Remove redundant import in TrackCStage2Light (TrackCStage2Entry already comes transitively via TrackCStage2ProofCore).
- Tighten the Stage-2 lightweight import graph without changing any semantics.
