### PR TITLE
Discrepancy: boundedness bridge (discOffsetUpTo ↔ discOffset)

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -61,6 +61,13 @@ The goal is to pair verified artifacts with learning scaffolding.
   `boundedDiscOffsetExists_iff_exists_forall_discOffsetUpTo_le`:
   `BoundedDiscOffsetExists f d m ↔ ∃ B, ∀ N, discOffsetUpTo f d m N ≤ B`.
   This packages the fixed-`B` bridge `boundedDiscOffset_iff_forall_discOffsetUpTo_le` into a single ergonomic equivalence.
++
++- **API note (boundedness bridge, `UpTo` ↔ witnesses):** when you want to move *a fixed bound* `B` between the two quantifier normal forms,
++  - `(∀ N, discOffsetUpTo f d m N ≤ B)` and
++  - `(∀ n, discOffset f d m n ≤ B)`,
++  use `forall_discOffsetUpTo_le_iff_forall_discOffset_le`.
++  The directional lemmas `forall_discOffset_le_of_forall_discOffsetUpTo_le` and
++  `forall_discOffsetUpTo_le_of_forall_discOffset_le` are convenient when you want to stay in implication form.
 - **API note (max recursion):** when you need to peel the last case off a cutoff, rewrite `discOffsetUpTo f d m (N+1)` using `discOffsetUpTo_succ` to get a clean `max (discOffsetUpTo … N) (discOffset … (N+1))` normal form.
 - **API note (step positivity):** when extracting unboundedness witnesses, prefer the `Nat.succ` normal forms (`HasDiscrepancyAtLeast.exists_witness_succ(_pos)` and the affine analogue) so you can work with a concrete positive step without carrying a separate `d ≥ 1` side condition.
   The degenerate corner case `d = 0` also has stable-surface simp normal forms:

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -1627,6 +1627,54 @@ theorem boundedDiscOffset_iff_forall_discOffsetUpTo_le (f : ℕ → ℤ) (d m B 
     exact le_trans hle hUpTo
 
 /-!
+### Bridge: boundedness of `discOffsetUpTo` ↔ boundedness of all `discOffset` witnesses
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) —
+Bridge: boundedness of `discOffsetUpTo` ↔ boundedness of all `discOffset` witnesses.
+
+These are the **direct** quantifier-level bridge lemmas promised by the checklist item:
+
+`(∀ N, discOffsetUpTo f d m N ≤ B) ↔ (∀ n, discOffset f d m n ≤ B)`.
+
+We keep the main statement as an `iff` and also expose the two directions as named lemmas.
+-/
+
+/-- If all finitary maxima `discOffsetUpTo f d m N` are bounded by `B`, then every witness
+`discOffset f d m n` is bounded by `B`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — boundedness bridge (`UpTo` → witnesses).
+-/
+lemma forall_discOffset_le_of_forall_discOffsetUpTo_le (f : ℕ → ℤ) (d m B : ℕ)
+    (h : ∀ N : ℕ, discOffsetUpTo f d m N ≤ B) :
+    ∀ n : ℕ, discOffset f d m n ≤ B := by
+  intro n
+  have hUpTo : discOffsetUpTo f d m n ≤ B := h n
+  exact le_trans (discOffset_le_discOffsetUpTo_self (f := f) (d := d) (m := m) (n := n)) hUpTo
+
+/-- If every witness `discOffset f d m n` is bounded by `B`, then every finitary maximum
+`discOffsetUpTo f d m N` is bounded by `B`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — boundedness bridge (witnesses → `UpTo`).
+-/
+lemma forall_discOffsetUpTo_le_of_forall_discOffset_le (f : ℕ → ℤ) (d m B : ℕ)
+    (h : ∀ n : ℕ, discOffset f d m n ≤ B) :
+    ∀ N : ℕ, discOffsetUpTo f d m N ≤ B := by
+  intro N
+  -- Reuse the `BoundedDiscOffset` bridge lemma.
+  exact (boundedDiscOffset_iff_forall_discOffsetUpTo_le (f := f) (d := d) (m := m) (B := B)).1 h N
+
+/-- Quantifier-level boundedness bridge between the `discOffsetUpTo` normal form and the pointwise
+`discOffset` witnesses.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — boundedness bridge (`iff`).
+-/
+theorem forall_discOffsetUpTo_le_iff_forall_discOffset_le (f : ℕ → ℤ) (d m B : ℕ) :
+    (∀ N : ℕ, discOffsetUpTo f d m N ≤ B) ↔ (∀ n : ℕ, discOffset f d m n ≤ B) := by
+  constructor
+  · exact forall_discOffset_le_of_forall_discOffsetUpTo_le (f := f) (d := d) (m := m) (B := B)
+  · exact forall_discOffsetUpTo_le_of_forall_discOffset_le (f := f) (d := d) (m := m) (B := B)
+
+/-!
 ### Exists-bound normal form
 
 Checklist item: Problems/erdos_discrepancy.md (Track B) — Boundedness normal form (exists-bound).

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -143,6 +143,11 @@ example : (C < discOffsetUpTo f d m n) ↔ (∃ n' ≤ n, C < discOffset f d m n
   simpa using
     (lt_discOffsetUpTo_iff_exists_lt_discOffset (f := f) (d := d) (m := m) (N := n) (C := C))
 
+-- NEW (Track B): boundedness bridge (`discOffsetUpTo` ↔ pointwise `discOffset`).
+example (B : ℕ) :
+    (∀ N : ℕ, discOffsetUpTo f d m N ≤ B) ↔ (∀ n : ℕ, discOffset f d m n ≤ B) := by
+  simpa using (forall_discOffsetUpTo_le_iff_forall_discOffset_le (f := f) (d := d) (m := m) (B := B))
+
 example (hq : q > 0) : discOffsetUpTo f d m n ≤ discOffsetUpTo f d m (n * q) := by
   simpa using (discOffsetUpTo_le_mul (f := f) (d := d) (m := m) (N := n) (q := q) hq)
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Bridge: boundedness of `discOffsetUpTo` ↔ boundedness of all `discOffset` witnesses: prove

What this PR does
- Adds direct quantifier-level bridge lemmas:
  - `forall_discOffset_le_of_forall_discOffsetUpTo_le`
  - `forall_discOffsetUpTo_le_of_forall_discOffset_le`
  - `forall_discOffsetUpTo_le_iff_forall_discOffset_le`
- Adds a stable-surface regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.

Notes
- Lemmas live next to the existing `BoundedDiscOffset` ↔ `discOffsetUpTo` bridge (`boundedDiscOffset_iff_forall_discOffsetUpTo_le`) and reuse it in one direction.
