### PR TITLE
Track C: package offset-bound negation

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
@@ -40,6 +40,19 @@ theorem erdos_discrepancy_not_exists_boundedDiscOffset (f : ℕ → ℤ) (hf : I
         (Tao2015.stage3Out (f := f) (hf := hf)).m B := by
   exact Tao2015.stage3_not_exists_boundedDiscOffset (f := f) (hf := hf)
 
+/-- Existential packaging of `erdos_discrepancy_not_exists_boundedDiscOffset`.
+
+Normal form:
+`∃ d m, 1 ≤ d ∧ ¬ ∃ B, BoundedDiscOffset f d m B`.
+
+This is a small convenience wrapper around
+`Tao2015.stage3_exists_params_one_le_not_exists_boundedDiscOffset`.
+-/
+theorem erdos_discrepancy_exists_params_one_le_not_exists_boundedDiscOffset (f : ℕ → ℤ)
+    (hf : IsSignSequence f) :
+    ∃ d m : ℕ, 1 ≤ d ∧ ¬ ∃ B : ℕ, BoundedDiscOffset f d m B := by
+  exact Tao2015.stage3_exists_params_one_le_not_exists_boundedDiscOffset (f := f) (hf := hf)
+
 /-- Stable packaging of the Stage-3 offset-discrepancy unboundedness witness.
 
 Normal form:


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add an existential packaging lemma for the Stage-3 offset-boundedness negation normal form.
- Lets consumers get parameters d, m with 1 ≤ d and ¬ ∃ B, BoundedDiscOffset f d m B by importing only ErdosDiscrepancy.
