### PR TITLE
Discrepancy: regression example for discAlong↔discOffset bridge

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -943,6 +943,19 @@ example : apSumOffset f d 0 n = apSum f d n := by
   simp
 
 /-!
+### NEW (Track B): `discAlong` ↔ `discOffset` bridge coherence
+
+Compile-only regression: moving between the “along” and “offset” normal forms should be a one-liner
+without unfolding definitions.
+-/
+
+example : discAlong f d n = discOffset f d 0 n := by
+  simpa using (discAlong_eq_discOffset (f := f) (d := d) (n := n))
+
+example : discOffset f d 0 n = discAlong f d n := by
+  simp
+
+/-!
 ### NEW (Track B): `UpTo` API coherence (degenerate parameters + micro-pipeline)
 
 These compile-only examples ensure the stable-surface `UpTo` wrappers stay easy to use.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `discOffset`/`discAlong` bridge coherence: add a canonical lemma expressing `discAlong f d n` as a `discOffset` (or vice versa) in the repo’s preferred orientation, so downstream code can move between “along” and “offset” normal forms without unfolding.

What this does
- Adds a stable-surface compile-only regression example showing `discAlong f d n = discOffset f d 0 n` (and the reverse direction) as a one-liner under `import MoltResearch.Discrepancy`.

Notes
- No new lemmas introduced; this is a SurfaceAudit-style guard against accidental API regression.
