### PR TITLE
Track C: Stage2 start is a multiple of d

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
@@ -58,6 +58,18 @@ in downstream arithmetic rewrites.
 theorem start_eq_m_mul_d (out : Stage2Output f) : out.start = out.m * out.d := by
   rfl
 
+/-- The Stage-2 start index is a multiple of the Stage-2 step size. -/
+theorem d_dvd_start (out : Stage2Output f) : out.d ∣ out.start := by
+  refine ⟨out.m, ?_⟩
+  simp [Stage2Output.start, Nat.mul_comm]
+
+/-- The Stage-2 start index has remainder `0` modulo the Stage-2 step size.
+
+This is often the most convenient normal form of `d_dvd_start`.
+-/
+theorem start_mod_d (out : Stage2Output f) : out.start % out.d = 0 := by
+  exact Nat.mod_eq_zero_of_dvd out.d_dvd_start
+
 /-- Convenience projection: positivity of the reduced step size. -/
 @[simp] abbrev hd (out : Stage2Output f) : out.d > 0 := out.out1.hd
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Added Stage-2 arithmetic API lemmas: start is a multiple of the reduced step size d.
- Provided the modulo-normal form start % d = 0 as a convenience wrapper for downstream stages.
