### PR TITLE
Track C: Stage-2 start_div_d in core

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
@@ -70,6 +70,16 @@ This is often the most convenient normal form of `d_dvd_start`.
 theorem start_mod_d (out : Stage2Output f) : out.start % out.d = 0 := by
   exact Nat.mod_eq_zero_of_dvd out.d_dvd_start
 
+/-- Recover the offset parameter `out.m` by dividing the start index `out.start` by the step size
+`out.d`.
+
+This is a tiny arithmetic convenience lemma: `out.start = out.m * out.d` by definition.
+-/
+theorem start_div_d (out : Stage2Output f) : out.start / out.d = out.m := by
+  have hd' : 0 < out.d := by
+    simpa using out.out1.hd
+  simpa [Stage2Output.start] using (Nat.mul_div_left out.m hd')
+
 /-- Convenience projection: positivity of the reduced step size. -/
 @[simp] abbrev hd (out : Stage2Output f) : out.d > 0 := out.out1.hd
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2CoreExtras.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2CoreExtras.lean
@@ -103,16 +103,8 @@ theorem start_add_mod_d (out : Stage2Output f) (n : ℕ) :
     (out.start + n) % out.d = n % out.d := by
   simpa [Nat.add_comm] using out.add_start_mod_d (f := f) (n := n)
 
-/-- Recover the offset parameter `out.m` by dividing the start index `out.start` by the step size
-`out.d`.
-
-This is a tiny arithmetic convenience lemma: `out.start = out.m * out.d` by definition.
--/
-theorem start_div_d (out : Stage2Output f) : out.start / out.d = out.m := by
-  -- `out.out1.hd` is the only side condition needed for `Nat.mul_div_left`.
-  have hd' : 0 < out.d := by
-    simpa [Stage2Output.d] using out.out1.hd
-  simpa [Stage2Output.start] using (Nat.mul_div_left out.m hd')
+-- Note: `Stage2Output.start_div_d` lives in
+-- `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Core` (hard-gate surface).
 
 /-!
 ## Reduced-sequence rewrite helpers


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Moved Tao2015.Stage2Output.start_div_d into TrackCStage2Core so the Stage-2 hard-gate surface includes the basic start-index division lemma.
- Removed the duplicate definition from TrackCStage2CoreExtras (leaving a short note pointing to the core location).
