### PR TITLE
Discrepancy: zero-step (d=0) discipline checklist + discrepancy_zero_step

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -31,7 +31,8 @@ The goal is to pair verified artifacts with learning scaffolding.
 
   **Degenerate step (`d = 0`) convention:** `d = 0` is **allowed** (not forbidden) and the stable surface provides terminating `[simp]` normal forms so downstream goals don't get stuck in the corner case. Typical normal forms:
   - `apSum f 0 n` and `apSumOffset f 0 m n` simplify to constant-sums
-  - `disc f 0 n` / `discOffset f 0 m n` simplify to `n * Int.natAbs (f 0)`
+  - `disc f 0 n` / `discrepancy f 0 n` / `discOffset f 0 m n` simplify to `n * Int.natAbs (f 0)`
+    (see the stable-surface simp lemmas `disc_zero_step` / `discrepancy_zero_step` / `discOffset_zero_step`).
   - `discUpTo f 0 N` / `discOffsetUpTo f 0 m N` simplify to a `Finset.sup` of the same multiplicative form
 
   **Argument-order coherence:** `apSumFrom` uses `(a d n)` (“start, step, length”), while the historical offset nucleus uses `apSumOffset f d m n`. When you want to line up parameters across the affine/offset nuclei, use the definitional aliases `apSumOffset' f m d n`, `discOffset' f m d n`, and `discOffsetUpTo' f m d N`.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -1180,6 +1180,19 @@ Checklist item: Problems/erdos_discrepancy.md (Track B) —
   -- Reduce to `Int.natAbs ((n:ℤ) * f 0)` then simplify via multiplicativity of `natAbs`.
   simp [apSum_zero_step, Int.natAbs_mul, mul_assoc, mul_left_comm, mul_comm]
 
+/-- Degenerate-step normal form for the homogeneous wrapper `discrepancy`.
+
+This is definitionally the same as `disc_zero_step`, but we keep the lemma so downstream code
+using the `discrepancy` spelling doesn't have to detour through `disc`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) —
+“Zero-step / d=0 surface discipline”.
+-/
+@[simp] lemma discrepancy_zero_step (f : ℕ → ℤ) (n : ℕ) :
+    discrepancy f 0 n = n * Int.natAbs (f 0) := by
+  unfold discrepancy
+  simp [apSum_zero_step, Int.natAbs_mul, mul_assoc, mul_left_comm, mul_comm]
+
 /-- Degenerate-step normal form for `discUpTo`.
 
 This does **not** try to solve the `Finset.sup` further; it rewrites the inside to a clean

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -110,6 +110,10 @@ example : discOffset f 0 m n = n * Int.natAbs (f 0) := by
 example : disc f 0 n = n * Int.natAbs (f 0) := by
   simp
 
+-- Same normalization, but under the `discrepancy` spelling.
+example : discrepancy f 0 n = n * Int.natAbs (f 0) := by
+  simp
+
 example : discUpTo f 0 N = (Finset.range (N + 1)).sup (fun n => n * Int.natAbs (f 0)) := by
   simp
 

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -77,6 +77,14 @@ Goal: build a *directed* lemma scaffold (not lemma-sprawl). Each checkbox should
   (Implemented as `lt_discOffsetUpTo_iff_exists_lt_discOffset` in `MoltResearch/Discrepancy/Basic.lean`;
   regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
+- [x] Zero-step / `d = 0` surface discipline: make `d = 0` either forbidden in the “witness”
+  predicates (preferred: require `d > 0`), or fully simp-normalized so it never becomes a stuck
+  corner case in downstream proofs.
+  (Implemented as `HasDiscrepancyAtLeast` using `d > 0`, plus simp normal forms
+  `apSum_zero_step` / `apSumOffset_zero_step` / `disc_zero_step` / `discrepancy_zero_step` /
+  `discOffset_zero_step` in `MoltResearch/Discrepancy/Basic.lean`; regression examples in
+  `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
+
 #### Auto-generated backlog (needs triage)
 
 - [x] Canonical homogeneous view of offsets: prove `apSumOffset f d m n = apSum (fun k => f (k + m*d)) d n`

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -77,9 +77,9 @@ Goal: build a *directed* lemma scaffold (not lemma-sprawl). Each checkbox should
   (Implemented as `lt_discOffsetUpTo_iff_exists_lt_discOffset` in `MoltResearch/Discrepancy/Basic.lean`;
   regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
-- [x] Zero-step / `d = 0` surface discipline: make `d = 0` either forbidden in the “witness”
-  predicates (preferred: require `d > 0`), or fully simp-normalized so it never becomes a stuck
-  corner case in downstream proofs.
+- [x] Zero-step / d = 0 surface discipline
+  Make `d = 0` either forbidden in the “witness” predicates (preferred: require `d > 0`), or fully
+  simp-normalized so it never becomes a stuck corner case in downstream proofs.
   (Implemented as `HasDiscrepancyAtLeast` using `d > 0`, plus simp normal forms
   `apSum_zero_step` / `apSumOffset_zero_step` / `disc_zero_step` / `discrepancy_zero_step` /
   `discOffset_zero_step` in `MoltResearch/Discrepancy/Basic.lean`; regression examples in


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Zero-step / d = 0 surface discipline

What changed
- Add `[simp]` lemma `discrepancy_zero_step` (matches the existing `disc_zero_step` API).
- Mark the corresponding Track B checklist item as completed in `Problems/erdos_discrepancy.md`.
- Add a tiny stable-surface regression example for `discrepancy f 0 n` in `NormalFormExamples.lean`.

Notes
- CI: `make ci`.
- This keeps the convention that “witness” predicates (`HasDiscrepancyAtLeast`) require `d > 0`, while still providing simp-normal forms for the degenerate `d = 0` case.
