### PR TITLE
Track C: stage3 NNF wrapper + dedup decls

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancyWitnesses.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancyWitnesses.lean
@@ -31,6 +31,25 @@ theorem erdos_discrepancy_sum_Icc_offset_stage3 (f : ℕ → ℤ) (hf : IsSignSe
   simpa [Tao2015.stage3_m, Tao2015.stage3_d, hout.symm] using
     (Tao2015.Stage3Output.forall_exists_natAbs_sum_Icc_offset_gt (f := f) out)
 
+/-- Negation-normal-form corollary for the concrete Stage-3 offset parameters.
+
+Normal form:
+`¬ ∃ B, ∀ n, Int.natAbs (∑ i ∈ Icc (m+1) (m+n), f (i*d)) ≤ B`,
+where `d = Tao2015.stage3_d f hf` and `m = Tao2015.stage3_m f hf`.
+
+This is a thin wrapper around `Tao2015.stage3_not_exists_forall_natAbs_sum_Icc_offset_le`.
+-/
+theorem erdos_discrepancy_not_exists_forall_natAbs_sum_Icc_offset_le_stage3 (f : ℕ → ℤ)
+    (hf : IsSignSequence f) :
+    ¬ ∃ B : ℕ,
+      ∀ n : ℕ,
+        Int.natAbs
+            ((Finset.Icc ((Tao2015.stage3_m (f := f) (hf := hf)) + 1)
+                  ((Tao2015.stage3_m (f := f) (hf := hf)) + n)).sum
+                (fun i => f (i * (Tao2015.stage3_d (f := f) (hf := hf))))) ≤ B := by
+  simpa [Tao2015.stage3_m, Tao2015.stage3_d] using
+    (Tao2015.stage3_not_exists_forall_natAbs_sum_Icc_offset_le (f := f) (hf := hf))
+
 /-- Positive-length witness form of `erdos_discrepancy_sum_Icc_offset_stage3`.
 
 The witness length `n` cannot be `0`, since the interval `Icc (m+1) (m+n)` is empty when `n = 0`.

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Core.lean
@@ -65,11 +65,13 @@ theorem forall_hasDiscrepancyAtLeastAlong (out : Stage3Output f) :
           (g := out.g) (d := out.d)).2
       out.unboundedReducedAlong
 
-/-- Stage 3 implies the reduced sequence is not bounded along its fixed step size. -/
-theorem notBoundedReducedAlong (out : Stage3Output f) : ¬ BoundedDiscrepancyAlong out.g out.d := by
-  exact
-    (Tao2015.UnboundedDiscrepancyAlong.iff_not_boundedDiscrepancyAlong (g := out.g) (d := out.d)).1
-      out.unboundedReducedAlong
+/-!
+Note: `Stage3Output.notBoundedReducedAlong` is already defined in
+`Conjectures.C0002_erdos_discrepancy.src.TrackCStage3`.
+
+We do not re-declare it here so that `TrackCStage3Core` can be imported alongside `TrackCStage3`
+without name clashes.
+-/
 
 /-!
 Note: `Stage3Output.unboundedDiscrepancyAlong_core` is already defined in

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
@@ -370,18 +370,13 @@ theorem stage3_forall_exists_sum_Icc_d_ge_one_witness_pos (f : ℕ → ℤ) (hf 
     (forall_hasDiscrepancyAtLeast_iff_forall_exists_sum_Icc_d_ge_one_witness_pos f).1
       (stage3_forall_hasDiscrepancyAtLeast (f := f) (hf := hf))
 
-/-- Strengthened variant of `stage3_forall_exists_discrepancy_gt` with a positive-length witness.
+/-!
+Note: `stage3_forall_exists_discrepancy_gt_witness_pos` is already defined in
+`Conjectures.C0002_erdos_discrepancy.src.TrackCStage3EntryMinimal`.
 
-Since `discrepancy f d 0 = 0`, any witness with `discrepancy f d n > C` can be taken with `n > 0`.
+We avoid re-declaring it here so that `TrackCStage3EntryCore` can be imported alongside the
+minimal entry-point module without name clashes.
 -/
-theorem stage3_forall_exists_discrepancy_gt_witness_pos (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    ∀ C : ℕ, ∃ d n : ℕ, d > 0 ∧ n > 0 ∧ discrepancy f d n > C := by
-  intro C
-  rcases stage3_forall_exists_d_pos_witness_pos (f := f) (hf := hf) C with ⟨d, n, hd, hn, hw⟩
-  refine ⟨d, n, hd, hn, ?_⟩
-  -- `discrepancy f d n` is definitionally `Int.natAbs (apSum f d n)`.
-  change Int.natAbs (apSum f d n) > C
-  exact hw
 
 -- (also available via `Conjectures.C0002_erdos_discrepancy.src.TrackCStage3Entry`)
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Output.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Output.lean
@@ -214,17 +214,13 @@ theorem not_exists_forall_natAbs_apSumOffset_le (out : Stage3Output f) :
   simpa [Stage3Output.d, Stage3Output.m] using
     (Stage2Output.not_exists_forall_natAbs_apSumOffset_le (f := f) out.out2)
 
-/-- Normal form: Stage 3 unboundedness means there is no uniform `discOffset` bound.
+/-!
+Note: `Stage3Output.not_exists_forall_discOffset_le` is already defined in
+`Conjectures.C0002_erdos_discrepancy.src.TrackCStage3`.
 
-Negation-normal form:
-`¬ ∃ B, ∀ n, discOffset f out.d out.m n ≤ B`.
-
-This is a thin wrapper around `Stage2Output.not_exists_forall_discOffset_le`.
+We do not re-declare it here so that `TrackCStage3Output` can be imported alongside
+`TrackCStage3` without name clashes.
 -/
-theorem not_exists_forall_discOffset_le (out : Stage3Output f) :
-    ¬ ∃ B : ℕ, ∀ n : ℕ, discOffset f out.d out.m n ≤ B := by
-  simpa [Stage3Output.d, Stage3Output.m] using
-    (Stage2Output.not_exists_forall_discOffset_le (f := f) out.out2)
 
 /-- Nucleus witness form for the concrete Stage-1 parameters bundled in Stage 3.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a Stage-3 paper-notation negation-normal-form corollary: no uniform bound on shifted Icc sums at the deterministic (d, m).
- Remove duplicate Stage-3 declarations in TrackCStage3Core, TrackCStage3EntryCore, and TrackCStage3Output so they can be imported alongside the boundary/minimal modules without name clashes.
