### PR TITLE
Track C: Stage 3 start-index mod helpers

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
@@ -83,6 +83,22 @@ theorem start_mod_d (out : Stage3Output f) : out.start % out.d = 0 := by
   change Stage2Output.start out.out2 % out.out2.d = 0
   exact Stage2Output.start_mod_d (f := f) (out := out.out2)
 
+/-- Adding the start index does not change residues modulo the step size.
+
+Since `out.start` is a multiple of `out.d`, we have
+`(n + out.start) % out.d = n % out.d`.
+-/
+theorem add_start_mod_d (out : Stage3Output f) (n : ℕ) :
+    (n + out.start) % out.d = n % out.d := by
+  have hstart : out.start % out.d = 0 := out.start_mod_d (f := f)
+  simp [Nat.add_mod, hstart]
+
+/-- Variant of `add_start_mod_d` with the start index on the left. -/
+theorem start_add_mod_d (out : Stage3Output f) (n : ℕ) :
+    (out.start + n) % out.d = n % out.d := by
+  rw [Nat.add_comm]
+  exact out.add_start_mod_d (f := f) (n := n)
+
 /-- Stage 3 already closes the global goal `¬ BoundedDiscrepancy f`.
 
 We intentionally do not store this as a field: it is derived from the Stage-2 output.

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -129,41 +129,13 @@ Since `stage3Out ... .start` is a multiple of `stage3Out ... .d`, we have
 theorem stage3Out_add_start_mod_d (f : ℕ → ℤ) (hf : IsSignSequence f) (n : ℕ) :
     (n + (stage3Out (f := f) (hf := hf)).start) % (stage3Out (f := f) (hf := hf)).d =
       n % (stage3Out (f := f) (hf := hf)).d := by
-  -- We keep this proof explicit (rather than relying on simp unfolding `start = m*d`) so it is
-  -- robust under simp-set changes.
-  let out := stage3Out (f := f) (hf := hf)
-  have hstart : out.start % out.d = 0 := by
-    dsimp [out]
-    exact stage3Out_start_mod_d (f := f) (hf := hf)
-  have h : (n + out.start) % out.d = n % out.d := by
-    calc
-      (n + out.start) % out.d = (n % out.d + out.start % out.d) % out.d := by
-        simp [Nat.add_mod]
-      _ = (n % out.d + 0) % out.d := by
-        simp [hstart]
-      _ = n % out.d := by
-        simp
-  dsimp [out] at h
-  exact h
+  exact Stage3Output.add_start_mod_d (f := f) (out := stage3Out (f := f) (hf := hf)) n
 
 /-- Variant of `stage3Out_add_start_mod_d` with the start index on the left. -/
 theorem stage3Out_start_add_mod_d (f : ℕ → ℤ) (hf : IsSignSequence f) (n : ℕ) :
     ((stage3Out (f := f) (hf := hf)).start + n) % (stage3Out (f := f) (hf := hf)).d =
       n % (stage3Out (f := f) (hf := hf)).d := by
-  let out := stage3Out (f := f) (hf := hf)
-  have hstart : out.start % out.d = 0 := by
-    dsimp [out]
-    exact stage3Out_start_mod_d (f := f) (hf := hf)
-  have h : (out.start + n) % out.d = n % out.d := by
-    calc
-      (out.start + n) % out.d = (out.start % out.d + n % out.d) % out.d := by
-        simp [Nat.add_mod]
-      _ = (0 + n % out.d) % out.d := by
-        simp [hstart]
-      _ = n % out.d := by
-        simp
-  dsimp [out] at h
-  exact h
+  exact Stage3Output.start_add_mod_d (f := f) (out := stage3Out (f := f) (hf := hf)) n
 
 /-- Convenience lemma: the Stage-3 reduced sequence is a sign sequence.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Added small Stage3Output arithmetic helpers for start-index modulo rewrites.
- Simplified the hard-gate Stage-3 entry module by delegating to these helpers (less duplicated proof text).
