### PR TITLE
Track C: move UnboundedDiscOffset NNF lemma to Tao2015

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/Tao2015.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/Tao2015.lean
@@ -614,6 +614,19 @@ theorem iff_not_exists_forall_natAbs_sum_Icc_offset_le (f : ℕ → ℤ) (d m : 
 
 end UnboundedDiscOffset
 
+/-- Normal form: unbounded offset discrepancy means there is no uniform bundled offset-nucleus bound.
+
+Negation-normal form:
+`¬ ∃ B, ∀ n, Int.natAbs (apSumOffset f d m n) ≤ B`.
+
+This is just a naming wrapper around
+`UnboundedDiscOffset.iff_not_exists_forall_natAbs_apSumOffset_le`.
+-/
+theorem unboundedDiscOffset_iff_not_exists_forall_natAbs_apSumOffset_le (f : ℕ → ℤ) (d m : ℕ) :
+    UnboundedDiscOffset f d m ↔ (¬ ∃ B : ℕ, ∀ n : ℕ, Int.natAbs (apSumOffset f d m n) ≤ B) := by
+  simpa using
+    (UnboundedDiscOffset.iff_not_exists_forall_natAbs_apSumOffset_le (f := f) (d := d) (m := m))
+
 /-- Normal form: unbounded offset discrepancy means there is no uniform `discOffset` bound.
 
 Negation-normal form:

--- a/Conjectures/C0002_erdos_discrepancy/src/Tao2015Extras.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/Tao2015Extras.lean
@@ -126,23 +126,6 @@ theorem exists_boundedDiscOffset_iff_exists_forall_natAbs_apSumFrom_mul_le (f : 
       (boundedDiscOffset_iff_forall_natAbs_apSumFrom_mul_le (f := f) (d := d) (m := m) (B := B)).2
         hB
 
-/-- Normal form: unbounded offset discrepancy means there is no uniform bundled offset-nucleus bound.
-
-Negation-normal form:
-`¬ ∃ B, ∀ n, Int.natAbs (apSumOffset f d m n) ≤ B`.
-
-This can be convenient when proving unboundedness by contradiction.
--/
-theorem unboundedDiscOffset_iff_not_exists_forall_natAbs_apSumOffset_le (f : ℕ → ℤ) (d m : ℕ) :
-    UnboundedDiscOffset f d m ↔
-      (¬ ∃ B : ℕ, ∀ n : ℕ, Int.natAbs (apSumOffset f d m n) ≤ B) := by
-  -- Rewrite unboundedness through the negation-normal-form boundedness predicate, then unfold the
-  -- relevant definitions.
-  simpa [BoundedDiscOffset, discOffset, -natAbs_apSumOffset_eq_discOffset] using
-    (Tao2015.unboundedDiscOffset_iff_not_exists_boundedDiscOffset (f := f) (d := d) (m := m))
-
--- moved to `Conjectures.C0002_erdos_discrepancy.src.Tao2015` (core interface)
-
 /-- Normal form: unbounded offset discrepancy means there is no uniform affine-tail nucleus bound.
 
 Negation-normal form:


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a core lemma unboundedDiscOffset_iff_not_exists_forall_natAbs_apSumOffset_le to Tao2015.
- Remove the duplicate declaration from Tao2015Extras so downstream code can use the lemma without importing the larger extras module.
