### PR TITLE
Discrepancy: normalize Ico m (n+1) tails to apSumOffset

### DIFF
--- a/MoltResearch/Discrepancy/AffineTail.lean
+++ b/MoltResearch/Discrepancy/AffineTail.lean
@@ -1688,6 +1688,31 @@ lemma sum_Ico_eq_apSumOffset_of_le_affineEndpoints (f : ℕ → ℤ) (a d : ℕ)
     (sum_Icc_eq_apSumOffset_of_le_affineEndpoints (f := f) (a := a) (d := d) (m := m) (n := n)
       hmn)
 
+/-- Variant of `sum_Ico_eq_apSumOffset_of_le_affineEndpoints` for the common `Ico m (n+1)` paper
+notation.
+
+Many sources write the endpoint-normalized tail as a half-open interval `Ico m (n+1)` (instead of
+`Ico (m+1) (n+1)`) when the lower endpoint is already in “paper form”.
+
+Assuming `0 < m`, we can rewrite this directly into the nucleus `apSumOffset` normal form with
+offset parameter `m - 1`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — `Ico`/`Icc` interval normalization bundle.
+
+We keep this as an explicit rewrite lemma (not `[simp]`) to avoid simp loops between paper-notation
+and nucleus-notation.
+-/
+lemma sum_Ico_eq_apSumOffset_of_pos_le_affineEndpoints (f : ℕ → ℤ) (a d : ℕ) {m n : ℕ}
+    (hm0 : 0 < m) (hmn : m ≤ n) :
+    (Finset.Ico m (n + 1)).sum (fun i => f (a + i * d)) =
+      apSumOffset (fun k => f (a + k)) d (m - 1) (n - (m - 1)) := by
+  have hm1 : 1 ≤ m := Nat.succ_le_iff.mp hm0
+  have hmn' : m - 1 ≤ n := le_trans (Nat.sub_le m 1) hmn
+  -- `Ico m (n+1)` is the same set as `Icc m n`, and `m = (m-1)+1` when `0 < m`.
+  simpa [Finset.Ico_add_one_right_eq_Icc, Nat.sub_add_cancel hm1] using
+    (sum_Icc_eq_apSumOffset_of_le_affineEndpoints (f := f) (a := a) (d := d) (m := m - 1)
+      (n := n) hmn')
+
 /-- Mul-left variant of `sum_Icc_eq_apSumOffset_of_le_affineEndpoints`, with summand written as
 `f (a + d*i)`.
 -/

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -652,6 +652,14 @@ example (hmn : m ≤ n) :
     (sum_Ico_eq_apSumOffset_of_le_affineEndpoints (f := f) (a := a) (d := d) (m := m) (n := n)
       hmn)
 
+-- (1.3) Same tail sum, but in the common `Ico m (n+1)` notation → nucleus `apSumOffset`.
+example (hm0 : 0 < m) (hmn : m ≤ n) :
+    (Finset.Ico m (n + 1)).sum (fun i => f (a + i * d)) =
+      apSumOffset (fun k => f (a + k)) d (m - 1) (n - (m - 1)) := by
+  simpa using
+    (sum_Ico_eq_apSumOffset_of_pos_le_affineEndpoints (f := f) (a := a) (d := d) (m := m) (n := n)
+      hm0 hmn)
+
 -- (1.5) “Cut + reassemble” normal form at the `apSumFrom`-level (Track B checklist item).
 -- This is the exact concatenation equality at the nucleus level.
 example : apSumFrom f a d (n + k) = apSumFrom f a d n + apSumFrom f (a + n * d) d k := by


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `Ico`/`Icc` interval normalization bundle: add rewrite lemmas converting common interval sums (`∑ i in Finset.Ico m n, ...` and `∑ i in Finset.Icc (m+1) n, ...`) directly into the nucleus `apSumFrom`/`apSumOffset` shapes, with consistent endpoint conventions and stable-surface regression examples.

Summary:
- Added lemma `sum_Ico_eq_apSumOffset_of_pos_le_affineEndpoints` to normalize the common paper form
  ∑ i in Ico m (n+1), f (a + i*d)
  directly into the nucleus `apSumOffset` normal form (offset m-1), by reducing to the existing
  `Icc`/`Ico (m+1) (n+1)` affine-endpoints lemmas.
- Added a stable-surface regression `example` in `MoltResearch/Discrepancy/NormalFormExamples.lean`.

Notes:
- Kept as an explicit rewrite lemma (not simp) to avoid simp loops between paper and nucleus notations.