### PR TITLE
Track C: discOffset base case

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/Tao2015.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/Tao2015.lean
@@ -363,6 +363,15 @@ theorem discOffset_eq_natAbs_sum_Icc (f : ℕ → ℤ) (d m n : ℕ) :
     _ = Int.natAbs ((Finset.Icc (m + 1) (m + n)).sum (fun i => f (i * d))) :=
       natAbs_apSumOffset_eq_natAbs_sum_Icc (f := f) (d := d) (m := m) (n := n)
 
+/-- Base case: bundled offset discrepancy at length `0` is `0`.
+
+This is a tiny wrapper around the definitional equality
+`discOffset f d m n = Int.natAbs (apSumOffset f d m n)` together with the core simp lemma
+`apSumOffset_zero`.
+-/
+@[simp] theorem discOffset_zero (f : ℕ → ℤ) (d m : ℕ) : discOffset f d m 0 = 0 := by
+  simp [discOffset]
+
 namespace UnboundedDiscOffset
 
 /-- Witness-positivity: in the `∀ B, ∃ n, B < discOffset f d m n` unboundedness normal form,


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a simp lemma discOffset_zero for the bundled offset discrepancy wrapper.
- Keep witness-positivity in Tao2015.UnboundedDiscOffset relying only on simp, now with an explicit named base case available for downstream use.
