### PR TITLE
Track B: homogeneous cut-at-k API (regressions + checklist)

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -1654,10 +1654,21 @@ example (hk : k ≤ n) :
     disc f d n ≤ disc f d k + discOffset f d k (n - k) := by
   simpa using (disc_cut_le (f := f) (d := d) (n := n) (k := k) hk)
 
+-- Regression (Track B / homogeneous cut API, prefix+tail): cut `apSum` at `k ≤ n`.
+example (hk : k ≤ n) :
+    apSum f d n = apSum f d k + apSumOffset f d k (n - k) := by
+  simpa using (apSum_eq_add_apSumOffset_cut (f := f) (d := d) (n := n) (k := k) hk)
+
 -- Regression (Track B / homogeneous cut API, exact tail): subtract a prefix at `k ≤ n`.
 example (hk : k ≤ n) :
     apSum f d n - apSum f d k = apSumOffset f d k (n - k) := by
   simpa using (apSum_sub_apSum_cut (f := f) (d := d) (n := n) (k := k) hk)
+
+-- Regression (Track B / homogeneous cut API, disc-level rewrite):
+-- the length-`n` discrepancy rewrites into a single `natAbs (prefix + tail)`.
+example (hk : k ≤ n) :
+    disc f d n = Int.natAbs (apSum f d k + apSumOffset f d k (n - k)) := by
+  simpa using (disc_eq_natAbs_apSum_cut (f := f) (d := d) (n := n) (k := k) hk)
 
 -- Regression (Track B / step-factoring at a multiple start):
 -- normalize `apSumFrom f (a*d) (k*d) n` directly into an `apSumOffset` on a shifted sequence.

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -1266,6 +1266,7 @@ Definition of done:
 - [x] Residue split (equality) for homogeneous `apSum`: complement the existing offset-residue decomposition with a homogeneous `apSum` version (and the corresponding `disc` bound wrapper), so later reductions can switch between `apSum` and `apSumOffset` without losing access to the residue API.
 
 - [x] “Cut at k” API for homogeneous sums: provide the homogeneous analogue of the `discOffset` cut lemmas (both equality-level and triangle-inequality bound wrappers), so proofs that start in the non-offset normal form can still do cut+bound in one line.
+  (Implemented in `MoltResearch/Discrepancy/Basic.lean` as `apSum_eq_add_apSumOffset_cut`, `apSum_sub_apSum_cut`, `disc_eq_natAbs_apSum_cut`, and `disc_cut_le`, with stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
 - [ ] Stable-surface naming audit: do a pass to ensure the exported stable surface exposes a minimal, coherent set of names for the nucleus normal forms (`apSum`, `apSumFrom`, `apSumOffset`, `discOffset`, `discOffsetUpTo`, bridges), and add a compile-only `SurfaceAudit` file that fails if any of these names move or stop rewriting as intended.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: “Cut at k” API for homogeneous sums

This checks off the Track B item by:
- adding stable-surface regression examples for the homogeneous cut-at-`k` lemmas
  (`apSum_eq_add_apSumOffset_cut` and `disc_eq_natAbs_apSum_cut`) in
  `MoltResearch/Discrepancy/NormalFormExamples.lean`.
- marking the checklist item complete in `Problems/erdos_discrepancy.md` with pointers to the
  implementing lemmas in `MoltResearch/Discrepancy/Basic.lean`.

CI: `make ci`
