### PR TITLE
Track C: Stage2 start rewrite lemma in core

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
@@ -50,6 +50,14 @@ theorem hg (out : Stage2Output f) : IsSignSequence out.g := by
 /-- Convenience projection: the affine-tail start index `m*d` bundled in Stage 1. -/
 abbrev start (out : Stage2Output f) : ℕ := out.m * out.d
 
+/-- Definitional rewrite: the affine-tail start index is `m*d`.
+
+This lemma is intentionally tiny (and not a simp lemma): it exists mainly to reduce `dsimp` noise
+in downstream arithmetic rewrites.
+-/
+theorem start_eq_m_mul_d (out : Stage2Output f) : out.start = out.m * out.d := by
+  rfl
+
 /-- Convenience projection: positivity of the reduced step size. -/
 @[simp] abbrev hd (out : Stage2Output f) : out.d > 0 := out.out1.hd
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2CoreExtras.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2CoreExtras.lean
@@ -24,13 +24,8 @@ variable {f : ℕ → ℤ}
 
 -- Note: `Stage2Output.start` is defined in `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Core`.
 
-/-- Definitional rewrite: the affine-tail start index is `m*d`.
-
-This lemma is intentionally tiny (and not a simp lemma): it exists mainly to reduce `dsimp` noise
-in downstream arithmetic rewrites.
--/
-theorem start_eq_m_mul_d (out : Stage2Output f) : out.start = out.m * out.d := by
-  rfl
+-- Note: the definitional rewrite lemma `Stage2Output.start_eq_m_mul_d` lives in
+-- `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Core` (hard-gate surface).
 
 /-- Normal form: the affine-tail nucleus starting at the bundled start index `out.start`
 is the bundled offset nucleus at the bundled offset parameter `out.m`.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Move the definitional rewrite lemma Stage2Output.start_eq_m_mul_d into TrackCStage2Core (the hard-gate surface).
- Remove the duplicate definition from TrackCStage2CoreExtras (still available via the core import).
- Keeps the lemma non-simp; intended to reduce dsimp noise in downstream arithmetic rewrites.
