### PR TITLE
Discrepancy: d=0 simp normal forms for disc/UpTo wrappers

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -29,6 +29,11 @@ The goal is to pair verified artifacts with learning scaffolding.
 
   For definitional unfolding, prefer the explicit lemmas `discrepancy_eq_natAbs_apSum` / `disc_eq_natAbs_apSum` over the shorter `*_def` aliases. Similarly, for offsets prefer `discOffset_eq_natAbs_apSumOffset` (the older `discOffset_def` alias is deprecated).
 
+  **Degenerate step (`d = 0`) convention:** `d = 0` is **allowed** (not forbidden) and the stable surface provides terminating `[simp]` normal forms so downstream goals don't get stuck in the corner case. Typical normal forms:
+  - `apSum f 0 n` and `apSumOffset f 0 m n` simplify to constant-sums
+  - `disc f 0 n` / `discOffset f 0 m n` simplify to `n * Int.natAbs (f 0)`
+  - `discUpTo f 0 N` / `discOffsetUpTo f 0 m N` simplify to a `Finset.sup` of the same multiplicative form
+
   **Argument-order coherence:** `apSumFrom` uses `(a d n)` (“start, step, length”), while the historical offset nucleus uses `apSumOffset f d m n`. When you want to line up parameters across the affine/offset nuclei, use the definitional aliases `apSumOffset' f m d n`, `discOffset' f m d n`, and `discOffsetUpTo' f m d N`.
 - **API note (triangle vs reverse triangle):** for concatenation, `discOffset_add_le` is the forward triangle inequality. The reverse-triangle companions are `discOffset_left_le_add` / `discOffset_right_le_add`, proved by rewriting `S(n₁) = S(n₁+n₂) - S'(n₂)` and applying `Int.natAbs_sub_le`.
 - **API note (endpoint-algebra wrappers):** three-segment concatenation is available as `discOffset_add_add_le`, but downstream goals often appear with right-associated endpoints. Use `discOffset_add_add_le_assoc` when your goal has length `n₁ + (n₂ + n₃)` and/or third-start index `m + (n₁ + n₂)` so you can `simpa` without manual `Nat.add_assoc` reassociation.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -1164,9 +1164,49 @@ We keep these lemmas forward-oriented and obviously terminating.
   simp
 
 @[simp] lemma discOffset_zero_step (f : ℕ → ℤ) (m n : ℕ) :
-    discOffset f 0 m n = Int.natAbs ((n : ℤ) * f 0) := by
+    discOffset f 0 m n = n * Int.natAbs (f 0) := by
   unfold discOffset
-  simp
+  -- Reduce to `Int.natAbs ((n:ℤ) * f 0)` and simplify via multiplicativity of `natAbs`.
+  simp [apSumOffset_zero_step, Int.natAbs_mul, mul_assoc, mul_left_comm, mul_comm]
+
+/-- Degenerate-step normal form for the homogeneous wrapper `disc`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) —
+“Zero-step / d=0 surface discipline”.
+-/
+@[simp] lemma disc_zero_step (f : ℕ → ℤ) (n : ℕ) :
+    disc f 0 n = n * Int.natAbs (f 0) := by
+  unfold disc
+  -- Reduce to `Int.natAbs ((n:ℤ) * f 0)` then simplify via multiplicativity of `natAbs`.
+  simp [apSum_zero_step, Int.natAbs_mul, mul_assoc, mul_left_comm, mul_comm]
+
+/-- Degenerate-step normal form for `discUpTo`.
+
+This does **not** try to solve the `Finset.sup` further; it rewrites the inside to a clean
+multiplicative form so the `d = 0` case doesn't leave `Int` arithmetic in goals.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) —
+“Zero-step / d=0 surface discipline”.
+-/
+@[simp] lemma discUpTo_zero_step (f : ℕ → ℤ) (N : ℕ) :
+    discUpTo f 0 N = (Finset.range (N + 1)).sup (fun n => n * Int.natAbs (f 0)) := by
+  classical
+  unfold discUpTo
+  simp [disc_zero_step]
+
+/-- Degenerate-step normal form for `discOffsetUpTo`.
+
+In particular, the `d = 0` case becomes independent of the offset `m`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) —
+“Zero-step / d=0 surface discipline”.
+-/
+@[simp] lemma discOffsetUpTo_zero_step (f : ℕ → ℤ) (m N : ℕ) :
+    discOffsetUpTo f 0 m N = (Finset.range (N + 1)).sup (fun n => n * Int.natAbs (f 0)) := by
+  classical
+  unfold discOffsetUpTo
+  -- `discOffset_zero_step` makes the offset `m` disappear.
+  simp [discOffset_zero_step]
 
 /-!
 ### Step-one (`d = 1`) coherence simp lemmas

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -103,7 +103,17 @@ example : apSum f 0 n = (n : ℤ) * f 0 := by
 example : apSumOffset f 0 m n = (n : ℤ) * f 0 := by
   simp
 
-example : discOffset f 0 m n = Int.natAbs ((n : ℤ) * f 0) := by
+example : discOffset f 0 m n = n * Int.natAbs (f 0) := by
+  simp
+
+-- NEW (Track B): zero-step / `d = 0` surface discipline for `disc`/`UpTo` wrappers
+example : disc f 0 n = n * Int.natAbs (f 0) := by
+  simp
+
+example : discUpTo f 0 N = (Finset.range (N + 1)).sup (fun n => n * Int.natAbs (f 0)) := by
+  simp
+
+example : discOffsetUpTo f 0 m N = (Finset.range (N + 1)).sup (fun n => n * Int.natAbs (f 0)) := by
   simp
 
 -- NEW (Track B): nucleus API coherence (argument order)


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: “Zero-step / d=0” surface discipline: decide and enforce the canonical convention (`d=0` forbidden vs allowed with a simp-normal form), then add simp/guard lemmas ensuring downstream proofs never get stuck on `d=0` corner cases.

Summary:
- Treat `d = 0` as allowed, and provide terminating `[simp]` normal forms for the wrapper APIs.
- Added `disc_zero_step`, `discUpTo_zero_step`, and `discOffsetUpTo_zero_step`.
- Strengthened `discOffset_zero_step` to a clean multiplicative normal form (`n * Int.natAbs (f 0)`).

Stable-surface regression:
- Extended `MoltResearch/Discrepancy/NormalFormExamples.lean` with compile-only examples (under `import MoltResearch.Discrepancy`) that `simp` the new `d=0` wrapper normal forms.
