### PR TITLE
Track C: simplify Stage-3 offset witness statement

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancyWitnesses.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancyWitnesses.lean
@@ -1,4 +1,5 @@
 import Conjectures.C0002_erdos_discrepancy.src.ErdosDiscrepancy
+import Conjectures.C0002_erdos_discrepancy.src.TrackCStage3Entry
 import Conjectures.C0002_erdos_discrepancy.src.TrackCStage3Output
 
 /-!
@@ -16,18 +17,18 @@ namespace MoltResearch
 
 Normal form:
 `∀ B, ∃ n, Int.natAbs (∑ i ∈ Icc (m+1) (m+n), f (i*d)) > B`,
-where `d = (Tao2015.stage3Out f hf).d` and `m = (Tao2015.stage3Out f hf).m`.
+where `d = Tao2015.stage3_d f hf` and `m = Tao2015.stage3_m f hf`.
 
 This is a thin wrapper around `Tao2015.Stage3Output.forall_exists_natAbs_sum_Icc_offset_gt`.
 -/
 theorem erdos_discrepancy_sum_Icc_offset_stage3 (f : ℕ → ℤ) (hf : IsSignSequence f) :
     ∀ B : ℕ, ∃ n : ℕ,
       Int.natAbs
-          ((Finset.Icc (((Tao2015.stage3Out (f := f) (hf := hf)).m) + 1)
-                (((Tao2015.stage3Out (f := f) (hf := hf)).m) + n)).sum
-              (fun i => f (i * ((Tao2015.stage3Out (f := f) (hf := hf)).d)))) > B := by
+          ((Finset.Icc ((Tao2015.stage3_m (f := f) (hf := hf)) + 1)
+                ((Tao2015.stage3_m (f := f) (hf := hf)) + n)).sum
+              (fun i => f (i * (Tao2015.stage3_d (f := f) (hf := hf))))) > B := by
   set out := Tao2015.stage3Out (f := f) (hf := hf) with hout
-  simpa [hout.symm] using
+  simpa [Tao2015.stage3_m, Tao2015.stage3_d, hout.symm] using
     (Tao2015.Stage3Output.forall_exists_natAbs_sum_Icc_offset_gt (f := f) out)
 
 /-- Positive-length witness form of `erdos_discrepancy_sum_Icc_offset_stage3`.
@@ -37,11 +38,11 @@ The witness length `n` cannot be `0`, since the interval `Icc (m+1) (m+n)` is em
 theorem erdos_discrepancy_sum_Icc_offset_stage3_witness_pos (f : ℕ → ℤ) (hf : IsSignSequence f) :
     ∀ B : ℕ, ∃ n : ℕ, n > 0 ∧
       Int.natAbs
-          ((Finset.Icc (((Tao2015.stage3Out (f := f) (hf := hf)).m) + 1)
-                (((Tao2015.stage3Out (f := f) (hf := hf)).m) + n)).sum
-              (fun i => f (i * ((Tao2015.stage3Out (f := f) (hf := hf)).d)))) > B := by
+          ((Finset.Icc ((Tao2015.stage3_m (f := f) (hf := hf)) + 1)
+                ((Tao2015.stage3_m (f := f) (hf := hf)) + n)).sum
+              (fun i => f (i * (Tao2015.stage3_d (f := f) (hf := hf))))) > B := by
   set out := Tao2015.stage3Out (f := f) (hf := hf) with hout
-  simpa [hout.symm] using
+  simpa [Tao2015.stage3_m, Tao2015.stage3_d, hout.symm] using
     (Tao2015.Stage3Output.forall_exists_natAbs_sum_Icc_offset_gt_witness_pos (f := f) out)
 
 /-- Witness form of `erdos_discrepancy` directly in terms of the nucleus `apSum`.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Restated the Stage-3 offset-sum witness corollaries in ErdosDiscrepancyWitnesses using the deterministic projections stage3_d and stage3_m.
- Added the minimal import needed to access these projections, and adjusted the proofs with simp rewrites.
