### PR TITLE
Discrepancy: step-scaling wrappers for affine pull-out normal form

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -110,6 +110,11 @@ The goal is to pair verified artifacts with learning scaffolding.
     which package the `((m+i+1)*d)*q = (m+i+1)*(d*q)` index normalization.
     If your goal is oriented the other way (the step is already written as `d*q` / `q*d` and you want to push the multiplier into the input), use the non-simp orientation helpers:
     `discOffsetUpTo_step_mul_right` / `discOffsetUpTo_step_mul_left`.
+
+    **Tip (sum-level and witness-level):** the same “step is already scaled” orientation helpers exist one level down:
+    - `apSumOffset_step_mul_right` / `apSumOffset_step_mul_left`
+    - `discOffset_step_mul_right` / `discOffset_step_mul_left`
+    These are handy when you want to normalize a tail sum/discrepancy *before* applying residue/dilation lemmas, without unfolding definitions.
     For cutoff scaling bookkeeping, use `discOffsetUpTo_le_mul` (monotonicity under `N ↦ N*q`, assuming `q > 0`).
     If you just need to normalize the *orientation* of a scaled cutoff (so you can match another lemma’s statement), use:
     - `discOffsetUpTo_length_mul_comm` to rewrite `discOffsetUpTo f d m (q * N)` into `discOffsetUpTo f d m (N * q)`

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -197,6 +197,28 @@ lemma apSumOffset_map_mul_left (f : ℕ → ℤ) (q d m n : ℕ) :
   intro i hi
   simp [Nat.mul_assoc, Nat.mul_comm]
 
+/-!
+#### Step-scaling rewrite wrappers (orientation helpers)
+
+These are the `apSumOffset`-level analogues of `discOffsetUpTo_step_mul_right` / `discOffsetUpTo_step_mul_left`.
+
+Downstream normal-form code often has the *step* written as `d*q`/`q*d` already and wants to push the
+multiplier into the function argument (`k ↦ k*q` or `k ↦ q*k`). The core dilation lemmas above are oriented
+the other way, so we provide these tiny wrappers for ergonomic rewriting.
+
+These are **not** tagged `[simp]`.
+-/
+
+/-- Rewrite a multiplied step `d*q` into a multiplied input (`mul_right` convention). -/
+lemma apSumOffset_step_mul_right (f : ℕ → ℤ) (q d m n : ℕ) :
+    apSumOffset f (d * q) m n = apSumOffset (fun k => f (k * q)) d m n := by
+  simpa using (apSumOffset_map_mul_right (f := f) (q := q) (d := d) (m := m) (n := n)).symm
+
+/-- Rewrite a multiplied step `q*d` into a multiplied input (`mul_left` convention). -/
+lemma apSumOffset_step_mul_left (f : ℕ → ℤ) (q d m n : ℕ) :
+    apSumOffset f (q * d) m n = apSumOffset (fun k => f (q * k)) d m n := by
+  simpa using (apSumOffset_map_mul_left (f := f) (q := q) (d := d) (m := m) (n := n)).symm
+
 /-- Canonical homogeneous view of offsets: push the start shift `m*d` into the summand.
 
 (Track B normal-form checklist item.)
@@ -958,6 +980,27 @@ lemma discOffset_map_mul_left (f : ℕ → ℤ) (q d m n : ℕ) :
     discOffset (fun k => f (q * k)) d m n = discOffset f (q * d) m n := by
   unfold discOffset
   simp [apSumOffset_map_mul_left]
+
+/-!
+#### Step-scaling rewrite wrappers (orientation helpers)
+
+These are the `discOffset`-level analogues of `discOffsetUpTo_step_mul_right` / `discOffsetUpTo_step_mul_left`.
+
+They are convenient when the step is already presented as `d*q`/`q*d` and you want to push the multiplier
+into the summand in one rewrite.
+
+These are **not** tagged `[simp]`.
+-/
+
+/-- Rewrite a multiplied step `d*q` into a multiplied input (`mul_right` convention). -/
+lemma discOffset_step_mul_right (f : ℕ → ℤ) (q d m n : ℕ) :
+    discOffset f (d * q) m n = discOffset (fun k => f (k * q)) d m n := by
+  simpa using (discOffset_map_mul_right (f := f) (q := q) (d := d) (m := m) (n := n)).symm
+
+/-- Rewrite a multiplied step `q*d` into a multiplied input (`mul_left` convention). -/
+lemma discOffset_step_mul_left (f : ℕ → ℤ) (q d m n : ℕ) :
+    discOffset f (q * d) m n = discOffset (fun k => f (q * k)) d m n := by
+  simpa using (discOffset_map_mul_left (f := f) (q := q) (d := d) (m := m) (n := n)).symm
 
 /-- Shift–dilation coherence for the discrepancy wrapper `discOffset`.
 

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -884,6 +884,14 @@ example (q : ℕ) : apSumFrom f (a * q) (d * q) n = apSumFrom (fun t => f (t * q
 example (q : ℕ) : discFrom f (a * q) (d * q) n = discFrom (fun t => f (t * q)) a d n := by
   simpa using (discFrom_mul_pull_out_right (f := f) (q := q) (a := a) (d := d) (n := n))
 
+-- Offset / tail-level analogues: when the *step* is already written as `d*q`, we can push the
+-- multiplier into the summand in one rewrite.
+example (q : ℕ) : apSumOffset f (d * q) m n = apSumOffset (fun t => f (t * q)) d m n := by
+  simpa using (apSumOffset_step_mul_right (f := f) (q := q) (d := d) (m := m) (n := n))
+
+example (q : ℕ) : discOffset f (d * q) m n = discOffset (fun t => f (t * q)) d m n := by
+  simpa using (discOffset_step_mul_right (f := f) (q := q) (d := d) (m := m) (n := n))
+
 /-!
 ### NEW (Track B): residue-class splitting (disc-level inequality wrapper)
 

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -1280,7 +1280,7 @@ Definition of done:
 - [x] `apSupport` API polish: prove a small bundle about the progression support set `{(m+i+1)*d | i < n}` (or the repo’s canonical `apSupport`), including `card = n` (for `d>0`) and a clean membership characterization lemma, to support later pigeonhole/counting steps without re-opening `Finset.image` algebra.
   (Implemented in `MoltResearch/Discrepancy/Basic.lean` as `card_apSupport_eq`, `mem_apSupport`, `mem_apSupport_index_iff`, etc., with stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
-- [ ] “Affine step pull-out” normal form: package a lemma rewriting `apSumFrom f (a*q) (d*q) n` into `apSumFrom (fun t => f (t*q)) a d n` (and corresponding offset/disc versions), so scaling an affine AP can be normalized in one `rw` before applying residue/dilation lemmas.
+- [x] “Affine step pull-out” normal form: package a lemma rewriting `apSumFrom f (a*q) (d*q) n` into `apSumFrom (fun t => f (t*q)) a d n` (and corresponding offset/disc versions), so scaling an affine AP can be normalized in one `rw` before applying residue/dilation lemmas.
 
 - [ ] `discOffset`/`discAlong` bridge coherence: add a canonical lemma expressing `discAlong f d n` as a `discOffset` (or vice versa) in the repo’s preferred orientation, so downstream code can move between “along” and “offset” normal forms without unfolding.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: “Affine step pull-out” normal form: package a lemma rewriting `apSumFrom f (a*q) (d*q) n` into `apSumFrom (fun t => f (t*q)) a d n` (and corresponding offset/disc versions)

What:
- Add orientation-helper “step-scaling” wrappers for `apSumOffset`/`discOffset`:
  - `apSumOffset_step_mul_right/left`
  - `discOffset_step_mul_right/left`
- Add stable-surface regression examples for the new wrappers.
- Check off the corresponding Track B checklist item.

Why:
- Downstream normal-form code often has the step already written as `d*q` (or `q*d`) and wants a single rewrite pushing `q` into the summand before applying residue/dilation lemmas.

CI:
- `make ci`