### PR TITLE
Discrepancy: argmax-style witness for discOffsetUpTo

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -35,10 +35,12 @@ The goal is to pair verified artifacts with learning scaffolding.
 - **API note:** `discOffsetUpTo` is monotone in the cutoff. Use `discOffsetUpTo_mono` for an arbitrary `N ≤ N'`, or the convenience wrapper `discOffsetUpTo_le_add` for the common “extend by `K`” case `N ≤ N+K`.
   If your goal is stated with `Nat.succ N` instead of `N+1`, use the wrapper `discOffsetUpTo_le_succNat`.
 - **API note (argmax witness for `discOffsetUpTo`):** the lemma
-  `exists_discOffset_eq_discOffsetUpTo` returns not just a witness `n ≤ N` with
-  `discOffset … n = discOffsetUpTo … N`, but also the comparison fact
-  `∀ n' ≤ N, discOffset … n' ≤ discOffset … n`.
-  Pattern: `rcases exists_discOffset_eq_discOffsetUpTo … with ⟨n, hnle, hnEq, hmax⟩` and then use `hmax` to avoid rebuilding “≤ sup” inequalities.
+  `exists_discOffset_eq_discOffsetUpTo` returns a witness `n ≤ N` together with
+  the *argmax* comparison fact `∀ n' ≤ N, discOffset … n' ≤ discOffset … n`, and
+  an equality oriented as `discOffsetUpTo … N = discOffset … n`.
+  Pattern: `rcases exists_discOffset_eq_discOffsetUpTo … with ⟨n, hnle, hnEq, hmax⟩`;
+  then `simpa [hnEq]` rewrites the max value to the chosen witness, and `hmax`
+  supplies all “≤ maximizer” inequalities without redoing `Finset.sup` reasoning.
 - **API note (tail concatenation, max-level):** for later Tao2015 bookkeeping, prefer the wrapper
   `discOffsetUpTo_tail_concat_le`:
   `discOffsetUpTo f d m (N+K) ≤ discOffsetUpTo f d m N + discOffsetUpTo f d (m+N) K`.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -1351,13 +1351,17 @@ lemma discOffsetUpTo_le_succNat (f : ℕ → ℤ) (d m N : ℕ) :
     discOffsetUpTo f d m N ≤ discOffsetUpTo f d m (Nat.succ N) := by
   simpa [Nat.succ_eq_add_one] using (discOffsetUpTo_le_succ (f := f) (d := d) (m := m) (N := N))
 
-/-- The maximum in `discOffsetUpTo` is attained by some `n ≤ N`.
+/-- The maximum in `discOffsetUpTo` is attained by some `n ≤ N`, together with an
+argmax-style comparison lemma.
+
+This packages the common pattern “choose a maximizer `n` and then reuse the inequality
+`discOffset _ n' ≤ discOffset _ n` for all `n' ≤ N`” without unfolding `discOffsetUpTo`.
 
 Checklist item: Problems/erdos_discrepancy.md (Track B) — “Max discrepancy up to N” API.
 -/
 lemma exists_discOffset_eq_discOffsetUpTo (f : ℕ → ℤ) (d m N : ℕ) :
     ∃ n ≤ N,
-      discOffset f d m n = discOffsetUpTo f d m N ∧
+      discOffsetUpTo f d m N = discOffset f d m n ∧
       ∀ n' ≤ N, discOffset f d m n' ≤ discOffset f d m n := by
   classical
   unfold discOffsetUpTo
@@ -1371,13 +1375,14 @@ lemma exists_discOffset_eq_discOffsetUpTo (f : ℕ → ℤ) (d m N : ℕ) :
   refine ⟨n, ?_, ?_⟩
   · -- `n ∈ range (N+1)` implies `n ≤ N`.
     exact Nat.le_of_lt_succ (Finset.mem_range.1 hnmem)
-  · refine ⟨hsup.symm, ?_⟩
+  · refine ⟨hsup, ?_⟩
     intro n' hn'le
     have hn'mem : n' ∈ Finset.range (N + 1) := by
       exact Finset.mem_range.2 (Nat.lt_succ_of_le hn'le)
     have hle :=
       Finset.le_sup (s := Finset.range (N + 1)) (f := fun t => discOffset f d m t) hn'mem
-    simpa [hsup.symm] using hle
+    -- rewrite the `sup` value to the chosen maximizer
+    simpa [hsup] using hle
 
 /-- In a fixed residue class modulo `q`, the maximum in `discUpTo` is attained by some `n ≤ N`.
 

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -510,7 +510,7 @@ unfolding `discOffsetUpTo`.
 
 example (f : ℕ → ℤ) (d m N : ℕ) :
     ∃ n ≤ N,
-      discOffset f d m n = discOffsetUpTo f d m N ∧
+      discOffsetUpTo f d m N = discOffset f d m n ∧
       ∀ n' ≤ N, discOffset f d m n' ≤ discOffset f d m n := by
   -- This is the packaged witness-extraction lemma.
   simpa using (exists_discOffset_eq_discOffsetUpTo (f := f) (d := d) (m := m) (N := N))

--- a/MoltResearch/Discrepancy/SurfaceAudit.lean
+++ b/MoltResearch/Discrepancy/SurfaceAudit.lean
@@ -266,7 +266,7 @@ section
   example : ∃ t ≤ n, discOffset f d m t = discOffsetUpTo f d m n := by
     rcases exists_discOffset_eq_discOffsetUpTo (f := f) (d := d) (m := m) (N := n) with
       ⟨t, ht, htEq, -⟩
-    exact ⟨t, ht, htEq⟩
+    exact ⟨t, ht, htEq.symm⟩
 
   -- One-line usage audit: residue-class `UpTo` extraction wrappers.
   example (q r : ℕ)


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `discOffset` extremizer API (argmax, not just max value): strengthen `exists_discOffset_eq_discOffsetUpTo` to return an explicit `n` together with a proof that it maximizes `discOffset` among `n' ≤ N` (argmax-style), so later proofs can “choose a maximizer” without rebuilding comparison lemmas.

What changed
- Strengthen `exists_discOffset_eq_discOffsetUpTo` to return the equality in the direction
  `discOffsetUpTo … = discOffset … n`, plus the argmax inequality `∀ n' ≤ N, discOffset … n' ≤ discOffset … n`.
- Update stable-surface regressions (`NormalFormExamples.lean` + `SurfaceAudit.lean`) to match the new API.

CI
- `make ci`