### PR TITLE
Track C: simp rewrite for stage3Out.start

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -87,6 +87,11 @@ output produced by Stage 2.
     (stage3Out (f := f) (hf := hf)).g = (stage2Out (f := f) (hf := hf)).g := by
   rfl
 
+/-- Definitional rewrite: the Stage-3 start index `m*d` equals the Stage-2 start index. -/
+@[simp] theorem stage3Out_start (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    (stage3Out (f := f) (hf := hf)).start = (stage2Out (f := f) (hf := hf)).start := by
+  rfl
+
 /-- Convenience lemma: the Stage-3 reduced sequence is a sign sequence.
 
 This is a tiny wrapper around the Stage-2 core projection lemma `Stage2Output.hg`.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a simp lemma stage3Out_start so Stage-3 start index rewrites directly to the Stage-2 start index.
- Keeps TrackCStage3EntryMinimal rewrites complete alongside the existing .d/.m/.g lemmas.
