### PR TITLE
Discrepancy: apSupport cardinality bookkeeping

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -86,8 +86,9 @@ The goal is to pair verified artifacts with learning scaffolding.
   `apSupport_add`:
   `apSupport d m (n+k) = apSupport d m n ∪ apSupport d (m+n) k`.
   This is the support-side normal form that matches “concatenate AP sums” arguments.
-- **API note (`apSupport` size / no collisions):** if you need a cardinality statement, use `card_apSupport (m := m) (n := n) (hd := hd)` to rewrite
-  `(apSupport d m n).card = n` (the proof is by injectivity of `i ↦ (m+i+1)*d` when `d > 0`).
+- **API note (`apSupport` size / no collisions):** if you need a cardinality statement, there are two stable-surface wrappers:
+  - `card_apSupport_le` gives the always-true bound `(apSupport d m n).card ≤ n` (since it is an image of `Finset.range n`), and
+  - `card_apSupport_eq` (or the older `card_apSupport`) gives the exact value `(apSupport d m n).card = n` assuming `d > 0` (injectivity of `i ↦ (m+i+1)*d`).
 - **API note (shift–dilation coherence):** when you both (i) push an offset shift into the summand and (ii) pull a factor `q` into the step, use the commutation lemma `apSumOffset_shift_mul_right_comm` (and the wrapper `discOffset_shift_mul_right_comm`) to avoid redoing index algebra. Conceptually: “shift then dilate” = “dilate then shift (with scaled offset)”.
 - **API note (paper interval normalization):** many downstream proofs naturally produce paper-style terms like `Int.natAbs ((Finset.Icc (m+1) (m+n)).sum ...)`. The stable surface exports simp lemmas rewriting these directly to `discOffset f d m n`, so endpoint algebra can be normalized by `simp` without manually rewriting `discOffset_eq_natAbs_sum_Icc` back and forth.
 - **API note (affine interval sum → `apSumOffset`):** if you have an interval sum with an extra affine offset in the summand,

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -307,6 +307,39 @@ lemma mem_apSupport_of_lt {i d m n : ℕ} (hi : i < n) :
   exact ⟨i, Finset.mem_range.2 hi, rfl⟩
 
 /-!
+### Cardinality bounds (Track B)
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — `apSupport` cardinality bookkeeping.
+
+Because `apSupport d m n` is defined as an image of `Finset.range n`, its cardinality is always
+bounded by `n`. When `d > 0`, the sampling map `i ↦ (m + i + 1) * d` is injective, so the support
+contains *exactly* `n` indices.
+-/
+
+/-- Basic bookkeeping: `apSupport d m n` has cardinality at most `n`. -/
+lemma card_apSupport_le (d m n : ℕ) : (apSupport d m n).card ≤ n := by
+  classical
+  -- `card (image ...) ≤ card (range n) = n`.
+  simpa [apSupport] using (Finset.card_image_le (s := Finset.range n)
+    (f := fun i => (m + i + 1) * d))
+
+/-- Exact cardinality when the step is positive (no multiplicities collapse). -/
+lemma card_apSupport_eq (d m n : ℕ) (hd : d > 0) : (apSupport d m n).card = n := by
+  classical
+  -- The sampling map is injective when `d > 0`.
+  have hinj : Function.Injective (fun i : ℕ => (m + i + 1) * d) := by
+    intro i j hij
+    have hmul : m + i + 1 = m + j + 1 := Nat.mul_right_cancel hd hij
+    have hmul' : m + (i + 1) = m + (j + 1) := by
+      simpa [Nat.add_assoc] using hmul
+    have : i + 1 = j + 1 := Nat.add_left_cancel hmul'
+    exact Nat.succ_inj.mp (by simpa using this)
+  -- `card (image) = card (range n) = n`.
+  simpa [apSupport] using
+    (Finset.card_image_of_injective (s := Finset.range n)
+      (f := fun i : ℕ => (m + i + 1) * d) hinj)
+
+/-!
 ### Membership characterization (Track B)
 
 This is a small “unfold-free” interface lemma for the `apSupport` support finset.

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -142,6 +142,19 @@ example : apSupport d m n = (Finset.range n).image (fun i => (m + i + 1) * d) :=
   simp [apSupport_eq_image_range]
 
 /-!
+### NEW (Track B): `apSupport` cardinality bookkeeping
+
+Compile-only regressions: bounding the number of accessed indices should be a one-liner, and when
+`d > 0` the bound should be exact.
+-/
+
+example : (apSupport d m n).card ≤ n := by
+  simpa using (card_apSupport_le (d := d) (m := m) (n := n))
+
+example (hd : d > 0) : (apSupport d m n).card = n := by
+  simpa using (card_apSupport_eq (d := d) (m := m) (n := n) hd)
+
+/-!
 ### NEW (Track B): support concatenation normal form (`apSupport`)
 
 Compile-only regression: the stable surface API can split the support of a length `(n+k)` block


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Support cardinality bound: prove `Nat.card (apSupport d m n) ≤ n` (and the exact value `= n` when `d>0`) to make “number of accessed indices” bookkeeping one-liners in edit-sensitivity bounds.

This PR adds stable-surface lemmas:
- `card_apSupport_le` : `(apSupport d m n).card ≤ n`
- `card_apSupport_eq` : if `d > 0` then `(apSupport d m n).card = n`

Also adds compile-only regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean` (under `import MoltResearch.Discrepancy`).
