### PR TITLE
Track C: remove unnecessary simpa in Stage 3

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
@@ -99,8 +99,8 @@ Since `out.start` is a multiple of `out.d`, we have
 -/
 theorem add_start_mod_d (out : Stage3Output f) (n : ℕ) :
     (n + out.start) % out.d = n % out.d := by
-  simpa [Stage3Output.start, Stage3Output.d] using
-    (Stage2Output.add_start_mod_d (f := f) (out := out.out2) (n := n))
+  simp [Stage3Output.start, Stage3Output.d,
+    Stage2Output.add_start_mod_d (f := f) (out := out.out2) (n := n)]
 
 /-- Variant of `add_start_mod_d` with the start index on the left. -/
 theorem start_add_mod_d (out : Stage3Output f) (n : ℕ) :


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Refactored Stage-3 lemma add_start_mod_d to use simp instead of simpa.
- Removes the unnecessarySimpa linter warning while keeping the Stage-2 reuse unchanged.
