### PR TITLE
Track C: export Stage-2 reduced-sequence rewrites

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Entry.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Entry.lean
@@ -11,8 +11,8 @@ It contains only:
   `stage2_start_eq_m_mul_d`, `stage2_d_dvd_start`, `stage2_start_mod_d`,
   `stage2_add_start_mod_d`, `stage2_start_add_mod_d`, `stage2_start_div_d`.
 
-The reduced-sequence rewrite lemmas (`stage2_hg`, `stage2_g_eq`, `stage2_g_eq_fun`) live in
-`Conjectures.C0002_erdos_discrepancy.src.TrackCStage2ProofCore`.
+The reduced-sequence rewrite lemmas (`stage2_hg`, `stage2_g_eq`, `stage2_g_eq_fun`) are also
+provided here (as tiny wrappers over the Stage-1 reduction fields bundled in `stage2Out`).
 
 The conjecture stub itself (`stage2` and the deterministic name `stage2Out`) lives in
 `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Stub`.
@@ -139,12 +139,32 @@ theorem stage2_start_div_d (f : ℕ → ℤ) (hf : IsSignSequence f) :
   simpa [stage2_start] using (Nat.mul_div_left (stage2_m (f := f) (hf := hf)) hd)
 
 /-!
-The remaining proved projection lemmas about the reduced sequence `stage2_g` live in
-`Conjectures.C0002_erdos_discrepancy.src.TrackCStage2ProofCore`.
+## Reduced sequence projection lemmas
 
-We keep this entry-point module focused on deterministic parameter/projection definitions and
-small arithmetic facts about `stage2_start`.
+These are tiny proved wrapper lemmas specialized to the deterministic reduced sequence `stage2_g`.
+They are logically part of the Stage-1 reduction output bundled inside `stage2Out`, but they are
+useful enough that we keep them in the entry-point module so downstream stages can consume them
+without importing additional Stage-2 convenience layers.
 -/
+
+/-- The reduced sequence produced by Stage 2 is a sign sequence. -/
+theorem stage2_hg (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    IsSignSequence (stage2_g (f := f) (hf := hf)) := by
+  simpa [stage2_g] using (stage2Out (f := f) (hf := hf)).out1.hg
+
+/-- Rewrite for the reduced sequence produced by Stage 2: it is a shift by `m*d`. -/
+theorem stage2_g_eq (f : ℕ → ℤ) (hf : IsSignSequence f) (k : ℕ) :
+    stage2_g (f := f) (hf := hf) k = f (k + stage2_start (f := f) (hf := hf)) := by
+  -- This is just the Stage-1 reduction contract carried by the Stage-2 output.
+  simpa [stage2_g, stage2_start, stage2_m, stage2_d] using
+    (stage2Out (f := f) (hf := hf)).out1.g_eq k
+
+/-- Function-level rewrite for `stage2_g`: it is the shifted sequence `fun k => f (k + m*d)`. -/
+theorem stage2_g_eq_fun (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    stage2_g (f := f) (hf := hf) =
+      fun k => f (k + stage2_start (f := f) (hf := hf)) := by
+  funext k
+  simpa using stage2_g_eq (f := f) (hf := hf) k
 
 end Tao2015
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2ProofCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2ProofCore.lean
@@ -134,34 +134,6 @@ theorem stage2_exists_params_one_le_unboundedDiscOffset (f : ℕ → ℤ) (hf : 
       stage2_one_le_d (f := f) (hf := hf), ?_⟩
   exact stage2_unboundedDiscOffset (f := f) (hf := hf)
 
-/-!
-## Reduced sequence projection lemmas
-
-These are tiny proved wrapper lemmas specialized to the deterministic reduced sequence `stage2_g`.
-They are logically part of the Stage-1 reduction output bundled inside `stage2Out`, but we keep
-them out of the entry-point module `TrackCStage2Entry` so that file stays focused on deterministic
-parameter projections and small arithmetic facts.
--/
-
-/-- The reduced sequence produced by Stage 2 is a sign sequence. -/
-theorem stage2_hg (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    IsSignSequence (stage2_g (f := f) (hf := hf)) := by
-  simpa [stage2_g] using (stage2Out (f := f) (hf := hf)).out1.hg
-
-/-- Rewrite for the reduced sequence produced by Stage 2: it is a shift by `m*d`. -/
-theorem stage2_g_eq (f : ℕ → ℤ) (hf : IsSignSequence f) (k : ℕ) :
-    stage2_g (f := f) (hf := hf) k = f (k + stage2_start (f := f) (hf := hf)) := by
-  -- This is just the Stage-1 reduction contract carried by the Stage-2 output.
-  simpa [stage2_g, stage2_start, stage2_m, stage2_d] using
-    (stage2Out (f := f) (hf := hf)).out1.g_eq k
-
-/-- Function-level rewrite for `stage2_g`: it is the shifted sequence `fun k => f (k + m*d)`. -/
-theorem stage2_g_eq_fun (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    stage2_g (f := f) (hf := hf) =
-      fun k => f (k + stage2_start (f := f) (hf := hf)) := by
-  funext k
-  simpa using stage2_g_eq (f := f) (hf := hf) k
-
 end Tao2015
 
 end MoltResearch

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Entry.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Entry.lean
@@ -1,5 +1,5 @@
 import Conjectures.C0002_erdos_discrepancy.src.TrackCStage3EntryCore
-import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2ProofCore
+import Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Entry
 
 /-!
 # Track C: Stage 3 entry point (Tao 2015 plane)


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Move the reduced-sequence projection/rewrite lemmas (stage2_hg, stage2_g_eq, stage2_g_eq_fun) into TrackCStage2Entry so they are available from the lightweight entry import.
- Drop those lemmas from TrackCStage2ProofCore to avoid duplicate declarations.
- Update TrackCStage3Entry to import TrackCStage2Entry (lighter) instead of TrackCStage2ProofCore.
