### PR TITLE
Track C: reuse Stage-2 core reduced-boundedness lemma

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2ProofCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2ProofCore.lean
@@ -71,15 +71,9 @@ theorem stage2_notBoundedReducedAlong (f : ℕ → ℤ) (hf : IsSignSequence f) 
     ¬ BoundedDiscrepancyAlong
         (stage2_g (f := f) (hf := hf))
         (stage2_d (f := f) (hf := hf)) := by
-  have hunb : Tao2015.UnboundedDiscrepancyAlong
-      (stage2_g (f := f) (hf := hf))
-      (stage2_d (f := f) (hf := hf)) :=
-    stage2_unboundedDiscrepancyAlong (f := f) (hf := hf)
-  exact
-    (Tao2015.UnboundedDiscrepancyAlong.iff_not_boundedDiscrepancyAlong
-        (g := stage2_g (f := f) (hf := hf))
-        (d := stage2_d (f := f) (hf := hf))).1
-      hunb
+  -- Delegate to the proved Stage-2 core boundary API.
+  simpa [stage2_g, stage2_d, Stage2Output.g, Stage2Output.d] using
+    (Stage2Output.notBoundedReducedAlong (out := stage2Out (f := f) (hf := hf)))
 
 /-- Minimal consumer-facing Stage-2 consequence: Stage 2 yields an unbounded bundled offset
 discrepancy family `discOffset f d m` at the deterministic parameters produced by `stage2Out`.

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
@@ -86,10 +86,9 @@ theorem unboundedDiscrepancyAlong (out : Stage3Output f) :
 
 /-- Stage 3 implies the reduced sequence is not bounded along its fixed step size. -/
 theorem notBoundedReducedAlong (out : Stage3Output f) : ¬ BoundedDiscrepancyAlong out.g out.d := by
-  exact
-    (Tao2015.UnboundedDiscrepancyAlong.iff_not_boundedDiscrepancyAlong
-      (g := out.g) (d := out.d)).1
-      out.unboundedDiscrepancyAlong
+  -- Delegate to the Stage-2 core boundary lemma carried by Stage 3.
+  simpa [Stage3Output.g, Stage3Output.d] using
+    (Stage2Output.notBoundedReducedAlong (f := f) (out := out.out2))
 
 /-- Stage 3 output also exposes the Stage-2 fixed-step unboundedness witness, phrased using the
 verified core predicate `MoltResearch.UnboundedDiscrepancyAlong`.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Refactor stage2_notBoundedReducedAlong to delegate to the proved Stage-2 core lemma Stage2Output.notBoundedReducedAlong.
- Refactor Stage3Output.notBoundedReducedAlong to delegate to the carried Stage-2 core boundary lemma, reducing duplicated glue.
