### PR TITLE
Track C: stage3Out d positivity helpers

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -68,6 +68,22 @@ theorem stage3_one_le_d (f : ℕ → ℤ) (hf : IsSignSequence f) :
     1 ≤ (stage3Out (f := f) (hf := hf)).d := by
   simpa using (Stage2Output.one_le_d (out := (stage3Out (f := f) (hf := hf)).out2))
 
+/-- Convenience lemma: the Stage-3 reduced step size is positive.
+
+This is a tiny corollary of `stage3_one_le_d`.
+-/
+theorem stage3Out_d_pos (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    (stage3Out (f := f) (hf := hf)).d > 0 := by
+  exact lt_of_lt_of_le Nat.zero_lt_one (stage3_one_le_d (f := f) (hf := hf))
+
+/-- Convenience lemma: the Stage-3 reduced step size is nonzero.
+
+This is a tiny corollary of `stage3Out_d_pos`.
+-/
+theorem stage3Out_d_ne_zero (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    (stage3Out (f := f) (hf := hf)).d ≠ 0 := by
+  exact Nat.ne_of_gt (stage3Out_d_pos (f := f) (hf := hf))
+
 -- Note: the simp lemma `stage3Out_out2` is enough to rewrite projections like
 -- `(stage3Out ...).out2.d` to `(stage2Out ...).d`, so we avoid duplicating simp lemmas for
 -- `.d/.m/.g` here.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add two tiny arithmetic conveniences in TrackCStage3EntryMinimal: stage3Out_d_pos and stage3Out_d_ne_zero.
- These let hard-gate consumers recover positivity/nonzero facts about the Stage-3 step size without importing the larger TrackCStage3Entry convenience layer.
