### PR TITLE
Discrepancy: discAlong/discOffset bridge lemma

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -27,6 +27,11 @@ The goal is to pair verified artifacts with learning scaffolding.
   - `disc f d n` (matches the `discOffset` / `discOffsetUpTo` family).
   They are definitionally equal; use `discrepancy_eq_disc` / `disc_eq_discrepancy` when you want to normalize one spelling to the other without unfolding.
 
+- **API note (`discAlong` ↔ `discOffset` bridge):** `discAlong f d n` is the “no-offset” specialization
+  `discOffset f d 0 n`. Use the wrapper-level lemma `discAlong_def` to rewrite between these normal
+  forms **without unfolding**; it is intentionally *not* a `[simp]` lemma, since the discrepancy API
+  already contains other bridge lemmas that can interact to create simp loops.
+
 - **API note (homogeneous cut at `k ≤ n`):** if you want to cut a homogeneous AP sum/discrepancy without rewriting into an offset normal form, use:
   - `apSum_eq_add_apSumOffset_cut` / `apSum_sub_apSum_cut` for exact prefix+tail / tail-difference statements, and
   - `disc_cut_le` for the one-line triangle bound

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -1682,7 +1682,11 @@ Checklist item: Problems/erdos_discrepancy.md (Track B) — Along-`d` API cohere
 def discAlong (f : ℕ → ℤ) (d n : ℕ) : ℕ :=
   discOffset f d 0 n
 
-/-- Definitional lemma exposing `discAlong`. -/
+/-- Definitional lemma exposing `discAlong`.
+
+This is the canonical `discAlong`/`discOffset` bridge lemma (kept *out* of `[simp]` to avoid
+simp loops with other bridge lemmas in the discrepancy API).
+-/
 lemma discAlong_def (f : ℕ → ℤ) (d n : ℕ) : discAlong f d n = discOffset f d 0 n :=
   rfl
 

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -1637,6 +1637,11 @@ example : HasDiscrepancyAtLeastAlong f d C ↔ ∃ n : ℕ, C < discOffset f d 0
 example : HasDiscrepancyAtLeastAlong f d C ↔ ∃ n : ℕ, C < discAlong f d n := by
   simpa using (HasDiscrepancyAtLeastAlong.iff_exists_discAlong_lt (f := f) (d := d) (C := C))
 
+-- Regression (Track B / `discOffset`/`discAlong` bridge coherence): rewrite the along-`d`
+-- wrapper to the offset normal form without unfolding.
+example : discAlong f d n = discOffset f d 0 n := by
+  simpa using (discAlong_def (f := f) (d := d) (n := n))
+
 -- Regression (Track B / unbounded witness normal form, along-`d`): unshifted unboundedness
 -- rewrites to the `discOffset … 0 n` ∀∃ normal form.
 example : UnboundedDiscrepancyAlong f d ↔ (∀ C : ℕ, ∃ n : ℕ, C < discOffset f d 0 n) := by


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `discOffset`/`discAlong` bridge coherence: add a canonical lemma expressing `discAlong f d n` as a `discOffset` (or vice versa) in the repo’s preferred orientation, so downstream code can move between “along” and “offset” normal forms without unfolding.

## What changed
- Clarified `discAlong_def` as the canonical `discAlong` → `discOffset … 0 …` bridge lemma (kept out of `[simp]` to avoid simp-loop interactions with other coherence lemmas).
- Added a stable-surface regression example in `NormalFormExamples.lean` demonstrating the rewrite via `discAlong_def`.

## CI
- `make ci`