### PR TITLE
Track C: stage3Out_start_div_d

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -150,6 +150,17 @@ theorem stage3Out_d_pos (f : ℕ → ℤ) (hf : IsSignSequence f) :
   have h1 : 1 ≤ (stage3Out (f := f) (hf := hf)).d := stage3_one_le_d (f := f) (hf := hf)
   exact lt_of_lt_of_le Nat.zero_lt_one h1
 
+/-- Recover the offset parameter `m` by dividing the Stage-3 start index `start` by the step size `d`.
+
+This is a tiny arithmetic convenience lemma: `start = m*d` by definition.
+-/
+theorem stage3Out_start_div_d (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    (stage3Out (f := f) (hf := hf)).start / (stage3Out (f := f) (hf := hf)).d =
+      (stage3Out (f := f) (hf := hf)).m := by
+  have hd' : 0 < (stage3Out (f := f) (hf := hf)).d := stage3Out_d_pos (f := f) (hf := hf)
+  rw [stage3Out_start_eq_m_mul_d (f := f) (hf := hf)]
+  exact Nat.mul_div_left (stage3Out (f := f) (hf := hf)).m hd'
+
 /-- Convenience lemma: the Stage-3 reduced step size is nonzero.
 
 This is sometimes the right normal form for downstream stages that treat `d` as a denominator (or


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a minimal-entry lemma stage3Out_start_div_d: start divided by d recovers m
- Helps downstream stages normalize start-index arithmetic without importing larger Stage-3 convenience layers
