### PR TITLE
Track C: Stage-3 apSumFrom-start NNF

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
@@ -120,6 +120,23 @@ theorem stage3_not_exists_forall_natAbs_apSumOffset_le (f : ℕ → ℤ) (hf : I
         (d := out.out2.d) (m := out.out2.m)).1
       hunb
 
+/-- Consumer-facing normal form: there is no uniform bound on the affine-tail nuclei
+`Int.natAbs (apSumFrom f start d n)` at the deterministic Stage-2 parameters stored in `stage3Out`.
+
+Negation normal form:
+`¬ ∃ B, ∀ n, Int.natAbs (apSumFrom f start d n) ≤ B`.
+-/
+theorem stage3_not_exists_forall_natAbs_apSumFrom_start_le (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    ¬ ∃ B : ℕ,
+        ∀ n : ℕ,
+          Int.natAbs
+              (apSumFrom f
+                (stage3Out (f := f) (hf := hf)).out2.start
+                (stage3Out (f := f) (hf := hf)).out2.d n) ≤ B := by
+  let out := stage3Out (f := f) (hf := hf)
+  -- Delegate to the Stage-2 core-extras lemma (phrased using the bundled start index).
+  simpa [out] using out.out2.not_exists_forall_natAbs_apSumFrom_mul_le (f := f)
+
 /-- Paper-notation normal form: there is no uniform bound on the shifted progression sums
 `∑ i ∈ Icc (m+1) (m+n), f (i*d)` at the deterministic Stage-2 parameters stored in `stage3Out`.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add Stage-3 wrapper lemma stage3_not_exists_forall_natAbs_apSumFrom_start_le.
- Provides the affine-tail nucleus negation-normal-form statement at the deterministic stage3Out parameters, reusing the Stage-2 core-extras lemma.
