### PR TITLE
Track B: homogeneous residue split checklist + disc wrapper regression

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -4844,6 +4844,19 @@ example (f : ℕ → ℤ) (hf : IsSignSequence f) (d n : ℕ) :
     disc f d n ≤ n := by
   simpa using (disc_le (hf := hf) (d := d) (n := n))
 
+-- NEW (Track B): residue-class splitting wrapper for homogeneous discrepancy.
+example (f : ℕ → ℤ) (d q n : ℕ) (hq : q > 0) :
+    disc f d (q * (n + 1)) =
+      Int.natAbs ((Finset.range q).sum (fun r =>
+        f ((r + 1) * d) + apSumFrom f ((r + 1) * d) (q * d) n)) := by
+  simpa using (disc_mul_len_succ_eq_natAbs_sum_range (f := f) (d := d) (q := q) (n := n) hq)
+
+example (f : ℕ → ℤ) (d q n : ℕ) (hq : q > 0) :
+    disc f d (q * (n + 1)) ≤
+      (Finset.range q).sum (fun r =>
+        Int.natAbs (f ((r + 1) * d) + apSumFrom f ((r + 1) * d) (q * d) n)) := by
+  simpa using (disc_mul_len_succ_le_sum_range_natAbs (f := f) (d := d) (q := q) (n := n) hq)
+
 /-!
 ## Step-factor coherence regression tests
 

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -1263,7 +1263,7 @@ Definition of done:
 - [x] “Extract a common gcd” normal form for steps: add a lemma rewriting discrepancy along step `d` into discrepancy along step `d/g` on the subsequence `fun k => f (k*g)` (where `g ∣ d`), with consistent naming and a regression example. Intended use: normalize steps before applying residue splits/dilations.
   (Implemented as `disc_map_mul_div_of_dvd` in `MoltResearch/Discrepancy/Reindex.lean`, with a stable-surface regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
-- [ ] Residue split (equality) for homogeneous `apSum`: complement the existing offset-residue decomposition with a homogeneous `apSum` version (and the corresponding `disc` bound wrapper), so later reductions can switch between `apSum` and `apSumOffset` without losing access to the residue API.
+- [x] Residue split (equality) for homogeneous `apSum`: complement the existing offset-residue decomposition with a homogeneous `apSum` version (and the corresponding `disc` bound wrapper), so later reductions can switch between `apSum` and `apSumOffset` without losing access to the residue API.
 
 - [ ] “Cut at k” API for homogeneous sums: provide the homogeneous analogue of the `discOffset` cut lemmas (both equality-level and triangle-inequality bound wrappers), so proofs that start in the non-offset normal form can still do cut+bound in one line.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Residue split (equality) for homogeneous `apSum`

### What
- Mark the Track B checklist item as completed.
- Add stable-surface regression examples (compile-only) for the homogeneous residue-class split `disc` wrappers:
  - `disc_mul_len_succ_eq_natAbs_sum_range`
  - `disc_mul_len_succ_le_sum_range_natAbs`

### Why
The underlying residue-splitting API is now present in `MoltResearch/Discrepancy/Residue.lean`, but we also want a stable-surface example proving downstream code can use the `disc`-level wrapper without unfolding.

### CI
- `make ci`
