### PR TITLE
Track C: stage3Out reduced sequence is a sign sequence

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -87,6 +87,14 @@ output produced by Stage 2.
     (stage3Out (f := f) (hf := hf)).g = (stage2Out (f := f) (hf := hf)).g := by
   rfl
 
+/-- Convenience lemma: the Stage-3 reduced sequence is a sign sequence.
+
+This is a tiny wrapper around the Stage-2 core projection lemma `Stage2Output.hg`.
+-/
+theorem stage3Out_hg (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    IsSignSequence (stage3Out (f := f) (hf := hf)).g := by
+  simpa using (Stage2Output.hg (out := (stage3Out (f := f) (hf := hf)).out2))
+
 /-- Convenience lemma: the Stage-3 reduced step size is at least `1`.
 
 This is a tiny wrapper around the Stage-2 projection lemma `Stage2Output.one_le_d`.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add stage3Out_hg: the Stage-3 reduced sequence (stage3Out ...).g is a sign sequence.
- Proof is a thin wrapper around the Stage-2 core projection lemma Stage2Output.hg (no new imports).
