### PR TITLE
Discrepancy: cut-at-k API for homogeneous sums

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -27,6 +27,11 @@ The goal is to pair verified artifacts with learning scaffolding.
   - `disc f d n` (matches the `discOffset` / `discOffsetUpTo` family).
   They are definitionally equal; use `discrepancy_eq_disc` / `disc_eq_discrepancy` when you want to normalize one spelling to the other without unfolding.
 
+- **API note (homogeneous cut at `k ≤ n`):** if you want to cut a homogeneous AP sum/discrepancy without rewriting into an offset normal form, use:
+  - `apSum_eq_add_apSumOffset_cut` / `apSum_sub_apSum_cut` for exact prefix+tail / tail-difference statements, and
+  - `disc_cut_le` for the one-line triangle bound
+    `disc f d n ≤ disc f d k + discOffset f d k (n-k)`.
+
   For definitional unfolding, prefer the explicit lemmas `discrepancy_eq_natAbs_apSum` / `disc_eq_natAbs_apSum` over the shorter `*_def` aliases. Similarly, for offsets prefer `discOffset_eq_natAbs_apSumOffset` (the older `discOffset_def` alias is deprecated).
 
   **Degenerate step (`d = 0`) convention:** `d = 0` is **allowed** (not forbidden) and the stable surface provides terminating `[simp]` normal forms so downstream goals don't get stuck in the corner case. Typical normal forms:
@@ -71,13 +76,13 @@ The goal is to pair verified artifacts with learning scaffolding.
   `boundedDiscOffsetExists_iff_exists_forall_discOffsetUpTo_le`:
   `BoundedDiscOffsetExists f d m ↔ ∃ B, ∀ N, discOffsetUpTo f d m N ≤ B`.
   This packages the fixed-`B` bridge `boundedDiscOffset_iff_forall_discOffsetUpTo_le` into a single ergonomic equivalence.
-+
-+- **API note (boundedness bridge, `UpTo` ↔ witnesses):** when you want to move *a fixed bound* `B` between the two quantifier normal forms,
-+  - `(∀ N, discOffsetUpTo f d m N ≤ B)` and
-+  - `(∀ n, discOffset f d m n ≤ B)`,
-+  use `forall_discOffsetUpTo_le_iff_forall_discOffset_le`.
-+  The directional lemmas `forall_discOffset_le_of_forall_discOffsetUpTo_le` and
-+  `forall_discOffsetUpTo_le_of_forall_discOffset_le` are convenient when you want to stay in implication form.
+
+- **API note (boundedness bridge, `UpTo` ↔ witnesses):** when you want to move *a fixed bound* `B` between the two quantifier normal forms,
+  - `(∀ N, discOffsetUpTo f d m N ≤ B)` and
+  - `(∀ n, discOffset f d m n ≤ B)`,
+  use `forall_discOffsetUpTo_le_iff_forall_discOffset_le`.
+  The directional lemmas `forall_discOffset_le_of_forall_discOffsetUpTo_le` and
+  `forall_discOffsetUpTo_le_of_forall_discOffset_le` are convenient when you want to stay in implication form.
 - **API note (max recursion):** when you need to peel the last case off a cutoff, rewrite `discOffsetUpTo f d m (N+1)` using `discOffsetUpTo_succ` to get a clean `max (discOffsetUpTo … N) (discOffset … (N+1))` normal form.
 - **API note (step positivity):** when extracting unboundedness witnesses, prefer the `Nat.succ` normal forms (`HasDiscrepancyAtLeast.exists_witness_succ(_pos)` and the affine analogue) so you can work with a concrete positive step without carrying a separate `d ≥ 1` side condition.
   The degenerate corner case `d = 0` also has stable-surface simp normal forms:

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -4070,6 +4070,61 @@ lemma apSum_add_len (f : ℕ → ℤ) (d n₁ n₂ : ℕ) :
     apSum f d (n₁ + n₂) = apSum f d n₁ + apSumOffset f d n₁ n₂ := by
   simpa using (apSum_add_length (f := f) (d := d) (m := n₁) (n := n₂))
 
+/-!
+### “Cut at `k ≤ n`” API (homogeneous sums)
+
+This is the homogeneous analogue of the `discOffset` range-cut lemmas (see
+`MoltResearch/Discrepancy/Offset.lean`).
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — “Cut at k” API for homogeneous sums.
+
+Goal: proofs that start in the homogeneous normal form (`apSum` / `disc`) should be able to
+cut at `k ≤ n` and immediately obtain the exact tail (equality-level) or a one-line triangle bound.
+-/
+
+/-- Prefix + tail = total: cut a homogeneous AP sum at length `k ≤ n`.
+
+This is `apSum_add_length` specialized to the decomposition `n = k + (n-k)`.
+-/
+lemma apSum_eq_add_apSumOffset_cut (f : ℕ → ℤ) (d n k : ℕ) (hk : k ≤ n) :
+    apSum f d n = apSum f d k + apSumOffset f d k (n - k) := by
+  have hn : k + (n - k) = n := Nat.add_sub_of_le hk
+  -- rewrite to the canonical length-split normal form
+  simpa [hn] using (apSum_add_length (f := f) (d := d) (m := k) (n := (n - k)))
+
+/-- Exact tail difference after cutting a homogeneous AP sum at `k ≤ n`.
+
+This is the homogeneous analogue of `apSumOffset_sub_apSumOffset_cut`.
+-/
+lemma apSum_sub_apSum_cut (f : ℕ → ℤ) (d n k : ℕ) (hk : k ≤ n) :
+    apSum f d n - apSum f d k = apSumOffset f d k (n - k) := by
+  have h := apSum_eq_add_apSumOffset_cut (f := f) (d := d) (n := n) (k := k) hk
+  calc
+    apSum f d n - apSum f d k
+        = (apSum f d k + apSumOffset f d k (n - k)) - apSum f d k := by
+            simpa [h]
+    _ = apSumOffset f d k (n - k) := by
+          simpa using (add_sub_cancel_left (apSum f d k) (apSumOffset f d k (n - k)))
+
+/-- Range-cut equality, `disc`-level: rewrite the length-`n` discrepancy via a cut at `k ≤ n`.
+
+This is the homogeneous analogue of `discOffset_eq_natAbs_apSumOffset_cut`.
+-/
+lemma disc_eq_natAbs_apSum_cut (f : ℕ → ℤ) (d n k : ℕ) (hk : k ≤ n) :
+    disc f d n = Int.natAbs (apSum f d k + apSumOffset f d k (n - k)) := by
+  unfold disc
+  simpa [apSum_eq_add_apSumOffset_cut (f := f) (d := d) (n := n) (k := k) hk]
+
+/-- Range-cut triangle inequality for `disc`: split at a cut length `k ≤ n`.
+
+This is the homogeneous analogue of `discOffset_cut_le`.
+-/
+lemma disc_cut_le (f : ℕ → ℤ) (d n k : ℕ) (hk : k ≤ n) :
+    disc f d n ≤ disc f d k + discOffset f d k (n - k) := by
+  -- rewrite the LHS into a single `Int.natAbs (x + y)` and apply `|x+y| ≤ |x|+|y|`.
+  have hEq := disc_eq_natAbs_apSum_cut (f := f) (d := d) (n := n) (k := k) hk
+  simpa [hEq] using (Int.natAbs_add_le (apSum f d k) (apSumOffset f d k (n - k)))
+
 /-- `simp`-friendly corollary of `apSum_add_len` for `n₁ = 0`. -/
 @[simp] lemma apSum_add_len_zero_left (f : ℕ → ℤ) (d n : ℕ) :
     apSum f d (0 + n) = apSum f d n := by

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -1649,6 +1649,16 @@ example (hk : k ≤ n) :
     discOffset f d m n ≤ discOffset f d m k + discOffset f d (m + k) (n - k) := by
   simpa using (discOffset_cut_le (f := f) (d := d) (m := m) (n := n) (k := k) hk)
 
+-- Regression (Track B / homogeneous cut API): cut+bound for `disc` without rewriting to offsets.
+example (hk : k ≤ n) :
+    disc f d n ≤ disc f d k + discOffset f d k (n - k) := by
+  simpa using (disc_cut_le (f := f) (d := d) (n := n) (k := k) hk)
+
+-- Regression (Track B / homogeneous cut API, exact tail): subtract a prefix at `k ≤ n`.
+example (hk : k ≤ n) :
+    apSum f d n - apSum f d k = apSumOffset f d k (n - k) := by
+  simpa using (apSum_sub_apSum_cut (f := f) (d := d) (n := n) (k := k) hk)
+
 -- Regression (Track B / step-factoring at a multiple start):
 -- normalize `apSumFrom f (a*d) (k*d) n` directly into an `apSumOffset` on a shifted sequence.
 example : apSumFrom f (a * d) (k * d) n = apSumOffset (fun t => f ((t + a) * d)) k 0 n := by


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: “Cut at k” API for homogeneous sums: provide the homogeneous analogue of the `discOffset` cut lemmas (both equality-level and triangle-inequality bound wrappers), so proofs that start in the non-offset normal form can still do cut+bound in one line.

Summary:
- Added homogeneous cut-at-`k ≤ n` lemmas in `MoltResearch/Discrepancy/Basic.lean`:
  - `apSum_eq_add_apSumOffset_cut`
  - `apSum_sub_apSum_cut`
  - `disc_eq_natAbs_apSum_cut`
  - `disc_cut_le`
- Added compile-only regressions in `MoltResearch/Discrepancy/NormalFormExamples.lean` exercising the new API.

Notes:
- This mirrors the existing offset-level cut lemmas (e.g. `discOffset_cut_le`) but starts from `apSum`/`disc` so downstream proofs don’t need to rewrite into `discOffset` first.
