### PR TITLE
Docs: mark apSupport backlog items complete

### DIFF
--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -445,9 +445,11 @@ Goal: build a *directed* lemma scaffold (not lemma-sprawl). Each checkbox should
   `apSupport d m n ∪ apSupport d (m+n) k` (with a simp-friendly membership characterization), so edit-sensitivity and congruence arguments can split supports without re-proving set algebra.
   (Implemented as `apSupport_add` in `MoltResearch/Discrepancy/Basic.lean`, with membership interface `mem_apSupport` and a stable-surface regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
-- [ ] Support cardinality bound: prove `Nat.card (apSupport d m n) ≤ n` (and the exact value `= n` when `d>0`) to make “number of accessed indices” bookkeeping one-liners in edit-sensitivity bounds.
+- [x] Support cardinality bound: prove `Nat.card (apSupport d m n) ≤ n` (and the exact value `= n` when `d>0`) to make “number of accessed indices” bookkeeping one-liners in edit-sensitivity bounds.
+  (Implemented as `card_apSupport_le` / `card_apSupport_eq` in `MoltResearch/Discrepancy/Basic.lean`, with stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
-- [ ] Support monotonicity in length: package a lemma `apSupport d m n ⊆ apSupport d m (n+k)` (and a `Finset.image`-free membership form), to avoid manual arithmetic when extending tails.
+- [x] Support monotonicity in length: package a lemma `apSupport d m n ⊆ apSupport d m (n+k)` (and a `Finset.image`-free membership form), to avoid manual arithmetic when extending tails.
+  (Implemented as `apSupport_mono_right` in `MoltResearch/Discrepancy/Basic.lean`, with stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
 - [ ] Cut-stability for `apSupport`: prove a normal form stating that if `f=g` on `apSupport d m n` then they also agree on both cut pieces’ supports (and conversely), so “agree on accessed indices” hypotheses can be transported through `apSumOffset` cut/split lemmas.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Support cardinality bound: prove `Nat.card (apSupport d m n) ≤ n` (and the exact value `= n` when `d>0`) to make “number of accessed indices” bookkeeping one-liners in edit-sensitivity bounds.

This checklist item (and the closely related “support monotonicity in length”) were already implemented in `MoltResearch/Discrepancy/Basic.lean` as:
- `card_apSupport_le` / `card_apSupport_eq`
- `apSupport_mono_right`
with stable-surface regression examples under `import MoltResearch.Discrepancy` (see `MoltResearch/Discrepancy/NormalFormExamples.lean`).

This PR just marks the auto-generated backlog entries as completed so the Forge card picker stops selecting a duplicate already-done item.
