### PR TITLE
Track C: add d>0 unboundedDiscOffset packaging

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
@@ -69,6 +69,17 @@ theorem erdos_discrepancy_unboundedDiscOffset (f : ℕ → ℤ) (hf : IsSignSequ
 /-- Existential packaging of `erdos_discrepancy_unboundedDiscOffset`.
 
 Normal form:
+`∃ d m, d > 0 ∧ UnboundedDiscOffset f d m`.
+
+This is a small convenience wrapper around `Tao2015.stage3_exists_params_unboundedDiscOffset`.
+-/
+theorem erdos_discrepancy_exists_params_unboundedDiscOffset (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    ∃ d m : ℕ, d > 0 ∧ Tao2015.UnboundedDiscOffset f d m := by
+  exact Tao2015.stage3_exists_params_unboundedDiscOffset (f := f) (hf := hf)
+
+/-- Existential packaging of `erdos_discrepancy_unboundedDiscOffset`.
+
+Normal form:
 `∃ d m, 1 ≤ d ∧ UnboundedDiscOffset f d m`.
 
 This is a small convenience wrapper around


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Added a strict-positivity existential wrapper for the Stage-3 unbounded offset-discrepancy witness: exists d m with d > 0.
- Keeps the existing 1 ≤ d packaging lemma intact for downstream users that prefer that normal form.
