### PR TITLE
Discrepancy: IsSignSequence closed under shift/dilation

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -67,6 +67,10 @@ The goal is to pair verified artifacts with learning scaffolding.
   It is just a stable-name wrapper around `discOffsetUpTo_add_le_add_discOffsetUpTo`, but avoids downstream proofs having to remember that name.
 - **API note (Lipschitz step):** for sign sequences, the one-step cutoff bound is `discOffsetUpTo_succ_le_add_one`:
   `discOffsetUpTo f d m (N+1) ≤ discOffsetUpTo f d m N + 1`. The reverse direction (monotonicity) is `discOffsetUpTo_le_succ`.
+- **API note (sign sequences under reindexing):** once you have `hf : IsSignSequence f`, you should not re-prove the pointwise `{±1}` bound after shifting/dilating indices. Use:
+  - additive shift (`n ↦ n + k`): `IsSignSequence.shift_add (f := f) k hf` (or dot-notation `hf.shift_add' k`),
+  - multiplicative dilation (`n ↦ n * k`): `IsSignSequence.map_mul (f := f) k hf` (or dot-notation `hf.map_mul' k`).
+  These are intended as lightweight hypothesis-transport wrappers for later normal-form pipelines.
 - **API note (bounding a fixed tail):** to bound a particular `discOffset f d m n` by the max cutoff at the *same* `n`, use `discOffset_le_discOffsetUpTo_self` (it’s just the `N = n` specialization, so you don’t have to write `le_rfl`).
 - **API note (boundedness ↔ max-level nucleus, finite length):** for the finite-length “along `d`” predicate,
   `BoundedDiscrepancyAlong f d len B` is equivalent to the single inequality

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -16,6 +16,7 @@ namespace MoltResearch
 /-- A ±1-valued sequence on ℕ (values in ℤ). -/
 def IsSignSequence (f : ℕ → ℤ) : Prop := ∀ n, f n = 1 ∨ f n = -1
 
+
 /-- Sum of `f` along the homogeneous arithmetic progression `d, 2d, ..., nd`.
 
 We use `Finset.range n` with `i+1` so the progression starts at `d`.
@@ -3474,6 +3475,16 @@ lemma IsSignSequence.shift_add_left {f : ℕ → ℤ} (k : ℕ) (hf : IsSignSequ
 lemma IsSignSequence.map_mul {f : ℕ → ℤ} (k : ℕ) (hf : IsSignSequence f) :
     IsSignSequence (fun n => f (n * k)) :=
   IsSignSequence.comp (f := f) (fun n => n * k) hf
+
+/-- Dot-notation friendly wrapper for `IsSignSequence.shift_add` (argument order: hypothesis first). -/
+lemma IsSignSequence.shift_add' {f : ℕ → ℤ} (hf : IsSignSequence f) (k : ℕ) :
+    IsSignSequence (fun n => f (n + k)) :=
+  IsSignSequence.shift_add (f := f) k hf
+
+/-- Dot-notation friendly wrapper for `IsSignSequence.map_mul` (argument order: hypothesis first). -/
+lemma IsSignSequence.map_mul' {f : ℕ → ℤ} (hf : IsSignSequence f) (k : ℕ) :
+    IsSignSequence (fun n => f (n * k)) :=
+  IsSignSequence.map_mul (f := f) k hf
 
 lemma IsSignSequence.natAbs_eq_one {f : ℕ → ℤ} (hf : IsSignSequence f) (n : ℕ) :
     Int.natAbs (f n) = 1 := by

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -1420,6 +1420,16 @@ example (q : ℕ) (hq : q > 0) :
   simpa using
     (apSum_mul_len_succ_eq_sum_range_mul_left (f := f) (d := d) (q := q) (n := n) hq)
 
+-- Regression (Track B / sign sequences closed under reindexing):
+example (f : ℕ → ℤ) (hf : IsSignSequence f) (k : ℕ) :
+    IsSignSequence (fun n => f (n + k)) := by
+  simpa using (IsSignSequence.shift_add (f := f) k hf)
+
+-- Regression (Track B / sign sequences closed under reindexing):
+example (f : ℕ → ℤ) (hf : IsSignSequence f) (q : ℕ) :
+    IsSignSequence (fun n => f (n * q)) := by
+  simpa using (IsSignSequence.map_mul (f := f) q hf)
+
 -- Regression (Track B / local edit sensitivity, sum-level):
 -- if you flip at most one sampled sign, the sum changes by at most `2`.
 example :


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Shift/dilation closure for sign sequences: prove `IsSignSequence f → IsSignSequence (fun n => f (n + k))` and `IsSignSequence f → IsSignSequence (fun n => f (n * q))` (with simp-friendly wrappers for the repo’s preferred `shift_add`/`map_mul` naming), so later reductions can freely shift/dilate without re-proving the `{±1}` bound.

Summary:
- Add dot-notation-friendly wrappers `IsSignSequence.shift_add'` and `IsSignSequence.map_mul'` (hypothesis-first argument order).
- Add regression examples in `MoltResearch.Discrepancy.NormalFormExamples`.

Testing:
- `make ci`
