### PR TITLE
Checklist: Cut-at-k API for homogeneous sums

### DIFF
--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -1265,7 +1265,7 @@ Definition of done:
 
 - [x] Residue split (equality) for homogeneous `apSum`: complement the existing offset-residue decomposition with a homogeneous `apSum` version (and the corresponding `disc` bound wrapper), so later reductions can switch between `apSum` and `apSumOffset` without losing access to the residue API.
 
-- [ ] “Cut at k” API for homogeneous sums: provide the homogeneous analogue of the `discOffset` cut lemmas (both equality-level and triangle-inequality bound wrappers), so proofs that start in the non-offset normal form can still do cut+bound in one line.
+- [x] “Cut at k” API for homogeneous sums: provide the homogeneous analogue of the `discOffset` cut lemmas (both equality-level and triangle-inequality bound wrappers), so proofs that start in the non-offset normal form can still do cut+bound in one line.
 
 - [ ] Stable-surface naming audit: do a pass to ensure the exported stable surface exposes a minimal, coherent set of names for the nucleus normal forms (`apSum`, `apSumFrom`, `apSumOffset`, `discOffset`, `discOffsetUpTo`, bridges), and add a compile-only `SurfaceAudit` file that fails if any of these names move or stop rewriting as intended.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: “Cut at k” API for homogeneous sums

Marks the Track B checklist item as completed now that the homogeneous cut-at-`k ≤ n` API (`apSum_eq_add_apSumOffset_cut`, `apSum_sub_apSum_cut`, `disc_eq_natAbs_apSum_cut`, `disc_cut_le`) is present and has stable-surface regression examples under `import MoltResearch.Discrepancy`.
