### PR TITLE
Discrepancy: discOffsetUpTo argmax witness

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -34,6 +34,11 @@ The goal is to pair verified artifacts with learning scaffolding.
 - **API note (endpoint-algebra wrappers):** three-segment concatenation is available as `discOffset_add_add_le`, but downstream goals often appear with right-associated endpoints. Use `discOffset_add_add_le_assoc` when your goal has length `n₁ + (n₂ + n₃)` and/or third-start index `m + (n₁ + n₂)` so you can `simpa` without manual `Nat.add_assoc` reassociation.
 - **API note:** `discOffsetUpTo` is monotone in the cutoff. Use `discOffsetUpTo_mono` for an arbitrary `N ≤ N'`, or the convenience wrapper `discOffsetUpTo_le_add` for the common “extend by `K`” case `N ≤ N+K`.
   If your goal is stated with `Nat.succ N` instead of `N+1`, use the wrapper `discOffsetUpTo_le_succNat`.
+- **API note (argmax witness for `discOffsetUpTo`):** the lemma
+  `exists_discOffset_eq_discOffsetUpTo` returns not just a witness `n ≤ N` with
+  `discOffset … n = discOffsetUpTo … N`, but also the comparison fact
+  `∀ n' ≤ N, discOffset … n' ≤ discOffset … n`.
+  Pattern: `rcases exists_discOffset_eq_discOffsetUpTo … with ⟨n, hnle, hnEq, hmax⟩` and then use `hmax` to avoid rebuilding “≤ sup” inequalities.
 - **API note (tail concatenation, max-level):** for later Tao2015 bookkeeping, prefer the wrapper
   `discOffsetUpTo_tail_concat_le`:
   `discOffsetUpTo f d m (N+K) ≤ discOffsetUpTo f d m N + discOffsetUpTo f d (m+N) K`.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -1356,7 +1356,9 @@ lemma discOffsetUpTo_le_succNat (f : ℕ → ℤ) (d m N : ℕ) :
 Checklist item: Problems/erdos_discrepancy.md (Track B) — “Max discrepancy up to N” API.
 -/
 lemma exists_discOffset_eq_discOffsetUpTo (f : ℕ → ℤ) (d m N : ℕ) :
-    ∃ n ≤ N, discOffset f d m n = discOffsetUpTo f d m N := by
+    ∃ n ≤ N,
+      discOffset f d m n = discOffsetUpTo f d m N ∧
+      ∀ n' ≤ N, discOffset f d m n' ≤ discOffset f d m n := by
   classical
   unfold discOffsetUpTo
   -- `range (N+1)` is nonempty, so `sup` is attained.
@@ -1369,7 +1371,13 @@ lemma exists_discOffset_eq_discOffsetUpTo (f : ℕ → ℤ) (d m N : ℕ) :
   refine ⟨n, ?_, ?_⟩
   · -- `n ∈ range (N+1)` implies `n ≤ N`.
     exact Nat.le_of_lt_succ (Finset.mem_range.1 hnmem)
-  · exact hsup.symm
+  · refine ⟨hsup.symm, ?_⟩
+    intro n' hn'le
+    have hn'mem : n' ∈ Finset.range (N + 1) := by
+      exact Finset.mem_range.2 (Nat.lt_succ_of_le hn'le)
+    have hle :=
+      Finset.le_sup (s := Finset.range (N + 1)) (f := fun t => discOffset f d m t) hn'mem
+    simpa [hsup.symm] using hle
 
 /-- In a fixed residue class modulo `q`, the maximum in `discUpTo` is attained by some `n ≤ N`.
 
@@ -1711,7 +1719,8 @@ theorem unboundedDiscOffset_iff_forall_exists_discOffsetUpTo_lt (f : ℕ → ℤ
     refine (unboundedDiscOffset_iff_forall_exists_discOffset_lt (f := f) (d := d) (m := m)).2 ?_
     intro B
     rcases h B with ⟨N, hN⟩
-    rcases exists_discOffset_eq_discOffsetUpTo (f := f) (d := d) (m := m) (N := N) with ⟨n, hn, hnEq⟩
+    rcases exists_discOffset_eq_discOffsetUpTo (f := f) (d := d) (m := m) (N := N) with
+      ⟨n, hn, hnEq, -⟩
     refine ⟨n, ?_⟩
     simpa [hnEq] using hN
 

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -509,9 +509,18 @@ unfolding `discOffsetUpTo`.
 -/
 
 example (f : ℕ → ℤ) (d m N : ℕ) :
-    ∃ n ≤ N, discOffset f d m n = discOffsetUpTo f d m N := by
+    ∃ n ≤ N,
+      discOffset f d m n = discOffsetUpTo f d m N ∧
+      ∀ n' ≤ N, discOffset f d m n' ≤ discOffset f d m n := by
   -- This is the packaged witness-extraction lemma.
   simpa using (exists_discOffset_eq_discOffsetUpTo (f := f) (d := d) (m := m) (N := N))
+
+-- Regression: extract the argmax inequality from the witness.
+example (f : ℕ → ℤ) (d m N n' : ℕ) (hn' : n' ≤ N) :
+    ∃ n ≤ N, discOffset f d m n' ≤ discOffset f d m n := by
+  rcases exists_discOffset_eq_discOffsetUpTo (f := f) (d := d) (m := m) (N := N) with
+    ⟨n, hnle, -, hmax⟩
+  exact ⟨n, hnle, hmax n' hn'⟩
 
 /-!
 Periodic (non-constant) sanity check: the alternating sign sequence has period 2.
@@ -926,7 +935,9 @@ example : discOffsetUpTo f d m n₁ ≤ discOffsetUpTo f d m (n₁ + n₂) := by
   simpa using (discOffsetUpTo_le_add (f := f) (d := d) (m := m) (N := n₁) (K := n₂))
 
 example : ∃ t ≤ n, discOffset f d m t = discOffsetUpTo f d m n := by
-  simpa using (exists_discOffset_eq_discOffsetUpTo (f := f) (d := d) (m := m) (N := n))
+  rcases exists_discOffset_eq_discOffsetUpTo (f := f) (d := d) (m := m) (N := n) with
+    ⟨t, ht, htEq, -⟩
+  exact ⟨t, ht, htEq⟩
 
 -- Regression (Track B / boundedness transfer for `discOffsetUpTo`): extending the cutoff by `K`
 -- increases the max discrepancy by at most `K` (Lipschitz-by-1 for sign sequences).

--- a/MoltResearch/Discrepancy/SurfaceAudit.lean
+++ b/MoltResearch/Discrepancy/SurfaceAudit.lean
@@ -264,7 +264,9 @@ section
 
   -- One-line usage audit: the `sup` in `discOffsetUpTo` is attained by some `t ≤ N`.
   example : ∃ t ≤ n, discOffset f d m t = discOffsetUpTo f d m n := by
-    simpa using (exists_discOffset_eq_discOffsetUpTo (f := f) (d := d) (m := m) (N := n))
+    rcases exists_discOffset_eq_discOffsetUpTo (f := f) (d := d) (m := m) (N := n) with
+      ⟨t, ht, htEq, -⟩
+    exact ⟨t, ht, htEq⟩
 
   -- One-line usage audit: residue-class `UpTo` extraction wrappers.
   example (q r : ℕ)


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `discOffset` extremizer API (argmax, not just max value): strengthen `exists_discOffset_eq_discOffsetUpTo` to return an explicit `n` together with a proof that it maximizes `discOffset` among `n' ≤ N` (argmax-style), so later proofs can “choose a maximizer” without rebuilding comparison lemmas.

What changed
- Strengthened `exists_discOffset_eq_discOffsetUpTo` to return an argmax witness: in addition to equality with `discOffsetUpTo`, it now provides the comparison lemma `∀ n' ≤ N, discOffset … n' ≤ discOffset … n`.
- Updated stable-surface audits/examples to use the strengthened API and added a small regression example extracting the argmax inequality.

Notes
- No new opportunistic lemmas; just strengthens the existing API and updates call sites.
