### PR TITLE
Track C: Stage3Output start rewrite lemma

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
@@ -57,6 +57,14 @@ This is occasionally useful when later stages want access to the deterministic p
 abbrev start (out : Stage3Output f) : ℕ :=
   out.m * out.d
 
+/-- Definitional rewrite: the affine-tail start index is `m*d`.
+
+This lemma is intentionally tiny (and not a simp lemma): it exists mainly to reduce `dsimp` noise
+in downstream arithmetic rewrites.
+-/
+theorem start_eq_m_mul_d (out : Stage3Output f) : out.start = out.m * out.d := by
+  rfl
+
 /-- The affine-tail start index `out.start` is a multiple of the reduced step size `out.d`. -/
 theorem d_dvd_start (out : Stage3Output f) : out.d ∣ out.start := by
   refine ⟨out.m, ?_⟩


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Added a named definitional rewrite lemma Stage3Output.start_eq_m_mul_d.
- This avoids downstream dsimp noise when normalizing the Stage-3 start index expression.
