### PR TITLE
Track C: Stage3Output start_div_d

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
@@ -68,6 +68,15 @@ This is just the corresponding Stage-2 projection lemma, rewritten to use the St
 theorem start_eq_m_mul_d (out : Stage3Output f) : out.start = out.m * out.d := by
   rfl
 
+/-- Recover the offset parameter `out.m` by dividing the start index `out.start` by the step size
+`out.d`.
+
+This is a tiny arithmetic convenience lemma: `out.start = out.m * out.d` by definition (via Stage 2).
+-/
+theorem start_div_d (out : Stage3Output f) : out.start / out.d = out.m := by
+  simpa [Stage3Output.start, Stage3Output.d, Stage3Output.m] using
+    (Stage2Output.start_div_d (f := f) (out := out.out2))
+
 /-- The affine-tail start index `out.start` is a multiple of the reduced step size `out.d`. -/
 theorem d_dvd_start (out : Stage3Output f) : out.d ∣ out.start := by
   -- Rewrite to the corresponding Stage-2 normal form.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add Stage3Output.start_div_d: a small arithmetic convenience lemma recovering m from start/d.
- Proof delegates to the existing Stage2Output.start_div_d, keeping the Stage-3 API consistent with Stage 2.
