### PR TITLE
Discrepancy: stable discAlong/discOffset bridge lemmas

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -28,9 +28,13 @@ The goal is to pair verified artifacts with learning scaffolding.
   They are definitionally equal; use `discrepancy_eq_disc` / `disc_eq_discrepancy` when you want to normalize one spelling to the other without unfolding.
 
 - **API note (`discAlong` ↔ `discOffset` bridge):** `discAlong f d n` is the “no-offset” specialization
-  `discOffset f d 0 n`. Use the wrapper-level lemma `discAlong_def` to rewrite between these normal
-  forms **without unfolding**; it is intentionally *not* a `[simp]` lemma, since the discrepancy API
-  already contains other bridge lemmas that can interact to create simp loops.
+  `discOffset f d 0 n`. Use the stable-name wrapper-level bridge lemmas to rewrite between these normal
+  forms **without unfolding**:
+  - `discAlong_eq_discOffset` (rewrite `discAlong` → `discOffset … 0 …`),
+  - `discOffset_zero_eq_discAlong` (rewrite `discOffset … 0 …` → `discAlong`).
+
+  These are intentionally *not* `[simp]` lemmas, since the discrepancy API contains other bridge lemmas
+  that can interact to create simp loops.
 
 - **API note (homogeneous cut at `k ≤ n`):** if you want to cut a homogeneous AP sum/discrepancy without rewriting into an offset normal form, use:
   - `apSum_eq_add_apSumOffset_cut` / `apSum_sub_apSum_cut` for exact prefix+tail / tail-difference statements, and

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -1690,6 +1690,22 @@ simp loops with other bridge lemmas in the discrepancy API).
 lemma discAlong_def (f : ℕ → ℤ) (d n : ℕ) : discAlong f d n = discOffset f d 0 n :=
   rfl
 
+/-- Stable lemma name: rewrite `discAlong` into `discOffset` with zero offset.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — `discOffset`/`discAlong` bridge coherence.
+-/
+lemma discAlong_eq_discOffset (f : ℕ → ℤ) (d n : ℕ) :
+    discAlong f d n = discOffset f d 0 n :=
+  rfl
+
+/-- Stable lemma name: rewrite a zero-offset `discOffset` into `discAlong`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — `discOffset`/`discAlong` bridge coherence.
+-/
+lemma discOffset_zero_eq_discAlong (f : ℕ → ℤ) (d n : ℕ) :
+    discOffset f d 0 n = discAlong f d n :=
+  rfl
+
 /-- Bridge lemma: `discAlong` agrees with the original homogeneous wrapper `discrepancy`. -/
 lemma discAlong_eq_discrepancy (f : ℕ → ℤ) (d n : ℕ) : discAlong f d n = discrepancy f d n := by
   unfold discAlong discOffset discrepancy apSumOffset apSum

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -1640,7 +1640,12 @@ example : HasDiscrepancyAtLeastAlong f d C ↔ ∃ n : ℕ, C < discAlong f d n 
 -- Regression (Track B / `discOffset`/`discAlong` bridge coherence): rewrite the along-`d`
 -- wrapper to the offset normal form without unfolding.
 example : discAlong f d n = discOffset f d 0 n := by
-  simpa using (discAlong_def (f := f) (d := d) (n := n))
+  simpa using (discAlong_eq_discOffset (f := f) (d := d) (n := n))
+
+-- Regression (Track B / `discOffset`/`discAlong` bridge coherence): also rewrite the
+-- zero-offset `discOffset` normal form back into `discAlong`.
+example : discOffset f d 0 n = discAlong f d n := by
+  simpa using (discOffset_zero_eq_discAlong (f := f) (d := d) (n := n))
 
 -- Regression (Track B / unbounded witness normal form, along-`d`): unshifted unboundedness
 -- rewrites to the `discOffset … 0 n` ∀∃ normal form.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `discOffset`/`discAlong` bridge coherence: add a canonical lemma expressing `discAlong f d n` as a `discOffset` (or vice versa) in the repo’s preferred orientation, so downstream code can move between “along” and “offset” normal forms without unfolding.

Summary:
- Add stable, non-`[simp]` bridge lemma names:
  - `discAlong_eq_discOffset` (rewrite `discAlong` → `discOffset … 0 …`)
  - `discOffset_zero_eq_discAlong` (rewrite `discOffset … 0 …` → `discAlong`)
- Update `NormalFormExamples.lean` with compile-only regression examples using the new lemma names.

Notes:
- Lemmas are definitional (`rfl`) and intentionally kept out of `[simp]` to avoid rewrite loops.