### PR TITLE
Track C: de-duplicate Stage 3 witness APIs

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancyWitnesses.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancyWitnesses.lean
@@ -117,6 +117,17 @@ theorem erdos_discrepancy_discrepancy_d_ge_one (f : ℕ → ℤ) (hf : IsSignSeq
     (Tao2015.Stage3Output.forall_exists_discrepancy_gt_d_ge_one (f := f)
       (Tao2015.stage3Out (f := f) (hf := hf)))
 
+/-- Strengthened witness form of `erdos_discrepancy_discrepancy_d_ge_one` with a positive-length witness.
+
+Normal form:
+`∀ C, ∃ d n, d ≥ 1 ∧ n > 0 ∧ discrepancy f d n > C`.
+-/
+theorem erdos_discrepancy_discrepancy_d_ge_one_witness_pos (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    ∀ C : ℕ, ∃ d n : ℕ, d ≥ 1 ∧ n > 0 ∧ discrepancy f d n > C := by
+  simpa using
+    (Tao2015.Stage3Output.forall_exists_discrepancy_gt_d_ge_one_witness_pos (f := f)
+      (Tao2015.stage3Out (f := f) (hf := hf)))
+
 /-- Strengthened witness form of `erdos_discrepancy_discrepancy` with a positive-length witness.
 
 This is sometimes convenient when downstream stages want to rule out the degenerate case `n = 0`.
@@ -150,17 +161,8 @@ theorem erdos_discrepancy_exists_params_d_ne_zero_unboundedDiscOffset (f : ℕ �
     ⟨d, m, hd, hunb⟩
   exact ⟨d, m, Nat.ne_of_gt hd, hunb⟩
 
-/-- Variant of `erdos_discrepancy_exists_params_unboundedDiscOffset` packaging the step-size side
-condition as `1 ≤ d`.
-
-Many later stages prefer the normal form `1 ≤ d` rather than `d > 0`.
--/
-theorem erdos_discrepancy_exists_params_one_le_unboundedDiscOffset (f : ℕ → ℤ)
-    (hf : IsSignSequence f) :
-    ∃ d m : ℕ, 1 ≤ d ∧ Tao2015.UnboundedDiscOffset f d m := by
-  simpa using
-    (Tao2015.Stage3Output.exists_params_one_le_unboundedDiscOffset (f := f)
-      (Tao2015.stage3Out (f := f) (hf := hf)))
+-- Note: the packaging lemma `erdos_discrepancy_exists_params_one_le_unboundedDiscOffset` lives in
+-- `Conjectures.C0002_erdos_discrepancy.src.ErdosDiscrepancy`.
 
 /-- Track-C pipeline witness form (Tao 2015 plane): there exist concrete parameters `d, m` such that
   the bundled offset discrepancy family `discOffset f d m` takes arbitrarily large values.

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Core.lean
@@ -96,30 +96,11 @@ This lemma is intentionally tiny (and not marked as a simp lemma): it exists mai
 theorem start_eq_out2_start (out : Stage3Output f) : out.start = out.out2.start := by
   rfl
 
-/-- Definitional rewrite: `out.start = out.m * out.d`.
-
-This mirrors the Stage-2 lemma `Stage2Output.start_eq_m_mul_d` and avoids repeated unfolding of
-`Stage3Output.start` in downstream arithmetic rewrites.
--/
-theorem start_eq_m_mul_d (out : Stage3Output f) : out.start = out.m * out.d := by
-  rfl
+-- Note: the basic start-index lemmas
+-- `Stage3Output.start_eq_m_mul_d`, `Stage3Output.start_mod_d`, and `Stage3Output.add_start_mod_d`
+-- live in `Conjectures.C0002_erdos_discrepancy.src.TrackCStage3`.
 
 -- Note: the lemma `Stage3Output.d_dvd_start` lives in `Conjectures.C0002_erdos_discrepancy.src.TrackCStage3`.
-
-/-- The affine-tail start index `out.start` has remainder `0` when reduced modulo `out.d`. -/
-theorem start_mod_d (out : Stage3Output f) : out.start % out.d = 0 := by
-  simpa [start_eq_out2_start] using
-    (Stage2Output.start_mod_d (f := f) out.out2)
-
-/-- Adding the start index does not change residues modulo the step size.
-
-Since `out.start` is a multiple of `out.d`, we have
-`(n + out.start) % out.d = n % out.d`.
--/
-theorem add_start_mod_d (out : Stage3Output f) (n : ℕ) :
-    (n + out.start) % out.d = n % out.d := by
-  simpa [start_eq_out2_start] using
-    (Stage2Output.add_start_mod_d (f := f) out.out2 n)
 
 /-- Recover the offset parameter `out.m` by dividing the start index `out.start`
 by the step size `out.d`.

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
@@ -283,18 +283,8 @@ theorem stage3_exists_params_one_le_forall_exists_discOffset_gt'_witness_pos (f 
 -- (moved to `Conjectures.C0002_erdos_discrepancy.src.TrackCStage3EntryMinimal`)
 
 
-/-- Consumer-facing shortcut: Stage 3 yields the nucleus witness form
-
-`∀ C, ∃ d n, d ≥ 1 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C`.
-
-This is the most pipeline-friendly surface statement for consuming Stage 3 without importing the
-larger Stage-3 output-lemma layer.
--/
-theorem stage3_forall_exists_d_ge_one_witness_pos (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    ∀ C : ℕ, ∃ d n : ℕ, d ≥ 1 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C := by
-  exact
-    (forall_hasDiscrepancyAtLeast_iff_forall_exists_d_ge_one_witness_pos f).1
-      (stage3_forall_hasDiscrepancyAtLeast (f := f) (hf := hf))
+-- Note: the nucleus witness form `stage3_forall_exists_d_ge_one_witness_pos` lives in
+-- `Conjectures.C0002_erdos_discrepancy.src.TrackCStage3EntryMinimal`.
 
 /-- Discrepancy-form variant of `stage3_forall_exists_d_ge_one_witness_pos`.
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Output.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Output.lean
@@ -43,19 +43,8 @@ theorem forall_exists_d_ne_zero_witness_pos (out : Stage3Output f) :
     ∀ C : ℕ, ∃ d n : ℕ, d ≠ 0 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C := by
   exact Stage2Output.forall_exists_d_ne_zero_witness_pos (f := f) out.out2
 
-/-- Stage 3 output implies the discrepancy-witness normal form
-
-`∀ C, ∃ d n, d > 0 ∧ discrepancy f d n > C`.
-
-This is a thin wrapper around `Stage3Output.forall_hasDiscrepancyAtLeast` via
-`HasDiscrepancyAtLeast_iff_exists_discrepancy`.
--/
-theorem forall_exists_discrepancy_gt (out : Stage3Output f) :
-    ∀ C : ℕ, ∃ d n : ℕ, d > 0 ∧ discrepancy f d n > C := by
-  intro C
-  exact
-    (HasDiscrepancyAtLeast_iff_exists_discrepancy (f := f) (C := C)).1
-      ((out.forall_hasDiscrepancyAtLeast (f := f)) C)
+-- Note: `Stage3Output.forall_exists_discrepancy_gt` lives in
+-- `Conjectures.C0002_erdos_discrepancy.src.TrackCStage3` (the hard-gate boundary).
 
 /-- Variant of `forall_exists_discrepancy_gt` writing the step-size side condition as `d ≥ 1`.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a d ≥ 1, n > 0 discrepancy-witness corollary in ErdosDiscrepancyWitnesses.
- De-duplicate overlapping Stage 3 witness/start-index lemma declarations across the TrackCStage3 core and output layers so they compile together.
- Keep the hard-gate surface unchanged; changes are Conjectures-only.
