### PR TITLE
Discrepancy: normalize Ico interval sums to apSumFrom/apSumOffset

### DIFF
--- a/MoltResearch/Discrepancy/Affine.lean
+++ b/MoltResearch/Discrepancy/Affine.lean
@@ -427,6 +427,23 @@ lemma sum_Icc_eq_apSumFrom (f : ℕ → ℤ) (a d n : ℕ) :
     (Finset.Icc 1 n).sum (fun i => f (a + i * d)) = apSumFrom f a d n := by
   simpa using (apSumFrom_eq_sum_Icc (f := f) (a := a) (d := d) (n := n)).symm
 
+/-!
+### NEW (Track B): `Ico` ↔ `apSumFrom` normal form
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — `Ico`/`Icc` interval normalization bundle.
+
+In many sources, the “`1..n`” sum is written as an `Ico` interval `Ico 1 (n+1)`.
+This lemma rewrites that directly into the nucleus `apSumFrom` form.
+
+We keep this as an explicit rewrite lemma (not `[simp]`) to avoid simp loops between
+paper-notation and nucleus-notation.
+-/
+lemma sum_Ico_one_add_one_eq_apSumFrom (f : ℕ → ℤ) (a d n : ℕ) :
+    (Finset.Ico 1 (n + 1)).sum (fun i => f (a + i * d)) = apSumFrom f a d n := by
+  -- `Ico 1 (n+1)` is the same set as `Icc 1 n`.
+  simpa [Finset.Ico_add_one_right_eq_Icc] using
+    (sum_Icc_eq_apSumFrom (f := f) (a := a) (d := d) (n := n))
+
 -- (moved below: depends on `apSumFrom_eq_apSumOffset_step_one`)
 
 lemma apSumFrom_succ (f : ℕ → ℤ) (a d n : ℕ) :

--- a/MoltResearch/Discrepancy/AffineTail.lean
+++ b/MoltResearch/Discrepancy/AffineTail.lean
@@ -1668,6 +1668,26 @@ lemma sum_Icc_eq_apSumOffset_of_le_affineEndpoints (f : ℕ → ℤ) (a d : ℕ)
     (sum_Icc_eq_apSumOffset_of_le_affine_left (f := f) (a := a) (d := d) (m := m) (n := n)
       (hmn := hmn))
 
+/-!
+### NEW (Track B): `Ico` ↔ `apSumOffset` normal form
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — `Ico`/`Icc` interval normalization bundle.
+
+The tail sum `∑ i ∈ Icc (m+1) n, f (a + i*d)` is often written as an `Ico` interval
+`Ico (m+1) (n+1)`. This lemma rewrites that directly into the nucleus `apSumOffset` form.
+
+We keep this as an explicit rewrite lemma (not `[simp]`) to avoid simp loops between
+paper-notation and nucleus-notation.
+-/
+lemma sum_Ico_eq_apSumOffset_of_le_affineEndpoints (f : ℕ → ℤ) (a d : ℕ) {m n : ℕ}
+    (hmn : m ≤ n) :
+    (Finset.Ico (m + 1) (n + 1)).sum (fun i => f (a + i * d)) =
+      apSumOffset (fun k => f (a + k)) d m (n - m) := by
+  -- `Ico (m+1) (n+1)` is the same set as `Icc (m+1) n`.
+  simpa [Finset.Ico_add_one_right_eq_Icc] using
+    (sum_Icc_eq_apSumOffset_of_le_affineEndpoints (f := f) (a := a) (d := d) (m := m) (n := n)
+      hmn)
+
 /-- Mul-left variant of `sum_Icc_eq_apSumOffset_of_le_affineEndpoints`, with summand written as
 `f (a + d*i)`.
 -/

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -640,6 +640,18 @@ import MoltResearch.Discrepancy
 example : (Finset.Icc 1 n).sum (fun i => f (a + i * d)) = apSumFrom f a d n := by
   simpa [sum_Icc_eq_apSumFrom]
 
+-- (1.1) Same sum, but in the common `Ico 1 (n+1)` paper notation.
+example : (Finset.Ico 1 (n + 1)).sum (fun i => f (a + i * d)) = apSumFrom f a d n := by
+  simpa using (sum_Ico_one_add_one_eq_apSumFrom (f := f) (a := a) (d := d) (n := n))
+
+-- (1.2) Tail sum in `Ico (m+1) (n+1)` paper notation → nucleus `apSumOffset`.
+example (hmn : m ≤ n) :
+    (Finset.Ico (m + 1) (n + 1)).sum (fun i => f (a + i * d)) =
+      apSumOffset (fun k => f (a + k)) d m (n - m) := by
+  simpa using
+    (sum_Ico_eq_apSumOffset_of_le_affineEndpoints (f := f) (a := a) (d := d) (m := m) (n := n)
+      hmn)
+
 -- (1.5) “Cut + reassemble” normal form at the `apSumFrom`-level (Track B checklist item).
 -- This is the exact concatenation equality at the nucleus level.
 example : apSumFrom f a d (n + k) = apSumFrom f a d n + apSumFrom f (a + n * d) d k := by


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `Ico`/`Icc` interval normalization bundle: add rewrite lemmas converting common interval sums (`∑ i in Finset.Ico m n, ...` and `∑ i in Finset.Icc (m+1) n, ...`) directly into the nucleus `apSumFrom`/`apSumOffset` shapes, with consistent endpoint conventions and stable-surface regression examples.

What this PR does
- Adds `sum_Ico_one_add_one_eq_apSumFrom` (Affine): rewrites `∑ i∈Ico 1 (n+1), f (a + i*d)` to `apSumFrom f a d n`.
- Adds `sum_Ico_eq_apSumOffset_of_le_affineEndpoints` (AffineTail): rewrites `∑ i∈Ico (m+1) (n+1), f (a + i*d)` to `apSumOffset (fun k => f (a+k)) d m (n-m)` under `m ≤ n`.
- Adds stable-surface regression examples in `NormalFormExamples.lean` (importable via `import MoltResearch.Discrepancy`).

Notes
- No simp attributes added (explicit rewrite lemmas to avoid paper↔nucleus simp loops).
- `make ci` passes locally.
