### PR TITLE
Track C: mod arithmetic lemma for Stage-2 start

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
@@ -70,6 +70,16 @@ This is often the most convenient normal form of `d_dvd_start`.
 theorem start_mod_d (out : Stage2Output f) : out.start % out.d = 0 := by
   exact Nat.mod_eq_zero_of_dvd out.d_dvd_start
 
+/-- Adding the start index does not change residues modulo the step size.
+
+Since `out.start` is a multiple of `out.d`, we have
+`(n + out.start) % out.d = n % out.d`.
+-/
+theorem add_start_mod_d (out : Stage2Output f) (n : ℕ) :
+    (n + out.start) % out.d = n % out.d := by
+  have hstart : out.start % out.d = 0 := out.start_mod_d (f := f)
+  simp [Nat.add_mod, hstart]
+
 /-- Recover the offset parameter `out.m` by dividing the start index `out.start` by the step size
 `out.d`.
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
@@ -99,8 +99,8 @@ Since `out.start` is a multiple of `out.d`, we have
 -/
 theorem add_start_mod_d (out : Stage3Output f) (n : ℕ) :
     (n + out.start) % out.d = n % out.d := by
-  have hstart : out.start % out.d = 0 := out.start_mod_d (f := f)
-  simp [Nat.add_mod, hstart]
+  simpa [Stage3Output.start, Stage3Output.d] using
+    (Stage2Output.add_start_mod_d (f := f) (out := out.out2) (n := n))
 
 /-- Variant of `add_start_mod_d` with the start index on the left. -/
 theorem start_add_mod_d (out : Stage3Output f) (n : ℕ) :


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Added a small Stage-2 core lemma Stage2Output.add_start_mod_d: adding the start index does not change residues modulo the step size.
- Refactored the Stage-3 wrapper lemma add_start_mod_d to delegate to the Stage-2 core lemma (reduces duplication / keeps the Stage-3 file thinner).
