### PR TITLE
Discrepancy: step-division normal form for disc

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -4530,6 +4530,11 @@ example :
 example (k : ℕ) : apSum (fun x => f (x * k)) d n = apSum f (d * k) n := by
   simpa using apSum_map_mul (f := f) (k := k) (d := d) (n := n)
 
+-- Regression: step-division normal form (rewrite `disc f d n` into a `d/k` step on the subsequence).
+example (k : ℕ) (hk : k > 0) (hd : k ∣ d) :
+    disc f d n = disc (fun x => f (x * k)) (d / k) n := by
+  simpa using (disc_map_mul_div_of_dvd (f := f) (k := k) (d := d) (n := n) hk hd).symm
+
 -- Regression: reindex `apSumOffset` into the mapped-finset normal form.
 example :
     apSumOffset f d m n =

--- a/MoltResearch/Discrepancy/Reindex.lean
+++ b/MoltResearch/Discrepancy/Reindex.lean
@@ -559,6 +559,27 @@ lemma apSumOffset_map_mul_div_of_dvd (f : ℕ → ℤ) (k d m n : ℕ) (hk : k >
   have d0k : d0 * k = k * d0 := Nat.mul_comm d0 k
   simpa [hd', d0k] using (apSumOffset_map_mul (f := f) (k := k) (d := d0) (m := m) (n := n))
 
+/-!
+### Step division normal form (homogeneous discrepancy)
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — “Extract a common gcd” normal form.
+
+These lemmas let downstream code rewrite discrepancy along step `d` into discrepancy along step
+`d/k` on the gcd-restricted subsequence `x ↦ f (x*k)` when `k ∣ d`.
+
+They are intentionally wrapper-level: the real work is done by `apSum_map_mul_div_of_dvd`.
+-/
+
+lemma disc_map_mul_div_of_dvd (f : ℕ → ℤ) (k d n : ℕ) (hk : k > 0) (hd : k ∣ d) :
+    disc (fun x => f (x * k)) (d / k) n = disc f d n := by
+  unfold disc
+  simpa [apSum_map_mul_div_of_dvd (f := f) (k := k) (d := d) (n := n) hk hd]
+
+lemma discrepancy_map_mul_div_of_dvd (f : ℕ → ℤ) (k d n : ℕ) (hk : k > 0) (hd : k ∣ d) :
+    discrepancy (fun x => f (x * k)) (d / k) n = discrepancy f d n := by
+  unfold discrepancy
+  simpa [apSum_map_mul_div_of_dvd (f := f) (k := k) (d := d) (n := n) hk hd]
+
 lemma apSumFrom_map_mul (f : ℕ → ℤ) (k a d n : ℕ) :
   apSumFrom (fun x => f (x * k)) a d n = apSumFrom f (a * k) (d * k) n := by
   unfold apSumFrom


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: “Extract a common gcd” normal form for steps: add a lemma rewriting discrepancy along step `d` into discrepancy along step `d/g` on the subsequence `fun k => f (k*g)` (where `g ∣ d`), with consistent naming and a regression example. Intended use: normalize steps before applying residue splits/dilations.

## What
- Add wrapper lemmas
  - `disc_map_mul_div_of_dvd`
  - `discrepancy_map_mul_div_of_dvd`
  rewriting `disc/discrepancy` along step `d` into step `d/k` on the subsequence `x ↦ f (x*k)` when `k ∣ d`.

## Why
This is a small, directed normal form used to “extract a common factor” from the step before downstream residue-splitting / dilation lemmas.

## Tests
- `make ci`
- Added `NormalFormExamples` regression example for the new rewrite.
