### PR TITLE
Track C: slim Stage 4 core imports

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage4Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage4Core.lean
@@ -1,4 +1,4 @@
-import Conjectures.C0002_erdos_discrepancy.src.TrackCStage3EntryCore
+import Conjectures.C0002_erdos_discrepancy.src.TrackCStage3EntryMinimal
 
 /-!
 # Track C — Stage 4 (core boundary)
@@ -9,7 +9,7 @@ Policy:
 - This file should stay API + wiring.
 - Put any additional derived lemmas / witness-form wrappers in
   `Conjectures.C0002_erdos_discrepancy.src.TrackCStage4Proof`.
-- Stage 4 should consume Stage 3 only through the hard-gate core import above.
+- Stage 4 should consume Stage 3 only through the hard-gate minimal entry-point import above.
 
 Current status: Stage-4 boundary API is still lightweight.
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage4Proof.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage4Proof.lean
@@ -1,4 +1,5 @@
 import Conjectures.C0002_erdos_discrepancy.src.TrackCStage4Core
+import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2CoreExtras
 
 /-!
 # Track C — Stage 4 proof file (derived wrappers)


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Make TrackCStage4Core depend only on the hard-gate minimal Stage-3 entry-point module.
- Add an explicit TrackCStage2CoreExtras import to TrackCStage4Proof so Stage-2 witness lemmas are sourced directly.
- Keeps the Stage-4 boundary module slimmer without changing any statements.
