### PR TITLE
Track C: Stage 3 discrepancy witness wrapper

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
@@ -186,6 +186,23 @@ theorem forall_exists_d_pos_witness_pos (out : Stage3Output f) :
     exact (Nat.succ_le_iff).1 h
   exact ⟨d, n, hdpos, hn, hgt⟩
 
+/-- Stage 3 output implies the explicit discrepancy witness normal form with a positive-length witness.
+
+Normal form:
+`∀ C, ∃ d n, d > 0 ∧ n > 0 ∧ discrepancy f d n > C`.
+
+This is a thin wrapper around `forall_exists_d_pos_witness_pos`, rewriting `discrepancy` to its
+definitional `apSum` form.
+-/
+theorem forall_exists_discrepancy_gt_witness_pos (out : Stage3Output f) :
+    ∀ C : ℕ, ∃ d n : ℕ, d > 0 ∧ n > 0 ∧ discrepancy f d n > C := by
+  intro C
+  rcases out.forall_exists_d_pos_witness_pos (f := f) C with ⟨d, n, hd, hn, hgt⟩
+  refine ⟨d, n, hd, hn, ?_⟩
+  -- `discrepancy f d n` is definitionally `Int.natAbs (apSum f d n)`.
+  change Int.natAbs (apSum f d n) > C
+  exact hgt
+
 end Stage3Output
 
 /-!

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -266,20 +266,13 @@ theorem stage3_forall_exists_discrepancy_gt (f : ℕ → ℤ) (hf : IsSignSequen
 Normal form:
 `∀ C, ∃ d n, d > 0 ∧ n > 0 ∧ discrepancy f d n > C`.
 
-Implementation note: we use the core witness-normal form lemma
-`HasDiscrepancyAtLeast_iff_exists_discrepancy_ge_one_witness_pos` to avoid re-proving that
-`discrepancy f d 0 = 0`.
+This is a thin wrapper around the Stage-3 API lemma
+`Stage3Output.forall_exists_discrepancy_gt_witness_pos`.
 -/
 theorem stage3_forall_exists_discrepancy_gt_witness_pos (f : ℕ → ℤ) (hf : IsSignSequence f) :
     ∀ C : ℕ, ∃ d n : ℕ, d > 0 ∧ n > 0 ∧ discrepancy f d n > C := by
-  intro C
-  have hC : HasDiscrepancyAtLeast f C :=
-    (stage3_forall_hasDiscrepancyAtLeast (f := f) (hf := hf)) C
-  rcases
-      (HasDiscrepancyAtLeast_iff_exists_discrepancy_ge_one_witness_pos (f := f) (C := C)).1 hC with
-    ⟨d, n, hd, hn, hgt⟩
-  refine ⟨d, n, ?_, hn, hgt⟩
-  exact lt_of_lt_of_le Nat.zero_lt_one hd
+  let out := stage3Out (f := f) (hf := hf)
+  exact out.forall_exists_discrepancy_gt_witness_pos (f := f)
 
 /-- Specialization of `stage3_forall_hasDiscrepancyAtLeast` at a fixed threshold `C`.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a Stage-3 API lemma giving positive-length discrepancy witnesses directly from Stage-3 output.
- Refactor the minimal Stage-3 entry point to delegate to this lemma, reducing duplication and keeping the boundary surface tidy.
