### PR TITLE
Discrepancy: discOffsetUpTo single-witness normal form

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -41,6 +41,11 @@ The goal is to pair verified artifacts with learning scaffolding.
   Pattern: `rcases exists_discOffset_eq_discOffsetUpTo … with ⟨n, hnle, hnEq, hmax⟩`;
   then `simpa [hnEq]` rewrites the max value to the chosen witness, and `hmax`
   supplies all “≤ maximizer” inequalities without redoing `Finset.sup` reasoning.
+
+- **API note (single-witness strict inequality, max-level):** if you *only* need a witness for a strict inequality (rather than an argmax + comparison), use
+  `lt_discOffsetUpTo_iff_exists_lt_discOffset`:
+  `C < discOffsetUpTo f d m N ↔ ∃ n ≤ N, C < discOffset f d m n`.
+  This is often the cleanest way to move between “max over a finite set” and “∃ witness” without unfolding `Finset.sup`.
 - **API note (tail concatenation, max-level):** for later Tao2015 bookkeeping, prefer the wrapper
   `discOffsetUpTo_tail_concat_le`:
   `discOffsetUpTo f d m (N+K) ≤ discOffsetUpTo f d m N + discOffsetUpTo f d (m+N) K`.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -1384,6 +1384,28 @@ lemma exists_discOffset_eq_discOffsetUpTo (f : ℕ → ℤ) (d m N : ℕ) :
     -- rewrite the `sup` value to the chosen maximizer
     simpa [hsup] using hle
 
+/-- Single-witness normal form for inequalities involving `discOffsetUpTo`.
+
+This is a convenience lemma: an inequality `C < discOffsetUpTo f d m N` is equivalent to the
+existence of a single witness `n ≤ N` with `C < discOffset f d m n`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) —
+`discOffsetUpTo` vs single-witness normal form.
+-/
+lemma lt_discOffsetUpTo_iff_exists_lt_discOffset (f : ℕ → ℤ) (d m N C : ℕ) :
+    (C < discOffsetUpTo f d m N) ↔ (∃ n ≤ N, C < discOffset f d m n) := by
+  classical
+  constructor
+  · intro h
+    rcases exists_discOffset_eq_discOffsetUpTo (f := f) (d := d) (m := m) (N := N) with
+      ⟨n, hnle, hEq, -⟩
+    refine ⟨n, hnle, ?_⟩
+    -- rewrite `discOffsetUpTo` to the maximizing `discOffset`
+    simpa [hEq] using h
+  · rintro ⟨n, hnle, hnC⟩
+    exact lt_of_lt_of_le hnC (discOffset_le_discOffsetUpTo (f := f) (d := d) (m := m) (n := n)
+      (N := N) hnle)
+
 /-- In a fixed residue class modulo `q`, the maximum in `discUpTo` is attained by some `n ≤ N`.
 
 This is a residue-friendly witness-extraction lemma: rather than maximizing over all `n ≤ N`, we

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -138,6 +138,11 @@ example : discOffsetUpTo f (d * q) m n = discOffsetUpTo (fun k => f (k * q)) d m
 example : discOffsetUpTo f (q * d) m n = discOffsetUpTo (fun k => f (q * k)) d m n := by
   simpa using (discOffsetUpTo_step_mul_left (f := f) (q := q) (d := d) (m := m) (N := n))
 
+-- NEW (Track B): `discOffsetUpTo` vs single-witness normal form.
+example : (C < discOffsetUpTo f d m n) ↔ (∃ n' ≤ n, C < discOffset f d m n') := by
+  simpa using
+    (lt_discOffsetUpTo_iff_exists_lt_discOffset (f := f) (d := d) (m := m) (N := n) (C := C))
+
 example (hq : q > 0) : discOffsetUpTo f d m n ≤ discOffsetUpTo f d m (n * q) := by
   simpa using (discOffsetUpTo_le_mul (f := f) (d := d) (m := m) (N := n) (q := q) hq)
 

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -72,6 +72,11 @@ Goal: build a *directed* lemma scaffold (not lemma-sprawl). Each checkbox should
   (Implemented as `natAbs_sum_Icc_of_le_affineEndpoints_eq_discOffset` (+ specializations/bound-level wrappers)
   in `MoltResearch/Discrepancy/AffineTail.lean`; regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
+- [x] `discOffsetUpTo` vs single-witness normal form: a lemma of the form
+  `C < discOffsetUpTo f d m N ↔ ∃ n ≤ N, C < discOffset f d m n`.
+  (Implemented as `lt_discOffsetUpTo_iff_exists_lt_discOffset` in `MoltResearch/Discrepancy/Basic.lean`;
+  regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
+
 #### Auto-generated backlog (needs triage)
 
 - [x] Canonical homogeneous view of offsets: prove `apSumOffset f d m n = apSum (fun k => f (k + m*d)) d n`


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `discOffsetUpTo` vs single-witness normal form: a lemma of the form
  `C < discOffsetUpTo f d m N ↔ ∃ n ≤ N, C < discOffset f d m n`.

Summary:
- Add lemma `lt_discOffsetUpTo_iff_exists_lt_discOffset` (in `MoltResearch/Discrepancy/Basic.lean`) giving a clean witness form for strict inequalities involving `discOffsetUpTo`.
- Add a stable-surface regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.
- Mark the checklist item as completed in `Problems/erdos_discrepancy.md`.

Tests:
- `make ci`
