### PR TITLE
Discrepancy: Ico/Icc interval normalization summand wrappers

### DIFF
--- a/MoltResearch/Discrepancy/AffineTail.lean
+++ b/MoltResearch/Discrepancy/AffineTail.lean
@@ -1806,6 +1806,66 @@ lemma sum_Ico_eq_apSumOffset_of_pos_le (f : ℕ → ℤ) (a d : ℕ) {m n : ℕ}
           -- (`Nat.add_assoc` etc. normalize the parenthesization.)
           simp [hmi, Nat.add_assoc, Nat.add_left_comm, Nat.add_comm, Nat.mul_assoc]
 
+/-!
+### NEW (Track B): `Ico` summand-convention wrappers
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — `Ico`/`Icc` interval normalization bundle.
+
+These are lightweight variants of `sum_Ico_eq_apSumFrom_of_pos_le` and
+`sum_Ico_eq_apSumOffset_of_pos_le` for the common summand conventions `i*d + a` and `d*i`.
+
+They are intentionally **not** tagged `[simp]` to avoid rewrite loops between paper notation and
+nucleus notation.
+-/
+
+-- `Ico` → `apSumFrom` tail form (summand `i*d + a`).
+lemma sum_Ico_eq_apSumFrom_of_pos_le_add (f : ℕ → ℤ) (a d : ℕ) {m n : ℕ}
+    (hm0 : 0 < m) (hmn : m ≤ n) :
+    (Finset.Ico m n).sum (fun i => f (i * d + a)) =
+      apSumFrom f (a + (m - 1) * d) d (n - m) := by
+  simpa [Nat.add_comm] using
+    (sum_Ico_eq_apSumFrom_of_pos_le (f := f) (a := a) (d := d) (m := m) (n := n) hm0 hmn)
+
+-- `Ico` → `apSumFrom` tail form (summand `a + d*i`).
+lemma sum_Ico_eq_apSumFrom_of_pos_le_mul_left (f : ℕ → ℤ) (a d : ℕ) {m n : ℕ}
+    (hm0 : 0 < m) (hmn : m ≤ n) :
+    (Finset.Ico m n).sum (fun i => f (a + d * i)) =
+      apSumFrom f (a + (m - 1) * d) d (n - m) := by
+  simpa [Nat.mul_comm] using
+    (sum_Ico_eq_apSumFrom_of_pos_le (f := f) (a := a) (d := d) (m := m) (n := n) hm0 hmn)
+
+-- `Ico` → `apSumFrom` tail form (summand `d*i + a`).
+lemma sum_Ico_eq_apSumFrom_of_pos_le_mul_left_add (f : ℕ → ℤ) (a d : ℕ) {m n : ℕ}
+    (hm0 : 0 < m) (hmn : m ≤ n) :
+    (Finset.Ico m n).sum (fun i => f (d * i + a)) =
+      apSumFrom f (a + (m - 1) * d) d (n - m) := by
+  simpa [Nat.add_comm, Nat.mul_comm] using
+    (sum_Ico_eq_apSumFrom_of_pos_le (f := f) (a := a) (d := d) (m := m) (n := n) hm0 hmn)
+
+-- `Ico` → `apSumOffset` (summand `i*d + a`).
+lemma sum_Ico_eq_apSumOffset_of_pos_le_add (f : ℕ → ℤ) (a d : ℕ) {m n : ℕ}
+    (hm0 : 0 < m) (hmn : m ≤ n) :
+    (Finset.Ico m n).sum (fun i => f (i * d + a)) =
+      apSumOffset (fun k => f (k + a)) d (m - 1) (n - m) := by
+  simpa [Nat.add_comm] using
+    (sum_Ico_eq_apSumOffset_of_pos_le (f := f) (a := a) (d := d) (m := m) (n := n) hm0 hmn)
+
+-- `Ico` → `apSumOffset` (summand `a + d*i`).
+lemma sum_Ico_eq_apSumOffset_of_pos_le_mul_left (f : ℕ → ℤ) (a d : ℕ) {m n : ℕ}
+    (hm0 : 0 < m) (hmn : m ≤ n) :
+    (Finset.Ico m n).sum (fun i => f (a + d * i)) =
+      apSumOffset (fun k => f (a + k)) d (m - 1) (n - m) := by
+  simpa [Nat.mul_comm] using
+    (sum_Ico_eq_apSumOffset_of_pos_le (f := f) (a := a) (d := d) (m := m) (n := n) hm0 hmn)
+
+-- `Ico` → `apSumOffset` (summand `d*i + a`).
+lemma sum_Ico_eq_apSumOffset_of_pos_le_mul_left_add (f : ℕ → ℤ) (a d : ℕ) {m n : ℕ}
+    (hm0 : 0 < m) (hmn : m ≤ n) :
+    (Finset.Ico m n).sum (fun i => f (d * i + a)) =
+      apSumOffset (fun k => f (k + a)) d (m - 1) (n - m) := by
+  simpa [Nat.add_comm, Nat.mul_comm] using
+    (sum_Ico_eq_apSumOffset_of_pos_le (f := f) (a := a) (d := d) (m := m) (n := n) hm0 hmn)
+
 /-- Mul-left variant of `sum_Icc_eq_apSumOffset_of_le_affineEndpoints`, with summand written as
 `f (a + d*i)`.
 -/

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -673,6 +673,19 @@ example (hm0 : 0 < m) (hmn : m ≤ n) :
   simpa using
     (sum_Ico_eq_apSumOffset_of_pos_le (f := f) (a := a) (d := d) (m := m) (n := n) hm0 hmn)
 
+-- (1.4.1a) Same `Ico m n` sum, but with summand `i*d + a`.
+example (hm0 : 0 < m) (hmn : m ≤ n) :
+    (Finset.Ico m n).sum (fun i => f (i * d + a)) = apSumFrom f (a + (m - 1) * d) d (n - m) := by
+  simpa using
+    (sum_Ico_eq_apSumFrom_of_pos_le_add (f := f) (a := a) (d := d) (m := m) (n := n) hm0 hmn)
+
+-- (1.4.1b) Same `Ico m n` sum, with summand `a + d*i`.
+example (hm0 : 0 < m) (hmn : m ≤ n) :
+    (Finset.Ico m n).sum (fun i => f (a + d * i)) =
+      apSumOffset (fun k => f (a + k)) d (m - 1) (n - m) := by
+  simpa using
+    (sum_Ico_eq_apSumOffset_of_pos_le_mul_left (f := f) (a := a) (d := d) (m := m) (n := n) hm0 hmn)
+
 -- (1.4.2) Common paper tail sum (`Icc (m+1) n`) → nucleus `apSumOffset`.
 example (hmn : m ≤ n) :
     (Finset.Icc (m + 1) n).sum (fun i => f (a + i * d)) =

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -1248,7 +1248,8 @@ Definition of done:
 - [x] Reverse/reindex normal form (sum-level): package a lemma rewriting `apSumOffset f d m n` as the sum over `Finset.range n` after the reindex `i ↦ n-1-i` (with a clean statement that avoids manual `Nat` subtraction clutter), so “reverse the order” steps don’t drop to raw `Finset` algebra.
   (Implemented as `apSumOffset_eq_sum_range_reverse` in `MoltResearch/Discrepancy/Basic.lean`, with a stable-surface regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
-- [ ] `Ico`/`Icc` interval normalization bundle: add rewrite lemmas converting common interval sums (`∑ i in Finset.Ico m n, ...` and `∑ i in Finset.Icc (m+1) n, ...`) directly into the nucleus `apSumFrom`/`apSumOffset` shapes, with consistent endpoint conventions and stable-surface regression examples.
+- [x] `Ico`/`Icc` interval normalization bundle: add rewrite lemmas converting common interval sums (`∑ i in Finset.Ico m n, ...` and `∑ i in Finset.Icc (m+1) n, ...`) directly into the nucleus `apSumFrom`/`apSumOffset` shapes, with consistent endpoint conventions and stable-surface regression examples.
+  (Implemented in `MoltResearch/Discrepancy/AffineTail.lean` as the `sum_Ico_*` / `sum_Icc_*` normal-form lemma family; stable-surface regression examples live in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
 - [ ] Step-one + affine-endpoint coherence: provide a one-line wrapper turning paper sums of the form `∑ i ∈ Icc (m+1) n, f (a + i*d)` into a step-one tail on the shifted sequence `fun k => f (a + k)` (i.e. normalize both “affine endpoints” and “step one” in a single lemma), so downstream proofs can choose the step-one normal form without two separate rewrites.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `Ico`/`Icc` interval normalization bundle

Adds small wrapper lemmas for common summand conventions when rewriting half-open interval sums
`∑ i in Finset.Ico m n, f (a + i*d)` into the nucleus API (`apSumFrom` / `apSumOffset`).

- New lemmas in `MoltResearch/Discrepancy/AffineTail.lean`:
  - `sum_Ico_eq_apSumFrom_of_pos_le_add` / `_mul_left` / `_mul_left_add`
  - `sum_Ico_eq_apSumOffset_of_pos_le_add` / `_mul_left` / `_mul_left_add`
- Stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean`.

CI: `make ci`