### PR TITLE
Track C: witness-pos discOffset gt' packaging

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Output.lean
@@ -326,6 +326,20 @@ theorem exists_params_one_le_forall_exists_discOffset_gt' (out : Stage2Output f)
   rcases h B with ⟨n, hn⟩
   exact ⟨n, by simpa [gt_iff_lt] using hn⟩
 
+/-- Positive-length witness variant of `exists_params_one_le_forall_exists_discOffset_gt'`.
+
+This is `exists_params_one_le_forall_exists_discOffset_gt_witness_pos` rewritten using `gt_iff_lt`.
+-/
+theorem exists_params_one_le_forall_exists_discOffset_gt'_witness_pos (out : Stage2Output f) :
+    ∃ d m : ℕ, 1 ≤ d ∧ (∀ B : ℕ, ∃ n : ℕ, n > 0 ∧ discOffset f d m n > B) := by
+  rcases out.exists_params_one_le_forall_exists_discOffset_gt_witness_pos (f := f) with
+      ⟨d, m, hd, h⟩
+  refine ⟨d, m, hd, ?_⟩
+  intro B
+  rcases h B with ⟨n, hnpos, hn⟩
+  refine ⟨n, hnpos, ?_⟩
+  simpa [gt_iff_lt] using hn
+
 /-- Existential packaging: Stage 2 yields concrete parameters `d, m` such that the affine-tail nucleus
 `apSumFrom f (m*d) d n` takes arbitrarily large absolute values.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a positive-length witness existential wrapper for the inequality-direction discOffset normal form.
- Keeps the Stage-2 output lemma layer symmetric with existing gt / gt' packaging, reducing downstream boilerplate.
