### PR TITLE
Discrepancy: cut-then-shift coherence

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -1420,6 +1420,14 @@ example (q k' : ℕ) (hk' : k' ≤ n) :
         simp [h₁, h₂, hadd, hmn, apSumOffset_shift_add_eq_apSumFrom_sub,
           Nat.add_assoc, Nat.add_left_comm, Nat.add_comm]
 
+-- Regression (Track B / cut-then-shift coherence):
+-- Rewriting the *tail* term of `discOffset_cut_le` into “shift-first” form should be a `simpa`.
+example (k : ℕ) (hk : k ≤ n) :
+    discOffset f d m n ≤
+      discOffset f d m k + discOffset (fun t => f (t + m * d)) d k (n - k) := by
+  simpa using
+    (discOffset_cut_le_shift_mul (f := f) (d := d) (m := m) (n := n) (k := k) hk)
+
 -- Regression (Track B / discOffset periodicity normal form):
 -- If `f` is periodic with period `p` and `p ∣ d`, then `discOffset f d m n` is independent of `m`.
 example (hp : Function.Periodic f p) (hd : p ∣ d) :

--- a/MoltResearch/Discrepancy/Offset.lean
+++ b/MoltResearch/Discrepancy/Offset.lean
@@ -274,6 +274,67 @@ lemma discOffset_cut_le (f : ℕ → ℤ) (d m n k : ℕ) (hk : k ≤ n) :
   simpa [hEq] using
     (Int.natAbs_add_le (apSumOffset f d m k) (apSumOffset f d (m + k) (n - k)))
 
+/-!
+### “Cut then shift” coherence (Track B)
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — “Cut then shift” coherence.
+
+Goal: allow longer normal-form pipelines to reorder the operations
+
+- cut a tail (turn the post-cut block into `m+k`)
+- shift the start into the summand (`t ↦ t + m*d`)
+
+without dropping to ad-hoc arithmetic on indices.
+-/
+
+/-- Shifting the start into the summand commutes with changing the offset start.
+
+Concretely: the tail sum starting at `m+k` is the same as first shifting the summand by `m*d`
+and then taking the tail starting at `k`.
+-/
+lemma apSumOffset_shift_mul_start (f : ℕ → ℤ) (d m k n : ℕ) :
+    apSumOffset (fun t => f (t + m * d)) d k n = apSumOffset f d (m + k) n := by
+  unfold apSumOffset
+  refine Finset.sum_congr rfl ?_
+  intro i hi
+  -- `(k+i+1)*d + m*d = (m+k+i+1)*d`.
+  have h : (k + i + 1) * d + m * d = (m + k + i + 1) * d := by
+    calc
+      (k + i + 1) * d + m * d
+          = m * d + (k + i + 1) * d := by
+              simp [Nat.add_comm, Nat.add_left_comm, Nat.add_assoc]
+      _ = (m + (k + i + 1)) * d := by
+            simpa using (Nat.add_mul m (k + i + 1) d).symm
+      _ = (m + k + i + 1) * d := by
+            simp [Nat.add_assoc]
+  -- The goal is equality after applying `f`, so use `congrArg` on the index identity `h`.
+  exact
+    congrArg f (by
+      simpa [Nat.add_assoc, Nat.add_left_comm, Nat.add_comm] using h)
+
+/-- `discOffset` analogue of `apSumOffset_shift_mul_start`. -/
+lemma discOffset_shift_mul_start (f : ℕ → ℤ) (d m k n : ℕ) :
+    discOffset (fun t => f (t + m * d)) d k n = discOffset f d (m + k) n := by
+  unfold discOffset
+  simpa using congrArg Int.natAbs (apSumOffset_shift_mul_start (f := f) (d := d) (m := m) (k := k) (n := n))
+
+/-- Cut-equality, with the tail written in “shift-first” form. -/
+lemma apSumOffset_eq_add_apSumOffset_cut_shift_mul (f : ℕ → ℤ) (d m n k : ℕ) (hk : k ≤ n) :
+    apSumOffset f d m n =
+      apSumOffset f d m k + apSumOffset (fun t => f (t + m * d)) d k (n - k) := by
+  simpa [apSumOffset_shift_mul_start (f := f) (d := d) (m := m) (k := k) (n := n - k), Nat.add_comm,
+    Nat.add_left_comm, Nat.add_assoc] using
+    (apSumOffset_eq_add_apSumOffset_cut (f := f) (d := d) (m := m) (n := n) (k := k) hk)
+
+/-- Cut-inequality, with the tail written in “shift-first” form. -/
+lemma discOffset_cut_le_shift_mul (f : ℕ → ℤ) (d m n k : ℕ) (hk : k ≤ n) :
+    discOffset f d m n ≤
+      discOffset f d m k + discOffset (fun t => f (t + m * d)) d k (n - k) := by
+  -- Start from the existing cut inequality and rewrite the tail term.
+  simpa [discOffset_shift_mul_start (f := f) (d := d) (m := m) (k := k) (n := n - k), Nat.add_comm,
+    Nat.add_left_comm, Nat.add_assoc] using
+    (discOffset_cut_le (f := f) (d := d) (m := m) (n := n) (k := k) hk)
+
 lemma apSumOffset_eq_sub (f : ℕ → ℤ) (d m n : ℕ) :
     apSumOffset f d m n = apSum f d (m + n) - apSum f d m := by
   have h0 := (apSum_add_length (f := f) (d := d) (m := m) (n := n)).symm

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -63,6 +63,11 @@ Goal: build a *directed* lemma scaffold (not lemma-sprawl). Each checkbox should
   `discOffset f d m n = discOffset g d m n` assuming pointwise agreement of summands on `Finset.range n`.
   (Implemented as `discOffset_congr_range` in `MoltResearch/Discrepancy/Offset.lean`; regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
+- [x] Cut then shift coherence: prove that cutting a tail and then shifting the start agrees with shifting first and cutting after,
+  at the level of `apSumOffset` and at the packaged `discOffset` inequalities.
+  (Implemented as `apSumOffset_shift_mul_start` / `discOffset_shift_mul_start` and cut wrappers in `MoltResearch/Discrepancy/Offset.lean`;
+  regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
+
 - [x] One-shot “normalization pipeline” wrapper lemma (paper affine endpoints → nucleus normal form):
   rewrite
   `Int.natAbs (∑ i ∈ Icc (m+1) n, f (a + i*d))`


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: “Cut then shift” coherence: prove that cutting a tail and then shifting the start agrees with shifting first and cutting after, at the level of `apSumOffset` and at the packaged `discOffset` inequalities, so longer normal-form pipelines can reorder these rewrites without manual algebra.

What this PR adds
- `apSumOffset_shift_mul_start` / `discOffset_shift_mul_start`: rewrite tail-start changes into “shift-first” form.
- `apSumOffset_eq_add_apSumOffset_cut_shift_mul` / `discOffset_cut_le_shift_mul`: cut lemmas with the tail expressed after shifting the summand.

Regression
- Adds a stable-surface example in `MoltResearch/Discrepancy/NormalFormExamples.lean` showing `discOffset_cut_le_shift_mul` works via `simpa`.

Notes
- No opportunistic lemma-sprawl: the only new lemmas are exactly the coherence wrappers requested by the Track B item.