### PR TITLE
Discrepancy: residue decomposition support API

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -4461,6 +4461,19 @@ example (hq : q > 0) :
       (Finset.range q).sum (fun r => f ((m + r + 1) * d) + apSumFrom f ((m + r + 1) * d) (q * d) n) := by
   simpa using apSumOffset_mul_len_succ_eq_sum_range (f := f) (d := d) (m := m) (q := q) (n := n) hq
 
+-- Regression (Track B / residue support API): callers can rewrite supports for residue-class splits.
+example (hq : q > 0) :
+    apSupport d m (q * (n + 1)) =
+      (Finset.range q).biUnion (fun r => apSupportResidue d m q n r) := by
+  simpa using
+    apSupport_mul_len_succ_eq_biUnion_apSupportResidue (d := d) (m := m) (q := q) (n := n) hq
+
+example (hq : q > 0) (hd : d > 0) {r₁ r₂ : ℕ} (hr₁ : r₁ < q) (hr₂ : r₂ < q) (hne : r₁ ≠ r₂) :
+    Disjoint (apSupportResidue d m q n r₁) (apSupportResidue d m q n r₂) := by
+  simpa using
+    disjoint_apSupportResidue_of_ne (d := d) (m := m) (q := q) (n := n)
+      (r₁ := r₁) (r₂ := r₂) hq hd hr₁ hr₂ hne
+
 -- Paper-notation (`Finset.Icc`) residue splitting: callers shouldn’t have to drop to `apSumOffset` first.
 example (hq : q > 0) :
     (Finset.Icc (m + 1) (m + q * (n + 1))).sum (fun i => f (i * d)) =

--- a/MoltResearch/Discrepancy/Residue.lean
+++ b/MoltResearch/Discrepancy/Residue.lean
@@ -454,6 +454,109 @@ lemma discOffset_step_one_mul_len_succ_eq_natAbs_sum_range
 
 
 /-!
+## Support API for residue decomposition (Track B)
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — Residue decomposition support API.
+
+After splitting a length-`q*(n+1)` offset AP sum into residue classes modulo `q`, it is useful to
+have a corresponding statement at the level of the *accessed-index support* finset `apSupport`.
+
+We package this as:
+- a finset `apSupportResidue d m q n r` for the indices accessed by the `r`-th residue class, and
+- a rewrite lemma expressing `apSupport d m (q*(n+1))` as the union of these residue supports.
+
+When `d > 0`, these residue supports are pairwise disjoint (no multiplicities collapse).
+-/
+
+def apSupportResidue (d m q n r : ℕ) : Finset ℕ :=
+  (Finset.range (n + 1)).image (fun k => (m + (q * k + r) + 1) * d)
+
+lemma apSupport_mul_len_succ_eq_biUnion_apSupportResidue (d m q n : ℕ) (hq : q > 0) :
+    apSupport d m (q * (n + 1)) =
+      (Finset.range q).biUnion (fun r => apSupportResidue d m q n r) := by
+  classical
+  ext x
+  constructor
+  · intro hx
+    rcases (mem_apSupport (d := d) (m := m) (n := q * (n + 1)) (x := x)).1 hx with ⟨i, hi, rfl⟩
+    let r : ℕ := i % q
+    let k : ℕ := i / q
+    have hr : r < q := Nat.mod_lt _ hq
+    have hk : k < n + 1 := by
+      -- `i < q*(n+1)` implies `i/q < n+1` when `q > 0`.
+      have hi' : i < (n + 1) * q := by
+        simpa [Nat.mul_comm, Nat.mul_left_comm, Nat.mul_assoc] using hi
+      have : i / q < n + 1 := (Nat.div_lt_iff_lt_mul hq).2 (by simpa [Nat.mul_comm] using hi')
+      simpa [k] using this
+    have hdecomp : q * k + r = i := by
+      -- `i / q * q + i % q = i`.
+      simpa [k, r, Nat.mul_comm, Nat.add_comm, Nat.add_left_comm, Nat.add_assoc] using
+        (Nat.div_add_mod i q)
+
+    -- Membership in the biUnion.
+    refine (Finset.mem_biUnion).2 ?_
+    refine ⟨r, Finset.mem_range.2 hr, ?_⟩
+    refine Finset.mem_image.2 ?_
+    refine ⟨k, Finset.mem_range.2 hk, ?_⟩
+    -- Normalize `q*k + r` back to `i`.
+    simp [apSupportResidue, hdecomp, Nat.add_assoc, Nat.add_left_comm, Nat.add_comm]
+
+  · intro hx
+    rcases (Finset.mem_biUnion).1 hx with ⟨r, hr, hx⟩
+    rcases Finset.mem_image.1 hx with ⟨k, hk, rfl⟩
+    have hr' : r < q := Finset.mem_range.1 hr
+    have hk' : k < n + 1 := Finset.mem_range.1 hk
+    -- Show the combined index `i = q*k + r` lies in the `q*(n+1)` range.
+    have hi : q * k + r < q * (n + 1) := by
+      -- First, `q*k + r < q*k + q` since `r < q`.
+      have h1 : q * k + r < q * k + q := Nat.add_lt_add_left hr' _
+      -- And `q*k + q = q*(k+1) ≤ q*(n+1)` since `k+1 ≤ n+1`.
+      have hle : q * k + q ≤ q * (n + 1) := by
+        have hkle : k + 1 ≤ n + 1 := Nat.succ_le_of_lt hk'
+        -- Multiply the inequality by `q` on the left.
+        have : q * (k + 1) ≤ q * (n + 1) := Nat.mul_le_mul_left q hkle
+        -- Rewrite `q*(k+1)`.
+        simpa [Nat.mul_add, Nat.mul_one, Nat.add_assoc, Nat.add_left_comm, Nat.add_comm] using this
+      exact lt_of_lt_of_le h1 hle
+
+    exact (mem_apSupport (d := d) (m := m) (n := q * (n + 1)) (x := (m + (q * k + r) + 1) * d)).2
+      ⟨q * k + r, by simpa [Nat.mul_assoc] using hi, rfl⟩
+
+lemma disjoint_apSupportResidue_of_ne
+    (d m q n r₁ r₂ : ℕ) (hq : q > 0) (hd : d > 0) (hr₁ : r₁ < q) (hr₂ : r₂ < q) (hne : r₁ ≠ r₂) :
+    Disjoint (apSupportResidue d m q n r₁) (apSupportResidue d m q n r₂) := by
+  classical
+  -- Prove disjointness by elementwise contradiction.
+  refine Finset.disjoint_left.2 ?_
+  intro x hx₁ hx₂
+  rcases Finset.mem_image.1 hx₁ with ⟨k₁, hk₁, hkx₁⟩
+  rcases Finset.mem_image.1 hx₂ with ⟨k₂, hk₂, hkx₂⟩
+
+  -- Cancel the positive factor `d`.
+  have hmul : (m + (q * k₁ + r₁) + 1) = (m + (q * k₂ + r₂) + 1) := by
+    apply Nat.mul_right_cancel hd
+    -- both sides equal `x`.
+    simpa [apSupportResidue] using hkx₁.trans hkx₂.symm
+
+  -- Cancel the common `m` and the trailing `+ 1`.
+  have hidx : q * k₁ + r₁ = q * k₂ + r₂ := by
+    -- First cancel the common prefix `m`.
+    have h' : (q * k₁ + r₁) + 1 = (q * k₂ + r₂) + 1 := by
+      have hm' : m + ((q * k₁ + r₁) + 1) = m + ((q * k₂ + r₂) + 1) := by
+        simpa [Nat.add_assoc] using hmul
+      exact Nat.add_left_cancel hm'
+    exact Nat.succ_inj.mp h'
+
+  -- Reduce the equality modulo `q` to force `r₁ = r₂`.
+  have hmod : (q * k₁ + r₁) % q = (q * k₂ + r₂) % q := congrArg (fun t => t % q) hidx
+  have : r₁ = r₂ := by
+    -- simplify both sides using `r < q`.
+    simpa [Nat.add_mod, Nat.mul_mod, Nat.mod_eq_of_lt hr₁, Nat.mod_eq_of_lt hr₂] using hmod
+
+  exact hne this
+
+
+/-!
 ## Multiplication-on-the-left variants
 
 These are small convenience wrappers around the main residue-class split lemmas.

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -454,7 +454,8 @@ Goal: build a *directed* lemma scaffold (not lemma-sprawl). Each checkbox should
 - [x] Cut-stability for `apSupport`: prove a normal form stating that if `f=g` on `apSupport d m n` then they also agree on both cut pieces’ supports (and conversely), so “agree on accessed indices” hypotheses can be transported through `apSumOffset` cut/split lemmas.
   (Implemented as `apSupport_agree_add_iff` and `apSupport_agree_cut_iff` in `MoltResearch/Discrepancy/Basic.lean`, with stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
-- [ ] Residue decomposition support API: after splitting an AP sum into residues mod `r`, prove the corresponding support union lemma (supports of each residue class are disjoint / have controlled overlap) and export a single wrapper so residue-class arguments can reuse the edit-sensitivity library without unfolding.
+- [x] Residue decomposition support API: after splitting an AP sum into residues mod `r`, prove the corresponding support union lemma (supports of each residue class are disjoint) and export a single wrapper so residue-class arguments can reuse the edit-sensitivity library without unfolding.
+  (Implemented as `apSupportResidue`, `apSupport_mul_len_succ_eq_biUnion_apSupportResidue`, and `disjoint_apSupportResidue_of_ne` in `MoltResearch/Discrepancy/Residue.lean`, with stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
 - [ ] `discOffset` extremizer API (argmax, not just max value): strengthen `exists_discOffset_eq_discOffsetUpTo` to return an explicit `n` together with a proof that it maximizes `discOffset` among `n' ≤ N` (argmax-style), so later proofs can “choose a maximizer” without rebuilding comparison lemmas.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Residue decomposition support API

Implements a small support-level API to accompany residue-class decomposition of AP sums:
- `apSupportResidue` for indices accessed by a fixed residue class
- `apSupport_mul_len_succ_eq_biUnion_apSupportResidue` rewrite lemma
- `disjoint_apSupportResidue_of_ne` disjointness when `d>0`

Adds stable-surface regression examples under `import MoltResearch.Discrepancy` in
`MoltResearch/Discrepancy/NormalFormExamples.lean`, and marks the checklist item complete.

CI: `make ci`