### PR TITLE
Discrepancy: cut/shift coherence for apSumOffset tails

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -55,6 +55,11 @@ The goal is to pair verified artifacts with learning scaffolding.
   `apSumOffset f d m n = ∑ i in range n, f ((m + (n - i)) * d)`.
   This packages the standard `range` reflection (`i ↦ n-1-i`) and simplifies the index to the clean `n - i` form.
 - **API note (triangle vs reverse triangle):** for concatenation, `discOffset_add_le` is the forward triangle inequality. The reverse-triangle companions are `discOffset_left_le_add` / `discOffset_right_le_add`, proved by rewriting `S(n₁) = S(n₁+n₂) - S'(n₂)` and applying `Int.natAbs_sub_le`.
+- **API note ("cut then shift" coherence):** when you’re building longer normal-form pipelines, you often want to commute:
+  1) a tail cut (rewrite a tail as a difference of a longer sum and its prefix), and
+  2) a start-shift (`m ↦ m + k`) pushed into the summand as `t ↦ t + k*d`.
+
+  Use `apSumOffset_tail_add_start_coherent` for the sum-level normal form, and `discOffset_add_start` as the wrapper-level rewrite so you can apply existing `discOffset_*` triangle/reverse-triangle bounds without unfolding.
 - **API note (endpoint-algebra wrappers):** three-segment concatenation is available as `discOffset_add_add_le`, but downstream goals often appear with right-associated endpoints. Use `discOffset_add_add_le_assoc` when your goal has length `n₁ + (n₂ + n₃)` and/or third-start index `m + (n₁ + n₂)` so you can `simpa` without manual `Nat.add_assoc` reassociation.
 - **API note:** `discOffsetUpTo` is monotone in the cutoff. Use `discOffsetUpTo_mono` for an arbitrary `N ≤ N'`, or the convenience wrapper `discOffsetUpTo_le_add` for the common “extend by `K`” case `N ≤ N+K`.
   If your goal is stated with `Nat.succ N` instead of `N+1`, use the wrapper `discOffsetUpTo_le_succNat`.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -2635,6 +2635,20 @@ lemma apSumOffset_add_start_add_left (f : ℕ → ℤ) (d m k n : ℕ) :
   -- Just commute the addition inside the shifted summand.
   simpa [Nat.add_comm] using (apSumOffset_add_start (f := f) (d := d) (m := m) (k := k) (n := n))
 
+/-- Wrapper-level normal form: `discOffset` is invariant under shifting the start index.
+
+Concretely, this rewrites
+`discOffset f d (m + k) n`
+into
+`discOffset (fun t => f (t + k*d)) d m n`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — “Cut then shift” coherence.
+-/
+lemma discOffset_add_start (f : ℕ → ℤ) (d m k n : ℕ) :
+    discOffset f d (m + k) n = discOffset (fun t => f (t + k * d)) d m n := by
+  unfold discOffset
+  exact congrArg Int.natAbs (apSumOffset_add_start (f := f) (d := d) (m := m) (k := k) (n := n))
+
 /-! ### Normalization of nested shifts inside summands -/
 
 /-- `simp` normal form for nested additive shifts under binders.
@@ -2800,6 +2814,29 @@ lemma apSumOffset_tail_eq_sub (f : ℕ → ℤ) (d m n₁ n₂ : ℕ) :
   have hsub := congrArg (fun z : ℤ => z - apSumOffset f d m n₁) h
   -- Clean up `(+ …) - …`.
   simpa [add_sub_cancel_left, Nat.add_assoc, Nat.add_left_comm, Nat.add_comm] using hsub.symm
+
+/-- “Cut then shift” coherence for `apSumOffset` tails.
+
+This packages a common normal-form pipeline equivalence:
+- cut a tail (difference of a longer sum and its prefix), then
+- shift the start index (`m ↦ m + k`) by pushing `k*d` into the summand.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — “Cut then shift” coherence.
+-/
+lemma apSumOffset_tail_add_start_coherent (f : ℕ → ℤ) (d m k n₁ n₂ : ℕ) :
+    apSumOffset f d (m + k + n₁) n₂ =
+      apSumOffset (fun t => f (t + k * d)) d m (n₁ + n₂) -
+        apSumOffset (fun t => f (t + k * d)) d m n₁ := by
+  -- First rewrite the tail (start = `(m+n₁)+k`) via `apSumOffset_add_start`.
+  have hshift : apSumOffset f d (m + k + n₁) n₂ =
+      apSumOffset (fun t => f (t + k * d)) d (m + n₁) n₂ := by
+    -- `(m + k + n₁) = (m + n₁) + k`.
+    simpa [Nat.add_assoc, Nat.add_left_comm, Nat.add_comm] using
+      (apSumOffset_add_start (f := f) (d := d) (m := m + n₁) (k := k) (n := n₂))
+  -- Then cut the shifted sum using the tail-as-difference normal form.
+  have htail :=
+    apSumOffset_tail_eq_sub (f := fun t => f (t + k * d)) (d := d) (m := m) (n₁ := n₁) (n₂ := n₂)
+  simpa [hshift] using htail
 
 /-- Rewrite the normal-form difference
 `apSumOffset f d m (n₁+n₂) - apSumOffset f d m n₁` as the tail `apSumOffset f d (m+n₁) n₂`.

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -182,6 +182,16 @@ example : apSumOffset' f m d n = apSumOffset f d m n := by
 example : apSumOffset f d m n = (Finset.range n).sum (fun i => f ((m + (n - i)) * d)) := by
   simpa using (apSumOffset_eq_sum_range_reverse (f := f) (d := d) (m := m) (n := n))
 
+-- NEW (Track B): “cut then shift” coherence (tail-cuts commute with start-shifts)
+example :
+    apSumOffset f d (m + k + n₁) n₂ =
+      apSumOffset (fun t => f (t + k * d)) d m (n₁ + n₂) - apSumOffset (fun t => f (t + k * d)) d m n₁ := by
+  simpa using
+    (apSumOffset_tail_add_start_coherent (f := f) (d := d) (m := m) (k := k) (n₁ := n₁) (n₂ := n₂))
+
+example : discOffset f d (m + k) n = discOffset (fun t => f (t + k * d)) d m n := by
+  simpa using (discOffset_add_start (f := f) (d := d) (m := m) (k := k) (n := n))
+
 example : discOffset' f m d n = discOffset f d m n := by
   rfl
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: “Cut then shift” coherence: prove that cutting a tail and then shifting the start agrees with shifting first and cutting after, at the level of `apSumOffset` and at the packaged `discOffset` inequalities, so longer normal-form pipelines can reorder these rewrites without manual algebra.

What this PR does
- Adds `apSumOffset_tail_add_start_coherent`, packaging the common pipeline equivalence:
  tail-cut (as a difference) + start-shift (push `k*d` into the summand).
- Adds wrapper lemma `discOffset_add_start` so wrapper-level goals rewrite without unfolding.
- Adds stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean`.

Notes
- No opportunistic lemma sprawl: the new lemmas are directly tied to the Track B item and have stable-surface examples.