### PR TITLE
Discrepancy: reverse/reindex normal form for apSumOffset

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -36,6 +36,10 @@ The goal is to pair verified artifacts with learning scaffolding.
   - `discUpTo f 0 N` / `discOffsetUpTo f 0 m N` simplify to a `Finset.sup` of the same multiplicative form
 
   **Argument-order coherence:** `apSumFrom` uses `(a d n)` (“start, step, length”), while the historical offset nucleus uses `apSumOffset f d m n`. When you want to line up parameters across the affine/offset nuclei, use the definitional aliases `apSumOffset' f m d n`, `discOffset' f m d n`, and `discOffsetUpTo' f m d N`.
+- **API note (reverse/reindex normal form, sum-level):** if you need to “reverse the order” of an offset AP sum without doing raw `Finset` algebra, use
+  `apSumOffset_eq_sum_range_reverse`:
+  `apSumOffset f d m n = ∑ i in range n, f ((m + (n - i)) * d)`.
+  This packages the standard `range` reflection (`i ↦ n-1-i`) and simplifies the index to the clean `n - i` form.
 - **API note (triangle vs reverse triangle):** for concatenation, `discOffset_add_le` is the forward triangle inequality. The reverse-triangle companions are `discOffset_left_le_add` / `discOffset_right_le_add`, proved by rewriting `S(n₁) = S(n₁+n₂) - S'(n₂)` and applying `Int.natAbs_sub_le`.
 - **API note (endpoint-algebra wrappers):** three-segment concatenation is available as `discOffset_add_add_le`, but downstream goals often appear with right-associated endpoints. Use `discOffset_add_add_le_assoc` when your goal has length `n₁ + (n₂ + n₃)` and/or third-start index `m + (n₁ + n₂)` so you can `simpa` without manual `Nat.add_assoc` reassociation.
 - **API note:** `discOffsetUpTo` is monotone in the cutoff. Use `discOffsetUpTo_mono` for an arbitrary `N ≤ N'`, or the convenience wrapper `discOffsetUpTo_le_add` for the common “extend by `K`” case `N ≤ N+K`.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -219,6 +219,57 @@ lemma apSumOffset_eq_apSum_shift_mul (f : ℕ → ℤ) (d m n : ℕ) :
   simpa [h]
 
 /-!
+### Reverse / reindex normal forms (Track B)
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — Reverse/reindex normal form (sum-level).
+
+Downstream proofs often want to “reverse the order” of an AP sum (typically to align endpoints)
+without dropping to ad-hoc `Finset` algebra.
+
+We package the canonical `Finset.range` reflection `i ↦ n-1-i`, and simplify the index
+`(n - 1 - i) + 1` to `n - i` inside the `apSumOffset` nucleus.
+-/
+
+/-- Reverse / reindex normal form for `apSumOffset`.
+
+This rewrites the sum in reverse order using the clean index `n - i`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — Reverse/reindex normal form (sum-level).
+-/
+lemma apSumOffset_eq_sum_range_reverse (f : ℕ → ℤ) (d m n : ℕ) :
+    apSumOffset f d m n = (Finset.range n).sum (fun i => f ((m + (n - i)) * d)) := by
+  -- Use the standard `range` reflection lemma.
+  unfold apSumOffset
+  -- Let `g j := f ((m + j + 1) * d)`.
+  have h :=
+    (Finset.sum_range_reflect (f := fun j : ℕ => f ((m + j + 1) * d)) n)
+  -- The RHS of `h` is exactly the defining sum; rewrite by symmetry.
+  -- Then simplify `(m + (n - 1 - i) + 1)` to `(m + (n - i))` under `i < n`.
+  refine (h.symm.trans ?_)
+  refine Finset.sum_congr rfl ?_
+  intro i hi
+  have hi' : i < n := by
+    simpa [Finset.mem_range] using hi
+  -- `n - 1 - i + 1 = n - i` when `i < n`.
+  have hni : n - 1 - i + 1 = n - i := by
+    cases n with
+    | zero =>
+        -- impossible since `i < 0`
+        cases (Nat.not_lt_zero i hi')
+    | succ n' =>
+        have hi_le : i ≤ n' := (Nat.lt_succ_iff.mp hi')
+        -- `succ n' - 1 = n'`, and `succ n' - i = succ (n' - i)` when `i ≤ n'`.
+        simpa [Nat.succ_sub_one, Nat.succ_sub hi_le, Nat.succ_eq_add_one, Nat.add_assoc]
+  -- Now simplify the summand.
+  have hmni : m + (n - 1 - i) + 1 = m + (n - i) := by
+    calc
+      m + (n - 1 - i) + 1 = m + (n - 1 - i + 1) := by
+        simp [Nat.add_assoc]
+      _ = m + (n - i) := by
+        simp [hni]
+  simp [hmni]
+
+/-!
 ### Shift–dilation coherence (Track B)
 
 Checklist item: Problems/erdos_discrepancy.md (Track B) — Shift–dilation coherence lemma.

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -124,6 +124,10 @@ example : discOffsetUpTo f 0 m N = (Finset.range (N + 1)).sup (fun n => n * Int.
 example : apSumOffset' f m d n = apSumOffset f d m n := by
   rfl
 
+-- NEW (Track B): reverse / reindex normal form (sum-level)
+example : apSumOffset f d m n = (Finset.range n).sum (fun i => f ((m + (n - i)) * d)) := by
+  simpa using (apSumOffset_eq_sum_range_reverse (f := f) (d := d) (m := m) (n := n))
+
 example : discOffset' f m d n = discOffset f d m n := by
   rfl
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Reverse/reindex normal form (sum-level): package a lemma rewriting `apSumOffset f d m n` as the sum over `Finset.range n` after the reindex `i ↦ n-1-i` (with a clean statement that avoids manual `Nat` subtraction clutter), so “reverse the order” steps don’t drop to raw `Finset` algebra.

Summary:
- Add `apSumOffset_eq_sum_range_reverse`, a stable-surface lemma reindexing the `range n` sum via `Finset.sum_range_reflect`.
- The resulting normal form uses the clean index `n - i` (rather than `n - 1 - i + 1`).
- Add a compile-only regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean` under `import MoltResearch.Discrepancy`.

Notes:
- This is a single new lemma in `MoltResearch/Discrepancy/Basic.lean`, directly tied to the Track B checklist item above, with an accompanying stable-surface regression example (anti-sprawl policy).
