### PR TITLE
Discrepancy: cut-stability for apSupport agreement hypotheses

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -102,3 +102,9 @@ The goal is to pair verified artifacts with learning scaffolding.
   `add_one_add_pred_eq_add` / `add_pred_add_one_eq_add` (both require `0 < n`) to normalize `m+1+(n-1)` (or `m+(n-1)+1`) back to `m+n`.
   We *do not* add generic associativity/commutativity theorems to the simp set here: that tends to loop. Keep these helper lemmas explicit.
 - **Related tasks:** `T1_01`, `T1_07`, `T1_12`.
+
+- **API note (`apSupport` cut-stability for congruence hypotheses):** when you have a hypothesis of the form
+  `h : ∀ x ∈ apSupport d m (n + k), f x = g x`, you often want to transport it through cut/split normal forms like `apSumOffset_add_len`.
+  Use `apSupport_agree_add_iff` to split/merge that hypothesis across the cut:
+  `∀ x ∈ apSupport d m (n+k), ...` ↔ `(∀ x ∈ apSupport d m n, ...) ∧ (∀ x ∈ apSupport d (m+n) k, ...)`.
+  This avoids unfolding `apSupport` and keeps the “agree on accessed indices” condition in a canonical shape.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -445,6 +445,41 @@ lemma apSupport_add (d m n k : ℕ) :
       · simpa [Nat.add_assoc, Nat.add_left_comm, Nat.add_comm] using (Nat.add_lt_add_left hj n)
       · simp [Nat.add_assoc, Nat.add_left_comm, Nat.add_comm]
 
+/-- Cut-stability for support-form agreement hypotheses.
+
+If `f` and `g` agree on the accessed indices for a length `(n+k)` block, then they agree on both
+cut pieces; conversely, agreement on both cut pieces implies agreement on the whole block.
+
+This is the key glue lemma for transporting “agree on accessed indices” assumptions through
+cut/split normal forms such as `apSumOffset_add_len`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — Cut-stability for `apSupport`.
+-/
+lemma apSupport_agree_add_iff {β : Type} (f g : ℕ → β) (d m n k : ℕ) :
+    (∀ x ∈ apSupport d m (n + k), f x = g x) ↔
+      (∀ x ∈ apSupport d m n, f x = g x) ∧ (∀ x ∈ apSupport d (m + n) k, f x = g x) := by
+  constructor
+  · intro h
+    refine ⟨?_, ?_⟩
+    · intro x hx
+      -- Promote membership in the left block to membership in the full `(n+k)` support.
+      have hx' : x ∈ apSupport d m n ∪ apSupport d (m + n) k := (Finset.mem_union).2 (Or.inl hx)
+      have hx'' : x ∈ apSupport d m (n + k) := by
+        simpa [apSupport_add (d := d) (m := m) (n := n) (k := k)] using hx'
+      exact h x hx''
+    · intro x hx
+      have hx' : x ∈ apSupport d m n ∪ apSupport d (m + n) k := (Finset.mem_union).2 (Or.inr hx)
+      have hx'' : x ∈ apSupport d m (n + k) := by
+        simpa [apSupport_add (d := d) (m := m) (n := n) (k := k)] using hx'
+      exact h x hx''
+  · rintro ⟨h₁, h₂⟩ x hx
+    have hx' : x ∈ apSupport d m n ∪ apSupport d (m + n) k := by
+      simpa [apSupport_add (d := d) (m := m) (n := n) (k := k)] using hx
+    rcases (Finset.mem_union).1 hx' with hxL | hxR
+    · exact h₁ x hxL
+    · exact h₂ x hxR
+
+
 /-!
 ### Cardinality (Track B)
 

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -164,6 +164,27 @@ into a union of the two block supports.
 example : apSupport d m (n + k) = apSupport d m n ∪ apSupport d (m + n) k := by
   simpa using (apSupport_add (d := d) (m := m) (n := n) (k := k))
 
+/-!
+### NEW (Track B): cut-stability for support-form congruence hypotheses
+
+Compile-only regression: if `f` and `g` agree on the accessed indices for a length `(n+k)` block,
+we can split that hypothesis into the two cut pieces and transport it through the length-splitting
+normal form `apSumOffset_add_len`, without unfolding `apSupport`.
+-/
+
+example (h : ∀ x ∈ apSupport d m (n + k), f x = g x) :
+    apSumOffset f d m (n + k) = apSumOffset g d m (n + k) := by
+  have hpieces :
+      (∀ x ∈ apSupport d m n, f x = g x) ∧ (∀ x ∈ apSupport d (m + n) k, f x = g x) :=
+    (apSupport_agree_add_iff (f := f) (g := g) (d := d) (m := m) (n := n) (k := k)).1 h
+  calc
+    apSumOffset f d m (n + k) = apSumOffset f d m n + apSumOffset f d (m + n) k := by
+      simpa [apSumOffset_add_len]
+    _ = apSumOffset g d m n + apSumOffset g d (m + n) k := by
+      simp [apSumOffset_congr_support, hpieces.1, hpieces.2]
+    _ = apSumOffset g d m (n + k) := by
+      simpa [apSumOffset_add_len]
+
 example : Int.natAbs (apSum f d n) = disc f d n := by
   rfl
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Cut-stability for `apSupport`: prove a normal form stating that if `f=g` on `apSupport d m n` then they also agree on both cut pieces’ supports (and conversely), so “agree on accessed indices” hypotheses can be transported through `apSumOffset` cut/split lemmas.

Adds:
- `apSupport_agree_add_iff`: splits/combines “agree on accessed indices” hypotheses across the `(n+k)` cut.
- Stable-surface regression example showing how the split hypothesis transports through `apSumOffset_add_len`.
