### PR TITLE
Track C: package Stage-2 stub as typeclass

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Stub.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Stub.lean
@@ -16,12 +16,27 @@ namespace MoltResearch
 
 namespace Tao2015
 
+/-- Typeclass packaging of the Stage-2 conjecture assumption.
+
+This lets downstream code replace the axiom stub by providing a local instance.
+-/
+class Stage2Assumption : Type where
+  /-- Stage 2 of Tao 2015: given a sign sequence `f`, produce a Stage-2 output consisting of a
+  Stage-1 reduction output and an unbounded fixed-step discrepancy witness along the reduced
+  sequence. -/
+  stage2 (f : ℕ → ℤ) (hf : IsSignSequence f) : Stage2Output f
+
+/-- Default axiom instance for the Stage-2 assumption (Conjectures-only stub). -/
+axiom instStage2Assumption : Stage2Assumption
+attribute [instance] instStage2Assumption
+
 /-- **Conjecture stub:** Stage 2 of Tao 2015.
 
 Given a sign sequence `f`, produce a Stage-2 output consisting of a Stage-1 reduction output and an
 unbounded fixed-step discrepancy witness along the reduced sequence.
 -/
-axiom stage2 (f : ℕ → ℤ) (hf : IsSignSequence f) : Stage2Output f
+noncomputable def stage2 (f : ℕ → ℤ) (hf : IsSignSequence f) [Stage2Assumption] : Stage2Output f :=
+  Stage2Assumption.stage2 (f := f) (hf := hf)
 
 /-- Deterministic name for the Stage-2 output (useful to keep later statements readable). -/
 noncomputable abbrev stage2Out (f : ℕ → ℤ) (hf : IsSignSequence f) : Stage2Output f :=


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Wrapped the Stage-2 conjecture stub behind a Stage2Assumption typeclass.
- Added a default axiom instance so downstream Stage-3 and ErdosDiscrepancy glue elaborates unchanged.
- Allows swapping in a proved Stage 2 later by providing a local instance.
