### PR TITLE
Discrepancy: cut-then-shift coherence wrappers

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -3252,6 +3252,21 @@ example (k : ℕ) :
     apSumOffset f d (m + k) n = apSumOffset (fun t => f (k * d + t)) d m n := by
   simpa using apSumOffset_shift_start_add_left (f := f) (d := d) (m := m) (k := k) (n := n)
 
+-- Regression (Track B / “cut then shift” coherence, sum-level):
+-- cut a tail after shifting the start, or shift after cutting.
+example (k : ℕ) (hn : n₁ ≤ n₂) :
+    apSumOffset f d (m + k) n₂ - apSumOffset f d (m + k) n₁ =
+      apSumOffset (fun t => f (t + k * d)) d (m + n₁) (n₂ - n₁) := by
+  simpa using
+    apSumOffset_sub_apSumOffset_eq_apSumOffset_shift_start_add (f := f) (d := d) (m := m) (k := k)
+      (n₁ := n₁) (n₂ := n₂) hn
+
+-- Wrapper-level version keyed to the start-index shape produced by tail cuts.
+example (k : ℕ) :
+    discOffset f d ((m + k) + n₁) n = discOffset (fun t => f (t + k * d)) d (m + n₁) n := by
+  simpa using
+    discOffset_shift_start_add_tail (f := f) (d := d) (m := m) (k := k) (n₁ := n₁) (n := n)
+
 -- Paper normal form: rewrite `Icc (m+1) (m+n)` tails to the fixed-lower-endpoint `Icc 1 n` form.
 example :
     (Finset.Icc (m + 1) (m + n)).sum (fun i => f (i * d)) =

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -5036,6 +5036,23 @@ example (f : ℕ → ℤ) (d n : ℕ) :
     disc (fun x => if x ∈ apSupport d 0 n then f x else 0) d n = disc f d n := by
   simpa using (disc_restrict_support (f := f) (d := d) (n := n))
 
+/-!
+## NEW (Track B): “cut then shift” coherence regression tests
+
+Compile-only regression examples showing that the tail-cut start-index shape `((m+k)+n₁)`
+normalizes cleanly at the `apSumOffset` and `discOffset` levels.
+-/
+
+example (f : ℕ → ℤ) (d m k n₁ n : ℕ) :
+    apSumOffset f d ((m + k) + n₁) n = apSumOffset (fun t => f (t + k * d)) d (m + n₁) n := by
+  simpa using
+    (apSumOffset_shift_start_add_tail (f := f) (d := d) (m := m) (k := k) (n₁ := n₁) (n := n))
+
+example (f : ℕ → ℤ) (d m k n₁ n : ℕ) :
+    discOffset f d ((m + k) + n₁) n = discOffset (fun t => f (t + k * d)) d (m + n₁) n := by
+  simpa using
+    (discOffset_shift_start_add_tail (f := f) (d := d) (m := m) (k := k) (n₁ := n₁) (n := n))
+
 end NormalFormExamples
 
 end MoltResearch

--- a/MoltResearch/Discrepancy/Offset.lean
+++ b/MoltResearch/Discrepancy/Offset.lean
@@ -2654,6 +2654,38 @@ lemma apSumOffset_sub_apSumOffset_eq_apSumOffset_shift_add (f : ℕ → ℤ) (d 
       (n₂ := n₂ - n₁)
   simpa [Nat.add_sub_of_le hn] using h
 
+/-- “Cut then shift” coherence for `apSumOffset`.
+
+When `n₁ ≤ n₂`, cutting off the first `n₁` terms of the offset sum starting at `m + k` produces a
+new offset sum starting at `m + k + n₁`. Shifting the start by `k` can either be done before the
+cut (by translating the summand), or after the cut (by rewriting the new start index).
+
+Concretely:
+`apSumOffset f d (m+k) n₂ - apSumOffset f d (m+k) n₁
+   = apSumOffset (fun t => f (t + k*d)) d (m+n₁) (n₂-n₁)`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — “Cut then shift” coherence.
+-/
+lemma apSumOffset_sub_apSumOffset_eq_apSumOffset_shift_start_add (f : ℕ → ℤ) (d m k : ℕ)
+    {n₁ n₂ : ℕ} (hn : n₁ ≤ n₂) :
+    apSumOffset f d (m + k) n₂ - apSumOffset f d (m + k) n₁ =
+      apSumOffset (fun t => f (t + k * d)) d (m + n₁) (n₂ - n₁) := by
+  -- First cut at `n₁`, then shift the new start index by rewriting `(m+k)+n₁` as `(m+n₁)+k`.
+  have hcut :=
+    apSumOffset_sub_apSumOffset_eq_apSumOffset (f := f) (d := d) (m := m + k) (n₁ := n₁)
+      (n₂ := n₂) (hn := hn)
+  -- `hcut` gives a tail starting at `(m+k)+n₁`; rewrite the start and apply shift-start coherence.
+  calc
+    apSumOffset f d (m + k) n₂ - apSumOffset f d (m + k) n₁
+        = apSumOffset f d ((m + k) + n₁) (n₂ - n₁) := by
+            simpa using hcut
+    _ = apSumOffset f d ((m + n₁) + k) (n₂ - n₁) := by
+            simp [Nat.add_assoc, Nat.add_left_comm, Nat.add_comm]
+    _ = apSumOffset (fun t => f (t + k * d)) d (m + n₁) (n₂ - n₁) := by
+            simpa using
+              (apSumOffset_shift_start_add (f := f) (d := d) (m := m + n₁) (k := k)
+                (n := n₂ - n₁))
+
 /-- Mul-left variant of `apSumOffset_sub_apSumOffset_eq_apSumOffset_shift_add` with the translation
 constant written as `d * (m + n₁)`.
 
@@ -2831,6 +2863,24 @@ lemma discOffset_shift_start_add_mul_left (f : ℕ → ℤ) (d m k n : ℕ) :
     discOffset f d (m + k) n = discOffset (fun t => f (t + d * k)) d m n := by
   simpa [Nat.mul_comm] using
     (discOffset_shift_start_add (f := f) (d := d) (m := m) (k := k) (n := n))
+
+/-- “Cut then shift” coherence for the wrapper `discOffset`.
+
+This is a reassociation-friendly wrapper around `discOffset_shift_start_add` keyed to the start
+index shape produced by tail-cuts:
+
+`discOffset f d ((m+k)+n₁) n = discOffset (fun t => f (t+k*d)) d (m+n₁) n`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — “Cut then shift” coherence.
+-/
+lemma discOffset_shift_start_add_tail (f : ℕ → ℤ) (d m k n₁ n : ℕ) :
+    discOffset f d ((m + k) + n₁) n = discOffset (fun t => f (t + k * d)) d (m + n₁) n := by
+  -- Reassociate the start index to match the canonical `m+k` shape and apply `discOffset_shift_start_add`.
+  -- (Tail-cut lemmas typically produce `((m+k)+n₁)` rather than `((m+n₁)+k)`.)
+  -- `discOffset_shift_start_add` is keyed to the syntactic shape `(m+n₁)+k`; tail cuts often
+  -- produce `((m+k)+n₁)`, so we just reassociate/commute the start index.
+  simpa [Nat.add_assoc, Nat.add_left_comm, Nat.add_comm] using
+    (discOffset_shift_start_add (f := f) (d := d) (m := m + n₁) (k := k) (n := n))
 
 /-!
 ### Boundedness transport lemmas (`BoundedDiscOffset`) for shift-start coherence

--- a/MoltResearch/Discrepancy/Offset.lean
+++ b/MoltResearch/Discrepancy/Offset.lean
@@ -2333,6 +2333,22 @@ lemma apSumOffset_shift_start_add_left (f : ℕ → ℤ) (d m k n : ℕ) :
   simpa [Nat.add_comm] using
     (apSumOffset_shift_start_add (f := f) (d := d) (m := m) (k := k) (n := n))
 
+/-- “Cut then shift” coherence for the nucleus `apSumOffset`.
+
+This is a reassociation-friendly wrapper around `apSumOffset_shift_start_add` keyed to the start
+index shape produced by tail-cuts:
+
+`apSumOffset f d ((m+k)+n₁) n = apSumOffset (fun t => f (t+k*d)) d (m+n₁) n`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — “Cut then shift” coherence.
+-/
+lemma apSumOffset_shift_start_add_tail (f : ℕ → ℤ) (d m k n₁ n : ℕ) :
+    apSumOffset f d ((m + k) + n₁) n = apSumOffset (fun t => f (t + k * d)) d (m + n₁) n := by
+  -- Reassociate the start index to match the canonical `m+k` shape and apply
+  -- `apSumOffset_shift_start_add`.
+  simpa [Nat.add_assoc, Nat.add_left_comm, Nat.add_comm] using
+    (apSumOffset_shift_start_add (f := f) (d := d) (m := m + n₁) (k := k) (n := n))
+
 /-- Normal form (mul-left variant): shift in the *start index* using the translation constant `d*k`.
 
 `apSumOffset f d (m + k) n = apSumOffset (fun t => f (t + d*k)) d m n`.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: “Cut then shift” coherence: prove that cutting a tail and then shifting the start agrees with shifting first and cutting after, at the level of `apSumOffset` and at the packaged `discOffset` inequalities, so longer normal-form pipelines can reorder these rewrites without manual algebra.

Summary:
- Add an `apSumOffset`-level lemma `apSumOffset_shift_start_add_tail` matching the `((m+k)+n₁)` start-index shape produced by tail cuts.
- Add compile-only stable-surface regression examples in `NormalFormExamples.lean` for both `apSumOffset_shift_start_add_tail` and the existing `discOffset_shift_start_add_tail`.

Notes:
- CI: `make ci`.
