### PR TITLE
Track C: lower priority Stage2 stub instance

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Stub.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Stub.lean
@@ -32,7 +32,9 @@ Design note: we register this instance at very low priority so that downstream d
 provide a verified `Stage2Assumption` instance that will be preferred by typeclass search.
 -/
 axiom instStage2Assumption : Stage2Assumption
-attribute [instance 10000] instStage2Assumption
+-- Low-priority default: downstream developments can provide a verified instance that typeclass
+-- search will prefer (larger priorities are tried first).
+attribute [instance 10] instStage2Assumption
 
 /-- **Conjecture stub:** Stage 2 of Tao 2015.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Fix Stage-2 stub typeclass instance priority so it is actually low-priority (smaller number), matching the design intent.
- Makes it easier for downstream developments to override the Conjectures-only axiom instance with a verified Stage2Assumption instance.
