### PR TITLE
EDP Track B: mark reverse/reindex normal form checklist item complete

### DIFF
--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -1245,7 +1245,8 @@ Definition of done:
 
 #### Auto-generated backlog (needs triage)
 
-- [ ] Reverse/reindex normal form (sum-level): package a lemma rewriting `apSumOffset f d m n` as the sum over `Finset.range n` after the reindex `i ↦ n-1-i` (with a clean statement that avoids manual `Nat` subtraction clutter), so “reverse the order” steps don’t drop to raw `Finset` algebra.
+- [x] Reverse/reindex normal form (sum-level): package a lemma rewriting `apSumOffset f d m n` as the sum over `Finset.range n` after the reindex `i ↦ n-1-i` (with a clean statement that avoids manual `Nat` subtraction clutter), so “reverse the order” steps don’t drop to raw `Finset` algebra.
+  (Implemented as `apSumOffset_eq_sum_range_reverse` in `MoltResearch/Discrepancy/Basic.lean`, with a stable-surface regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
 - [ ] `Ico`/`Icc` interval normalization bundle: add rewrite lemmas converting common interval sums (`∑ i in Finset.Ico m n, ...` and `∑ i in Finset.Icc (m+1) n, ...`) directly into the nucleus `apSumFrom`/`apSumOffset` shapes, with consistent endpoint conventions and stable-surface regression examples.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Reverse/reindex normal form (sum-level)

This PR just updates the Track B checklist to reflect that the reverse/reindex sum-level normal form is already implemented:
- lemma: `apSumOffset_eq_sum_range_reverse` in `MoltResearch/Discrepancy/Basic.lean`
- stable-surface regression: `MoltResearch/Discrepancy/NormalFormExamples.lean`

No code changes.
