### PR TITLE
Track C: simplify Stage-3 d>0 witness

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
@@ -245,9 +245,7 @@ theorem forall_exists_d_pos_witness_pos (out : Stage3Output f) :
   intro C
   rcases out.forall_exists_d_ge_one_witness_pos (f := f) C with ⟨d, n, hd, hn, hgt⟩
   have hdpos : d > 0 := by
-    have h : Nat.succ 0 ≤ d := by
-      simpa using hd
-    exact (Nat.succ_le_iff).1 h
+    exact lt_of_lt_of_le Nat.zero_lt_one hd
   exact ⟨d, n, hdpos, hn, hgt⟩
 
 /-- Stage 3 output implies the explicit discrepancy witness normal form with a positive-length witness.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Simplify Stage3Output.forall_exists_d_pos_witness_pos: derive d > 0 directly from d ≥ 1 via lt_of_lt_of_le Nat.zero_lt_one.
- Keeps the Stage-3 witness packaging unchanged while reducing proof noise and aligning with Stage-2 constructors.
