### PR TITLE
Discrepancy: exists-bound bridge for discOffsetUpTo

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -57,6 +57,10 @@ The goal is to pair verified artifacts with learning scaffolding.
   `BoundedDiscrepancyAlong f d len B` is equivalent to the single inequality
   `discOffsetUpTo f d 0 len ≤ B` via `boundedDiscrepancyAlong_iff_discOffsetUpTo_le`.
   This is the bridge that lets later steps rewrite boundedness hypotheses into a one-line max bound.
+- **API note (exists-bound normal form, `discOffsetUpTo`):** if you want the *existential* boundedness normal form (there exists a uniform bound over all cutoffs), use
+  `boundedDiscOffsetExists_iff_exists_forall_discOffsetUpTo_le`:
+  `BoundedDiscOffsetExists f d m ↔ ∃ B, ∀ N, discOffsetUpTo f d m N ≤ B`.
+  This packages the fixed-`B` bridge `boundedDiscOffset_iff_forall_discOffsetUpTo_le` into a single ergonomic equivalence.
 - **API note (max recursion):** when you need to peel the last case off a cutoff, rewrite `discOffsetUpTo f d m (N+1)` using `discOffsetUpTo_succ` to get a clean `max (discOffsetUpTo … N) (discOffset … (N+1))` normal form.
 - **API note (step positivity):** when extracting unboundedness witnesses, prefer the `Nat.succ` normal forms (`HasDiscrepancyAtLeast.exists_witness_succ(_pos)` and the affine analogue) so you can work with a concrete positive step without carrying a separate `d ≥ 1` side condition.
   The degenerate corner case `d = 0` also has stable-surface simp normal forms:

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -1647,6 +1647,26 @@ theorem boundedDiscOffsetExists_iff_exists_forall_discOffset_le (f : ℕ → ℤ
     BoundedDiscOffsetExists f d m ↔ ∃ B : ℕ, ∀ n : ℕ, discOffset f d m n ≤ B := by
   rfl
 
+/-!
+### Exists-bound bridge lemma for `discOffsetUpTo`
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) —
+Bridge: boundedness of `discOffsetUpTo` ↔ boundedness of all `discOffset` witnesses.
+
+This lemma upgrades the “there exists a uniform bound” normal form from pointwise `discOffset`
+to the `discOffsetUpTo` wrapper, reusing `boundedDiscOffset_iff_forall_discOffsetUpTo_le`.
+-/
+
+theorem boundedDiscOffsetExists_iff_exists_forall_discOffsetUpTo_le (f : ℕ → ℤ) (d m : ℕ) :
+    BoundedDiscOffsetExists f d m ↔ ∃ B : ℕ, ∀ N : ℕ, discOffsetUpTo f d m N ≤ B := by
+  constructor
+  · rintro ⟨B, hB⟩
+    refine ⟨B, ?_⟩
+    exact (boundedDiscOffset_iff_forall_discOffsetUpTo_le (f := f) (d := d) (m := m) (B := B)).1 hB
+  · rintro ⟨B, hB⟩
+    refine ⟨B, ?_⟩
+    exact (boundedDiscOffset_iff_forall_discOffsetUpTo_le (f := f) (d := d) (m := m) (B := B)).2 hB
+
 /-- `BoundedDiscAlongExists f d` means: there exists a uniform bound on all `discAlong f d n`.
 
 Checklist item: Problems/erdos_discrepancy.md (Track B) — Boundedness normal form (exists-bound, discAlong).

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -1013,6 +1013,12 @@ example (B : ℕ) :
     BoundedDiscOffset f d m B ↔ ∀ N : ℕ, discOffsetUpTo f d m N ≤ B := by
   simpa using (boundedDiscOffset_iff_forall_discOffsetUpTo_le (f := f) (d := d) (m := m) (B := B))
 
+-- Regression (Track B): exists-bound bridge for `discOffsetUpTo`.
+example (f : ℕ → ℤ) (d m : ℕ) :
+    BoundedDiscOffsetExists f d m ↔ ∃ B : ℕ, ∀ N : ℕ, discOffsetUpTo f d m N ≤ B := by
+  simpa using
+    (boundedDiscOffsetExists_iff_exists_forall_discOffsetUpTo_le (f := f) (d := d) (m := m))
+
 -- Regression (Track B / concatenation inequality for `discOffsetUpTo`): a sharper bound that
 -- isolates the tail segment.
 example :
@@ -4052,7 +4058,7 @@ example : apSumFrom f a d (n + 1) = apSumFrom f a d n + f (a + (n + 1) * d) := b
   simpa using apSumFrom_succ (f := f) (a := a) (d := d) (n := n)
 
 example : apSumFrom f a d 0 = 0 := by
-  simp
+  simpa using (apSumFrom_zero (f := f) (a := a) (d := d))
 
 example : apSumFrom f a d (n + 1) = f (a + d) + apSumFrom f (a + d) d n := by
   simpa using apSumFrom_succ_length (f := f) (a := a) (d := d) (n := n)
@@ -4065,7 +4071,7 @@ example : apSumFrom f a d (m + n) = apSumFrom f a d m + apSumFrom f (a + m * d) 
   simpa using apSumFrom_add_length (f := f) (a := a) (d := d) (m := m) (n := n)
 
 example : apSumFrom f a 0 n = n • f a := by
-  simp
+  simpa using (apSumFrom_zero_d (f := f) (a := a) (n := n))
 
 -- Affine sums at `a = 0` are just homogeneous AP sums.
 example : apSumFrom f 0 d n = apSum f d n := by


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Bridge: boundedness of `discOffsetUpTo` ↔ boundedness of all `discOffset` witnesses: prove

Adds the exists-bound normal form:
- `BoundedDiscOffsetExists f d m ↔ ∃ B, ∀ N, discOffsetUpTo f d m N ≤ B`

This packages the existing fixed-`B` bridge `boundedDiscOffset_iff_forall_discOffsetUpTo_le` into an ergonomic "there exists a uniform bound" equivalence.

Includes a stable-surface regression example under `import MoltResearch.Discrepancy` (NormalFormExamples).
