### PR TITLE
Discrepancy: apSupport concatenation normal form

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -82,6 +82,10 @@ The goal is to pair verified artifacts with learning scaffolding.
   If you want to expose the underlying `Finset.range` image form of the support (to map/filter/count over it) without unfolding the definition, rewrite via `apSupport_eq_image_range`.
 - **API note (`apSupport` canonical membership):** if your membership goal is already in the normal form
   `((m + i + 1) * d) ∈ apSupport d m n`, and you have `hd : d > 0`, then `simp [mem_apSupport_index_iff (m := m) (n := n) (i := i) hd]` reduces it to the expected bound `i < n`.
+- **API note (`apSupport` concatenation):** to split the support of a length `(n+k)` block into its first `n` and last `k` pieces, use
+  `apSupport_add`:
+  `apSupport d m (n+k) = apSupport d m n ∪ apSupport d (m+n) k`.
+  This is the support-side normal form that matches “concatenate AP sums” arguments.
 - **API note (`apSupport` size / no collisions):** if you need a cardinality statement, use `card_apSupport (m := m) (n := n) (hd := hd)` to rewrite
   `(apSupport d m n).card = n` (the proof is by injectivity of `i ↦ (m+i+1)*d` when `d > 0`).
 - **API note (shift–dilation coherence):** when you both (i) push an offset shift into the summand and (ii) pull a factor `q` into the step, use the commutation lemma `apSumOffset_shift_mul_right_comm` (and the wrapper `discOffset_shift_mul_right_comm`) to avoid redoing index algebra. Conceptually: “shift then dilate” = “dilate then shift (with scaled offset)”.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -363,6 +363,56 @@ finset reduces to the expected bound `i < n`.
     exact mem_apSupport_of_lt (d := d) (m := m) (n := n) (i := i) hi
 
 /-!
+### Support concatenation normal form (Track B)
+
+When we split a length `(n+k)` AP sum into its first `n` terms and its last `k` terms, the
+corresponding support finset splits as the union of two “block supports”.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — Support concatenation normal form (`apSupport`).
+-/
+
+lemma apSupport_add (d m n k : ℕ) :
+    apSupport d m (n + k) = apSupport d m n ∪ apSupport d (m + n) k := by
+  ext x
+  constructor
+  · intro hx
+    rcases (mem_apSupport_iff (d := d) (m := m) (n := n + k) (x := x)).1 hx with ⟨i, hi, rfl⟩
+    by_cases hin : i < n
+    · -- First block.
+      exact (Finset.mem_union).2 (Or.inl (mem_apSupport_of_lt (d := d) (m := m) (n := n) (i := i) hin))
+    · -- Second block: write `i = n + (i-n)`.
+      have hle : n ≤ i := Nat.le_of_not_gt hin
+      have hj : i - n < k := by
+        have hnk : n + (i - n) < n + k := by
+          -- rewrite `i` as `n + (i-n)` using `n ≤ i`.
+          simpa [Nat.add_sub_of_le hle] using hi
+        exact (Nat.add_lt_add_iff_left).1 hnk
+      have hbase : m + i + 1 = m + n + (i - n) + 1 := by
+        calc
+          m + i + 1 = m + (n + (i - n)) + 1 := by
+            simp [Nat.add_sub_of_le hle, Nat.add_assoc]
+          _ = m + n + (i - n) + 1 := by
+            simp [Nat.add_assoc]
+      have hrewrite : (m + i + 1) * d = (m + n + (i - n) + 1) * d := by
+        simpa [hbase]
+      exact (Finset.mem_union).2 (Or.inr (by
+        simpa [hrewrite] using
+          (mem_apSupport_of_lt (d := d) (m := m + n) (n := k) (i := i - n) hj)))
+  · intro hx
+    rcases (Finset.mem_union).1 hx with hx | hx
+    · -- Left block inclusion.
+      rcases (mem_apSupport_iff (d := d) (m := m) (n := n) (x := x)).1 hx with ⟨i, hi, rfl⟩
+      exact (mem_apSupport_iff (d := d) (m := m) (n := n + k) (x := (m + i + 1) * d)).2
+        ⟨i, Nat.lt_of_lt_of_le hi (Nat.le_add_right n k), rfl⟩
+    · -- Right block inclusion.
+      rcases (mem_apSupport_iff (d := d) (m := m + n) (n := k) (x := x)).1 hx with ⟨j, hj, rfl⟩
+      refine (mem_apSupport_iff (d := d) (m := m) (n := n + k)
+        (x := (m + n + j + 1) * d)).2 ?_
+      refine ⟨n + j, ?_, ?_⟩
+      · simpa [Nat.add_assoc, Nat.add_left_comm, Nat.add_comm] using (Nat.add_lt_add_left hj n)
+      · simp [Nat.add_assoc, Nat.add_left_comm, Nat.add_comm]
+
+/-!
 ### Cardinality (Track B)
 
 Assuming `d > 0`, the map `i ↦ (m + i + 1) * d` is injective, so the support finset contains

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -141,6 +141,16 @@ named lemma (so downstream proofs can do `simp [apSupport_eq_image_range]` inste
 example : apSupport d m n = (Finset.range n).image (fun i => (m + i + 1) * d) := by
   simp [apSupport_eq_image_range]
 
+/-!
+### NEW (Track B): support concatenation normal form (`apSupport`)
+
+Compile-only regression: the stable surface API can split the support of a length `(n+k)` block
+into a union of the two block supports.
+-/
+
+example : apSupport d m (n + k) = apSupport d m n ∪ apSupport d (m + n) k := by
+  simpa using (apSupport_add (d := d) (m := m) (n := n) (k := k))
+
 example : Int.natAbs (apSum f d n) = disc f d n := by
   rfl
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Support concatenation normal form (`apSupport`): prove a lemma describing `apSupport d m (n+k)` as the union of the two block supports

Adds `apSupport_add`:
- `apSupport d m (n+k) = apSupport d m n ∪ apSupport d (m+n) k`
- proved via the existing membership normal form `mem_apSupport_iff` (no `Finset.range` unfolding needed downstream)

Stable-surface regression:
- `MoltResearch/Discrepancy/NormalFormExamples.lean` now compiles an example using `apSupport_add` under `import MoltResearch.Discrepancy`.
