### PR TITLE
Track B: check off gcd/step normal form item

### DIFF
--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -1260,7 +1260,8 @@ Definition of done:
 - [x] Sign-sequence coercion hygiene: add a small lemma family that lets users treat `f : ℕ → {±1}`-style data as `ℕ → ℤ` sign sequences with `simp`-friendly coercions (and show `IsSignSequence` is preserved), to reduce friction when importing sequences from other modules.
   (Implemented in `MoltResearch/Discrepancy/SignSequenceCoercions.lean` as `SignZ`, `isSignSequence_coe`, and `isSignSequence_coe_signZ`, with a stable-surface regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
-- [ ] “Extract a common gcd” normal form for steps: add a lemma rewriting discrepancy along step `d` into discrepancy along step `d/g` on the subsequence `fun k => f (k*g)` (where `g ∣ d`), with consistent naming and a regression example. Intended use: normalize steps before applying residue splits/dilations.
+- [x] “Extract a common gcd” normal form for steps: add a lemma rewriting discrepancy along step `d` into discrepancy along step `d/g` on the subsequence `fun k => f (k*g)` (where `g ∣ d`), with consistent naming and a regression example. Intended use: normalize steps before applying residue splits/dilations.
+  (Implemented as `disc_map_mul_div_of_dvd` in `MoltResearch/Discrepancy/Reindex.lean`, with a stable-surface regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
 - [ ] Residue split (equality) for homogeneous `apSum`: complement the existing offset-residue decomposition with a homogeneous `apSum` version (and the corresponding `disc` bound wrapper), so later reductions can switch between `apSum` and `apSumOffset` without losing access to the residue API.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: “Extract a common gcd” normal form for steps

This checks off the Track B checklist item now that the step-division normal form exists:
- Lemma: `disc_map_mul_div_of_dvd` (`MoltResearch/Discrepancy/Reindex.lean`)
- Regression example: `MoltResearch/Discrepancy/NormalFormExamples.lean`

No code changes beyond the checklist bookkeeping.
