### PR TITLE
Track C: add Stage3 discrepancy witness lemma

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
@@ -258,6 +258,19 @@ theorem forall_exists_discrepancy_gt_witness_pos (out : Stage3Output f) :
   change Int.natAbs (apSum f d n) > C
   exact hgt
 
+/-- Stage 3 output implies the explicit discrepancy witness normal form.
+
+Normal form:
+`∀ C, ∃ d n, d > 0 ∧ discrepancy f d n > C`.
+
+This is just `forall_exists_discrepancy_gt_witness_pos` with the positivity side condition dropped.
+-/
+theorem forall_exists_discrepancy_gt (out : Stage3Output f) :
+    ∀ C : ℕ, ∃ d n : ℕ, d > 0 ∧ discrepancy f d n > C := by
+  intro C
+  rcases out.forall_exists_discrepancy_gt_witness_pos (f := f) C with ⟨d, n, hd, _hn, hgt⟩
+  exact ⟨d, n, hd, hgt⟩
+
 end Stage3Output
 
 /-!

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -339,10 +339,8 @@ This is obtained from `stage3_forall_hasDiscrepancyAtLeast` via
 -/
 theorem stage3_forall_exists_discrepancy_gt (f : ℕ → ℤ) (hf : IsSignSequence f) :
     ∀ C : ℕ, ∃ d n : ℕ, d > 0 ∧ discrepancy f d n > C := by
-  intro C
-  exact
-    (HasDiscrepancyAtLeast_iff_exists_discrepancy (f := f) (C := C)).1
-      ((stage3_forall_hasDiscrepancyAtLeast (f := f) (hf := hf)) C)
+  let out := stage3Out (f := f) (hf := hf)
+  exact out.forall_exists_discrepancy_gt (f := f)
 
 /-- Variant of `stage3_forall_exists_discrepancy_gt` with a positive-length witness `n > 0`.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Added Stage3Output.forall_exists_discrepancy_gt as a small corollary dropping the n > 0 side condition.
- Updated the Stage-3 minimal entry-point wrapper to use this core lemma (slightly thinner API surface).
