### PR TITLE
Discrepancy: sign-sequence coercion hygiene

### DIFF
--- a/MoltResearch/Discrepancy.lean
+++ b/MoltResearch/Discrepancy.lean
@@ -1,5 +1,6 @@
 import MoltResearch.Discrepancy.Basic
 import MoltResearch.Discrepancy.EndpointSimp
+import MoltResearch.Discrepancy.SignSequenceCoercions
 import MoltResearch.Discrepancy.Periodic
 import MoltResearch.Discrepancy.Parity
 import MoltResearch.Discrepancy.Residue

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -22,6 +22,22 @@ namespace MoltResearch
 
 section NormalFormExamples
 
+/-!
+### NEW (Track B): sign-sequence coercion hygiene
+
+Compile-only regression tests: sequences with `{±1}`-style values should be easy to use as
+`ℕ → ℤ` sign sequences via coercion.
+-/
+
+-- A `SignZ`-valued sequence coerces to an `IsSignSequence`.
+example (g : ℕ → SignZ) : IsSignSequence (fun n => (g n : ℤ)) := by
+  simpa using (isSignSequence_coe_signZ (f := g))
+
+-- Generic bridge: any coercion to `ℤ` plus a pointwise `±1` hypothesis gives `IsSignSequence`.
+example {α : Type} [CoeTC α ℤ] (g : ℕ → α) (hg : ∀ n, (g n : ℤ) = 1 ∨ (g n : ℤ) = -1) :
+    IsSignSequence (fun n => (g n : ℤ)) := by
+  simpa using (isSignSequence_coe (f := g) hg)
+
 variable (f : ℕ → ℤ) (a b d k m n n₁ n₂ p C : ℕ)
 
 /-!

--- a/MoltResearch/Discrepancy/SignSequenceCoercions.lean
+++ b/MoltResearch/Discrepancy/SignSequenceCoercions.lean
@@ -1,0 +1,43 @@
+import MoltResearch.Discrepancy.Basic
+
+/-!
+# Discrepancy: sign-sequence coercion hygiene
+
+This file provides a tiny “coercion bridge” for users who already have ±1-valued data packaged in a
+non-`ℤ` type (typically a subtype of `ℤ`, or a structure with a coercion to `ℤ`).
+
+The stable discrepancy API is expressed in terms of `f : ℕ → ℤ` together with `IsSignSequence f`.
+These lemmas make it easy to reuse existing data without rewriting everything by hand.
+-/
+
+namespace MoltResearch
+
+/-- A bundled ±1 value in `ℤ`, intended as a convenient source type for sign sequences.
+
+Users can write `f : ℕ → SignZ` and then coerce to `ℤ` via `(f n : ℤ)`.
+-/
+abbrev SignZ : Type := { z : ℤ // z = 1 ∨ z = -1 }
+
+instance : CoeTC SignZ ℤ := ⟨Subtype.val⟩
+
+@[simp] lemma SignZ.coe_mk (z : ℤ) (hz : z = 1 ∨ z = -1) : ((⟨z, hz⟩ : SignZ) : ℤ) = z := rfl
+
+/-- If a sequence has values in a type that coerces to `ℤ` and those coerced values are always
+`±1`, then the coerced sequence is a sign sequence.
+
+This is the main “treat `{±1}`-style data as `ℕ → ℤ`” helper.
+-/
+lemma isSignSequence_coe {α : Type} [CoeTC α ℤ] (f : ℕ → α)
+    (h : ∀ n, (f n : ℤ) = 1 ∨ (f n : ℤ) = -1) :
+    IsSignSequence (fun n => (f n : ℤ)) :=
+  h
+
+/-- Special case: a `SignZ`-valued sequence coerces to an `IsSignSequence` in one step.
+
+This lemma exists mostly so `simpa` can find it easily.
+-/
+lemma isSignSequence_coe_signZ (f : ℕ → SignZ) : IsSignSequence (fun n => (f n : ℤ)) := by
+  intro n
+  simpa using (f n).property
+
+end MoltResearch


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Sign-sequence coercion hygiene: add a small lemma family that lets users treat `f : ℕ → {±1}`-style data as `ℕ → ℤ` sign sequences with `simp`-friendly coercions (and show `IsSignSequence` is preserved), to reduce friction when importing sequences from other modules.

Summary:
- Add `MoltResearch.Discrepancy.SignSequenceCoercions` with a tiny `SignZ` subtype and generic coercion bridge lemma.
- Add stable-surface regression examples in `MoltResearch.Discrepancy.NormalFormExamples`.

Notes:
- No opportunistic lemma sprawl beyond the requested coercion-hygiene helpers.
