### PR TITLE
Discrepancy: monotonicity wrappers for boundedness predicates

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -96,6 +96,10 @@ The goal is to pair verified artifacts with learning scaffolding.
 - **API note (monotone-in-`C`):** `HasDiscrepancyAtLeast f C` is **antitone** in `C` (the witness inequality is `> C`).
   Use `HasDiscrepancyAtLeast.mono` to *lower* the bound, and the contrapositive lemma
   `HasDiscrepancyAtLeast.not_mono` to *raise* bounds under negation (useful for boundedness normal forms).
+- **API note (boundedness monotonicity, `B`):** for the boundedness predicates,
+  `BoundedDiscOffset f d m B` and `BoundedDiscrepancyAlong f d len B` are monotone in the bound parameter `B`.
+  Use `BoundedDiscOffset.mono_B` / `BoundedDiscrepancyAlong.mono_B` to enlarge bounds, and the contrapositive
+  helpers `BoundedDiscOffset.not_mono_B` / `BoundedDiscrepancyAlong.not_mono_B` to shrink bounds under negation.
 - **API note (degenerate parameters for `UpTo`):** in downstream goals, you often want to normalize away “spurious” degenerate parameters without unfolding the finitary `Finset.sup` definition. The stable surface exports simp lemmas for:
   - `discOffsetUpTo f d m 0 = 0`
   - `discOffsetUpTo f d 0 N = discUpTo f d N`

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -1973,6 +1973,19 @@ theorem BoundedDiscOffset.mono_B {f : ℕ → ℤ} {d m B B' : ℕ}
   intro n
   exact le_trans (h n) hBB'
 
+/-- Contrapositive monotonicity in the bound parameter `B`.
+
+If `B ≤ B'` and you cannot bound the discrepancies by the **larger** bound `B'`, then you
+certainly cannot bound them by the smaller bound `B`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — Monotonicity packaging for boundedness predicates.
+-/
+theorem BoundedDiscOffset.not_mono_B {f : ℕ → ℤ} {d m B B' : ℕ}
+    (h : ¬ BoundedDiscOffset f d m B') (hBB' : B ≤ B') :
+    ¬ BoundedDiscOffset f d m B := by
+  intro hB
+  exact h (BoundedDiscOffset.mono_B (f := f) (d := d) (m := m) (B := B) (B' := B') hB hBB')
+
 /-!
 ### `BoundedDiscrepancyAlong` (finite-length along-`d` boundedness)
 
@@ -1993,6 +2006,7 @@ def BoundedDiscrepancyAlong (f : ℕ → ℤ) (d len B : ℕ) : Prop :=
 theorem boundedDiscrepancyAlong_iff_forall_le_discAlong_le (f : ℕ → ℤ) (d len B : ℕ) :
     BoundedDiscrepancyAlong f d len B ↔ ∀ n : ℕ, n ≤ len → discAlong f d n ≤ B :=
   Iff.rfl
+
 
 /-- Bridge lemma: finite-length along-`d` boundedness is equivalent to a bound on the finitary
 maximum `discOffsetUpTo f d 0 len`.
@@ -2026,6 +2040,13 @@ theorem mono_B {f : ℕ → ℤ} {d len B B' : ℕ}
     BoundedDiscrepancyAlong f d len B' := by
   intro n hn
   exact le_trans (h n hn) hBB'
+
+/-- Contrapositive monotonicity in the bound parameter `B`. -/
+theorem not_mono_B {f : ℕ → ℤ} {d len B B' : ℕ}
+    (h : ¬ BoundedDiscrepancyAlong f d len B') (hBB' : B ≤ B') :
+    ¬ BoundedDiscrepancyAlong f d len B := by
+  intro hB
+  exact h (mono_B (f := f) (d := d) (len := len) (B := B) (B' := B') hB hBB')
 
 /-- Monotonicity in the length parameter `len` (shrinking the range keeps boundedness). -/
 theorem mono_len {f : ℕ → ℤ} {d len len' B : ℕ}

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -100,6 +100,31 @@ example (h : ¬ HasDiscrepancyAtLeast f C) (hC : C ≤ C') : ¬ HasDiscrepancyAt
   simpa using (HasDiscrepancyAtLeast.not_mono (f := f) (C₁ := C) (C₂ := C') h hC)
 
 /-!
+### NEW (Track B): monotonicity packaging for boundedness predicates
+
+Compile-only regression: we can weaken/strengthen bounds without unfolding `BoundedDiscOffset` or
+`BoundedDiscrepancyAlong`.
+-/
+
+example (B B' : ℕ) (h : BoundedDiscOffset f d m B) (hBB' : B ≤ B') : BoundedDiscOffset f d m B' := by
+  simpa using (BoundedDiscOffset.mono_B (f := f) (d := d) (m := m) (B := B) (B' := B') h hBB')
+
+example (B B' : ℕ) (h : ¬ BoundedDiscOffset f d m B') (hBB' : B ≤ B') : ¬ BoundedDiscOffset f d m B := by
+  simpa using (BoundedDiscOffset.not_mono_B (f := f) (d := d) (m := m) (B := B) (B' := B') h hBB')
+
+example (len B B' : ℕ) (h : BoundedDiscrepancyAlong f d len B) (hBB' : B ≤ B') :
+    BoundedDiscrepancyAlong f d len B' := by
+  simpa using (BoundedDiscrepancyAlong.mono_B (f := f) (d := d) (len := len) (B := B) (B' := B') h hBB')
+
+example (len B B' : ℕ) (h : ¬ BoundedDiscrepancyAlong f d len B') (hBB' : B ≤ B') :
+    ¬ BoundedDiscrepancyAlong f d len B := by
+  simpa using (BoundedDiscrepancyAlong.not_mono_B (f := f) (d := d) (len := len) (B := B) (B' := B') h hBB')
+
+example (len len' B : ℕ) (h : BoundedDiscrepancyAlong f d len B) (hlen : len' ≤ len) :
+    BoundedDiscrepancyAlong f d len' B := by
+  simpa using (BoundedDiscrepancyAlong.mono_len (f := f) (d := d) (len := len) (len' := len') (B := B) h hlen)
+
+/-!
 ### NEW (Track B): constant-sequence sanity checks (`apSum`/`discOffset`)
 
 These are explicit computed examples that should remain one-line `simp`/`simpa` proofs under the

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -1274,8 +1274,8 @@ Definition of done:
 
 - [x] Shift/dilation closure for sign sequences: prove `IsSignSequence f → IsSignSequence (fun n => f (n + k))` and `IsSignSequence f → IsSignSequence (fun n => f (n * q))` (with simp-friendly wrappers for the repo’s preferred `shift_add`/`map_mul` naming), so later reductions can freely shift/dilate without re-proving the `{±1}` bound.
 
-- [ ] Monotonicity packaging for discrepancy predicates: add one-line wrappers like
-  `HasDiscrepancyAtLeast f C → C ≤ C' → HasDiscrepancyAtLeast f C'` (and converses where appropriate), plus analogous monotonicity for the “boundedness” predicates, so later “weaken/strengthen the target constant” steps are boilerplate-free.
+- [x] Monotonicity packaging for discrepancy predicates: add one-line wrappers for “weaken/strengthen the target constant” steps (including contrapositive forms where appropriate), plus analogous monotonicity for the boundedness predicates.
+  (Implemented in `MoltResearch/Discrepancy/Basic.lean` as `HasDiscrepancyAtLeast.mono` / `HasDiscrepancyAtLeast.not_mono`, `BoundedDiscOffset.mono_B` / `BoundedDiscOffset.not_mono_B`, and `BoundedDiscrepancyAlong.mono_B` / `BoundedDiscrepancyAlong.not_mono_B` / `BoundedDiscrepancyAlong.mono_len`, with stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
 - [ ] `apSupport` API polish: prove a small bundle about the progression support set `{(m+i+1)*d | i < n}` (or the repo’s canonical `apSupport`), including `card = n` (for `d>0`) and a clean membership characterization lemma, to support later pigeonhole/counting steps without re-opening `Finset.image` algebra.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Monotonicity packaging for discrepancy predicates: add one-line wrappers for “weaken/strengthen the target constant” steps (including contrapositive forms where appropriate), plus analogous monotonicity for the boundedness predicates.

Adds contrapositive monotonicity wrappers for the boundedness predicates:
- `BoundedDiscOffset.not_mono_B`
- `BoundedDiscrepancyAlong.not_mono_B`

Also adds compile-only stable-surface regression examples under `import MoltResearch.Discrepancy` in `MoltResearch/Discrepancy/NormalFormExamples.lean`, and an overlay note in `Learning/EDUCATIONAL_OVERLAYS.md`.

CI: `make ci`