### PR TITLE
Discrepancy: cut-stability wrapper for apSupport agreement

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -107,4 +107,9 @@ The goal is to pair verified artifacts with learning scaffolding.
   `h : ∀ x ∈ apSupport d m (n + k), f x = g x`, you often want to transport it through cut/split normal forms like `apSumOffset_add_len`.
   Use `apSupport_agree_add_iff` to split/merge that hypothesis across the cut:
   `∀ x ∈ apSupport d m (n+k), ...` ↔ `(∀ x ∈ apSupport d m n, ...) ∧ (∀ x ∈ apSupport d (m+n) k, ...)`.
-  This avoids unfolding `apSupport` and keeps the “agree on accessed indices” condition in a canonical shape.
+
+  For the common “cut at `k ≤ n`” shape (prefix length `k`, suffix length `n-k`), use the wrapper
+  `apSupport_agree_cut_iff`:
+  `∀ x ∈ apSupport d m n, ...` ↔ `(∀ x ∈ apSupport d m k, ...) ∧ (∀ x ∈ apSupport d (m+k) (n-k), ...)`.
+
+  These avoid unfolding `apSupport` and keep “agree on accessed indices” hypotheses in a canonical, transport-friendly form.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -479,6 +479,20 @@ lemma apSupport_agree_add_iff {β : Type} (f g : ℕ → β) (d m n k : ℕ) :
     · exact h₁ x hxL
     · exact h₂ x hxR
 
+/-- Cut-stability for support-form agreement hypotheses (cut at `k ≤ n`).
+
+This is a convenience wrapper around `apSupport_agree_add_iff` that matches the common
+“prefix/suffix after a cut” shape used by `apSumOffset` cut/split lemmas.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — Cut-stability for `apSupport` through cuts.
+-/
+lemma apSupport_agree_cut_iff {β : Type} (f g : ℕ → β) (d m n k : ℕ) (hk : k ≤ n) :
+    (∀ x ∈ apSupport d m n, f x = g x) ↔
+      (∀ x ∈ apSupport d m k, f x = g x) ∧ (∀ x ∈ apSupport d (m + k) (n - k), f x = g x) := by
+  -- Rewrite `n` as `k + (n-k)` and apply the concatenation lemma.
+  simpa [Nat.add_sub_of_le hk, Nat.add_assoc, Nat.add_left_comm, Nat.add_comm] using
+    (apSupport_agree_add_iff (f := f) (g := g) (d := d) (m := m) (n := k) (k := n - k))
+
 
 /-!
 ### Cardinality (Track B)

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -185,6 +185,18 @@ example (h : ∀ x ∈ apSupport d m (n + k), f x = g x) :
     _ = apSumOffset g d m (n + k) := by
       simpa [apSumOffset_add_len]
 
+/-!
+### NEW (Track B): cut-stability for `apSupport` at `k ≤ n`
+
+Compile-only regression: the “cut at `k`” version of the support agreement lemma is available
+without manual rewriting `n = k + (n-k)`.
+-/
+
+example (hk : k ≤ n)
+    (h : ∀ x ∈ apSupport d m n, f x = g x) :
+    (∀ x ∈ apSupport d m k, f x = g x) ∧ (∀ x ∈ apSupport d (m + k) (n - k), f x = g x) := by
+  exact (apSupport_agree_cut_iff (f := f) (g := g) (d := d) (m := m) (n := n) (k := k) hk).1 h
+
 example : Int.natAbs (apSum f d n) = disc f d n := by
   rfl
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Cut-stability for `apSupport`: prove a normal form stating that if `f=g` on `apSupport d m n` then they also agree on both cut pieces’ supports (and conversely), so “agree on accessed indices” hypotheses can be transported through `apSumOffset` cut/split lemmas.

What changed:
- Added `apSupport_agree_cut_iff` as a wrapper around the existing concatenation lemma `apSupport_agree_add_iff`, matching the common cut shape `k ≤ n` with suffix length `n-k`.
- Added a compile-only regression example in `NormalFormExamples.lean` showing the lemma in action.

Notes:
- No new `Discrepancy/*` lemmas beyond the Track B checklist item; example lives on the stable surface (`import MoltResearch.Discrepancy`).
