### PR TITLE
Discrepancy: regression examples for discAlong/discOffset bridge

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -4958,6 +4958,21 @@ example (f : ℕ → ℤ) (d q n : ℕ) (hq : q > 0) :
   simpa using (disc_mul_len_succ_le_sum_range_natAbs (f := f) (d := d) (q := q) (n := n) hq)
 
 /-!
+### NEW (Track B): `discAlong`/`discOffset` bridge coherence regression tests
+
+These are compile-only sanity checks that the stable-surface bridge lemmas can move between
+`discAlong f d n` and the zero-offset normal form `discOffset f d 0 n` **without unfolding**.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — `discOffset`/`discAlong` bridge coherence.
+-/
+
+example (f : ℕ → ℤ) (d n : ℕ) : discAlong f d n = discOffset f d 0 n := by
+  simpa using (discAlong_eq_discOffset (f := f) (d := d) (n := n))
+
+example (f : ℕ → ℤ) (d n : ℕ) : discOffset f d 0 n = discAlong f d n := by
+  simpa using (discOffset_zero_eq_discAlong (f := f) (d := d) (n := n))
+
+/-!
 ## Step-factor coherence regression tests
 
 These are compile-time sanity checks that downstream code can “factor the step” at the discrepancy


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `discOffset`/`discAlong` bridge coherence: add a canonical lemma expressing `discAlong f d n` as a `discOffset` (or vice versa) in the repo’s preferred orientation, so downstream code can move between “along” and “offset” normal forms without unfolding.

What changed
- Added stable-surface compile-only regression examples for rewriting between `discAlong` and `discOffset` at zero offset, using the canonical bridge lemmas (no unfolding).

Notes
- The canonical bridge lemmas already exist in `MoltResearch.Discrepancy.Basic` (`discAlong_eq_discOffset` and `discOffset_zero_eq_discAlong`); this PR adds a NormalFormExamples regression section that exercises them on the stable surface.
