### PR TITLE
Track C: simplify stage2Of

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Stub.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Stub.lean
@@ -39,8 +39,8 @@ verified Stage-2 assumption explicitly.
 noncomputable def stage2Of (inst : Stage2Assumption) (f : ℕ → ℤ) (hf : IsSignSequence f) :
     Stage2Output f := by
   classical
-  letI : Stage2Assumption := inst
-  exact Classical.choice (Stage2Assumption.stage2_nonempty (f := f) (hf := hf))
+  -- Use the explicit assumption directly, avoiding typeclass search.
+  exact Classical.choice (inst.stage2_nonempty (f := f) (hf := hf))
 
 /-- Abbreviation wrapper for `stage2Of` (mirrors `stage2Out`). -/
 noncomputable abbrev stage2OutOf (inst : Stage2Assumption) (f : ℕ → ℤ) (hf : IsSignSequence f) :


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Simplify the Stage-2 explicit entry point stage2Of to use the provided Stage2Assumption directly, avoiding typeclass search.
- Keeps the Stage-2 stub interface unchanged while making the implementation a bit clearer and more robust.
