### PR TITLE
Track C: stage2 reduced boundedness in core

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
@@ -56,6 +56,13 @@ theorem d_ne_zero (out : Stage2Output f) : out.d ≠ 0 := by
 theorem one_le_d (out : Stage2Output f) : 1 ≤ out.d := by
   simpa using (Nat.succ_le_iff).2 out.hd
 
+/-- Stage 2 implies the reduced sequence is not bounded along its fixed step size. -/
+theorem notBoundedReducedAlong (out : Stage2Output f) : ¬ BoundedDiscrepancyAlong out.g out.d := by
+  exact
+    (Tao2015.UnboundedDiscrepancyAlong.iff_not_boundedDiscrepancyAlong
+      (g := out.g) (d := out.d)).1
+      out.unbounded
+
 /-!
 ## Stage-2 bridge back to the global statement
 -/

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
@@ -143,12 +143,8 @@ theorem forall_exists_natAbs_apSumFrom_mul_gt (out : Stage2Output f) :
 -- Note: `Stage2Output.forall_exists_natAbs_apSumFrom_start_gt` lives in
 -- `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2CoreExtras`.
 
--- Note: downstream hard-gate stages should prefer the smaller API in `TrackCStage2Core.lean`.
-
-/-- Stage 2 implies the reduced sequence is not bounded along its fixed step size. -/
-theorem notBoundedReducedAlong (out : Stage2Output f) : ¬ BoundedDiscrepancyAlong out.g out.d := by
-  exact (Tao2015.UnboundedDiscrepancyAlong.iff_not_boundedDiscrepancyAlong
-    (g := out.g) (d := out.d)).1 out.unbounded
+-- Note: `Stage2Output.notBoundedReducedAlong` now lives in `TrackCStage2Core.lean` so downstream
+-- hard-gate stages can use it without importing this larger convenience-lemma module.
 
 -- Note: downstream hard-gate stages should prefer the smaller API in `TrackCStage2Core.lean`.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Moved Stage2Output.notBoundedReducedAlong into the minimal Stage-2 core API so hard-gate consumers can use it without importing the larger output-lemma module.
- Left the larger TrackCStage2Output convenience layer intact, now relying on the core lemma.
