### PR TITLE
Track C: package Stage-2 offset-bound negation

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
@@ -232,6 +232,18 @@ theorem exists_params_one_le_unboundedDiscOffset (out : Stage2Output f) :
   refine ⟨out.d, out.m, out.one_le_d (f := f), ?_⟩
   exact out.unboundedDiscOffset (f := f)
 
+/-- Existential packaging: Stage 2 yields concrete parameters `d, m` with `1 ≤ d` such that there is
+no bundled offset-discrepancy bound at those parameters.
+
+Normal form: `∃ d m, 1 ≤ d ∧ ¬ ∃ B, BoundedDiscOffset f d m B`.
+
+This is just `Stage2Output.not_exists_boundedDiscOffset` packaged under an existential quantifier.
+-/
+theorem exists_params_one_le_not_exists_boundedDiscOffset (out : Stage2Output f) :
+    ∃ d m : ℕ, 1 ≤ d ∧ ¬ ∃ B : ℕ, BoundedDiscOffset f d m B := by
+  refine ⟨out.d, out.m, out.one_le_d (f := f), ?_⟩
+  simpa [Stage2Output.d, Stage2Output.m] using out.not_exists_boundedDiscOffset (f := f)
+
 /-- Existential packaging: Stage 2 yields concrete parameters `d, m` such that `discOffset f d m`
 has arbitrarily large values.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add Stage2Output.exists_params_one_le_not_exists_boundedDiscOffset: existential packaging of the Stage-2 offset-bound negation with the side condition 1 ≤ d.
- Keeps the Stage-2 convenience lemma suite parallel with the existing Stage-3 packaging, so downstream stages can consume the bound-negation witness without mentioning record fields.
