### PR TITLE
Track C: Stage4 start is a multiple of d

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage4Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage4Core.lean
@@ -71,6 +71,11 @@ They let downstream stages write `out.d`, `out.m`, etc. without reaching through
 /-- Convenience projection: the affine-tail start index `m*d` carried by Stage 4. -/
 abbrev start (out : Stage4Output f) : ℕ := out.m * out.d
 
+/-- The affine-tail start index `out.start` is a multiple of the reduced step size `out.d`. -/
+theorem d_dvd_start (out : Stage4Output f) : out.d ∣ out.start := by
+  refine ⟨out.m, ?_⟩
+  simp [Stage4Output.start, Nat.mul_comm]
+
 /-- Convenience projection: positivity of the reduced step size. -/
 @[simp] abbrev hd (out : Stage4Output f) : out.d > 0 := out.out2.hd
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add Stage4Output.d_dvd_start: the Stage-4 start index out.start is a multiple of the step size out.d.
- This mirrors the Stage-2/Stage-3 boundary arithmetic helper and reduces downstream rewriting noise.
