### PR TITLE
Track C: add start-index lemmas to Stage3EntryMinimal

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -102,13 +102,30 @@ theorem stage3Out_start_eq_m_mul_d (f : ℕ → ℤ) (hf : IsSignSequence f) :
       (stage3Out (f := f) (hf := hf)).m * (stage3Out (f := f) (hf := hf)).d := by
   rfl
 
+/-- The Stage-3 start index is a multiple of the Stage-3 reduced step size.
+
+This lemma is intentionally kept in the minimal entry-point module: it is a common arithmetic
+rewrite needed by downstream stages, and it is already proved at the Stage-3 boundary.
+-/
+theorem stage3Out_d_dvd_start (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    (stage3Out (f := f) (hf := hf)).d ∣ (stage3Out (f := f) (hf := hf)).start := by
+  exact Stage3Output.d_dvd_start (f := f) (out := stage3Out (f := f) (hf := hf))
+
+/-- The Stage-3 start index has remainder `0` modulo the reduced step size.
+
+This is often the most convenient normal form of `stage3Out_d_dvd_start`.
+-/
+theorem stage3Out_start_mod_d (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    (stage3Out (f := f) (hf := hf)).start % (stage3Out (f := f) (hf := hf)).d = 0 := by
+  exact Nat.mod_eq_zero_of_dvd (stage3Out_d_dvd_start (f := f) (hf := hf))
+
 /-- Convenience lemma: the Stage-3 reduced sequence is a sign sequence.
 
 This is a tiny wrapper around the Stage-2 core projection lemma `Stage2Output.hg`.
 -/
 theorem stage3Out_hg (f : ℕ → ℤ) (hf : IsSignSequence f) :
     IsSignSequence (stage3Out (f := f) (hf := hf)).g := by
-  simpa using (Stage2Output.hg (out := (stage3Out (f := f) (hf := hf)).out2))
+  exact Stage2Output.hg (out := (stage3Out (f := f) (hf := hf)).out2)
 
 /-- Convenience lemma: the Stage-3 reduced step size is at least `1`.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Extend the Stage-3 minimal entry module with start-index arithmetic facts needed downstream.
- Add lemmas stage3Out_d_dvd_start and stage3Out_start_mod_d for the deterministic Stage-3 parameters.
- Keep the hard-gate surface lightweight by proving these directly from the Stage-3 boundary output.
