### PR TITLE
Track C: simplify stage3Out_d_pos

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -101,7 +101,7 @@ This is sometimes the right normal form when downstream stages want to treat `d`
 theorem stage3Out_d_pos (f : ℕ → ℤ) (hf : IsSignSequence f) :
     (stage3Out (f := f) (hf := hf)).d > 0 := by
   -- Delegate to the Stage-2 core projection lemma (Stage 3 carries a Stage-2 output).
-  simpa using (Stage2Output.hd (out := (stage3Out (f := f) (hf := hf)).out2))
+  simp
 
 /-- Convenience lemma: the Stage-3 reduced step size is nonzero.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Simplify the proof of stage3Out_d_pos by using simp (instead of simpa).
- Removes an unnecessarySimpa linter warning in the hard-gate minimal Stage-3 entry module.
