### PR TITLE
Discrepancy: cut-then-shift coherence for discOffset

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -59,7 +59,11 @@ The goal is to pair verified artifacts with learning scaffolding.
   1) a tail cut (rewrite a tail as a difference of a longer sum and its prefix), and
   2) a start-shift (`m ↦ m + k`) pushed into the summand as `t ↦ t + k*d`.
 
-  Use `apSumOffset_tail_add_start_coherent` for the sum-level normal form, and `discOffset_add_start` as the wrapper-level rewrite so you can apply existing `discOffset_*` triangle/reverse-triangle bounds without unfolding.
+  Use:
+  - `apSumOffset_tail_add_start_coherent` for the sum-level normal form, and
+  - `discOffset_tail_add_start_eq_natAbs_sub` / `discOffset_tail_add_start_le` for the discrepancy-level normal form + triangle bound,
+
+  so downstream code can reorder these rewrites and apply `discOffset_*` bounds **without** unfolding definitions or redoing index algebra.
 - **API note (endpoint-algebra wrappers):** three-segment concatenation is available as `discOffset_add_add_le`, but downstream goals often appear with right-associated endpoints. Use `discOffset_add_add_le_assoc` when your goal has length `n₁ + (n₂ + n₃)` and/or third-start index `m + (n₁ + n₂)` so you can `simpa` without manual `Nat.add_assoc` reassociation.
 - **API note:** `discOffsetUpTo` is monotone in the cutoff. Use `discOffsetUpTo_mono` for an arbitrary `N ≤ N'`, or the convenience wrapper `discOffsetUpTo_le_add` for the common “extend by `K`” case `N ≤ N+K`.
   If your goal is stated with `Nat.succ N` instead of `N+1`, use the wrapper `discOffsetUpTo_le_succNat`.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -2838,6 +2838,42 @@ lemma apSumOffset_tail_add_start_coherent (f : ℕ → ℤ) (d m k n₁ n₂ : �
     apSumOffset_tail_eq_sub (f := fun t => f (t + k * d)) (d := d) (m := m) (n₁ := n₁) (n₂ := n₂)
   simpa [hshift] using htail
 
+/-- “Cut then shift” coherence, `discOffset`-level: express the shifted tail as a normal-form
+`Int.natAbs` difference.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — “Cut then shift” coherence.
+-/
+lemma discOffset_tail_add_start_eq_natAbs_sub (f : ℕ → ℤ) (d m k n₁ n₂ : ℕ) :
+    discOffset f d (m + k + n₁) n₂ =
+      Int.natAbs
+        (apSumOffset (fun t => f (t + k * d)) d m (n₁ + n₂) -
+          apSumOffset (fun t => f (t + k * d)) d m n₁) := by
+  unfold discOffset
+  -- Apply `Int.natAbs` to the sum-level coherence lemma.
+  simpa using congrArg Int.natAbs
+    (apSumOffset_tail_add_start_coherent (f := f) (d := d) (m := m) (k := k) (n₁ := n₁) (n₂ := n₂))
+
+/-- “Cut then shift” coherence, `discOffset`-level triangle bound.
+
+This is the packaged inequality form typically used in normal-form pipelines:
+`|S_tail| ≤ |S_big| + |S_prefix|`, after commuting a start-shift with a tail-cut.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — “Cut then shift” coherence.
+-/
+lemma discOffset_tail_add_start_le (f : ℕ → ℤ) (d m k n₁ n₂ : ℕ) :
+    discOffset f d (m + k + n₁) n₂ ≤
+      discOffset (fun t => f (t + k * d)) d m (n₁ + n₂) +
+        discOffset (fun t => f (t + k * d)) d m n₁ := by
+  -- Reduce to the `Int.natAbs` triangle inequality on a difference.
+  have hEq :=
+    discOffset_tail_add_start_eq_natAbs_sub (f := f) (d := d) (m := m) (k := k)
+      (n₁ := n₁) (n₂ := n₂)
+  -- `simp` converts `Int.natAbs (apSumOffset …)` into `discOffset …`.
+  simpa [hEq] using
+    (Int.natAbs_sub_le
+      (apSumOffset (fun t => f (t + k * d)) d m (n₁ + n₂))
+      (apSumOffset (fun t => f (t + k * d)) d m n₁))
+
 /-- Rewrite the normal-form difference
 `apSumOffset f d m (n₁+n₂) - apSumOffset f d m n₁` as the tail `apSumOffset f d (m+n₁) n₂`.
 

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -189,6 +189,13 @@ example :
   simpa using
     (apSumOffset_tail_add_start_coherent (f := f) (d := d) (m := m) (k := k) (n₁ := n₁) (n₂ := n₂))
 
+-- Same coherence, but as the packaged `discOffset`-native triangle bound.
+example :
+    discOffset f d (m + k + n₁) n₂ ≤
+      discOffset (fun t => f (t + k * d)) d m (n₁ + n₂) + discOffset (fun t => f (t + k * d)) d m n₁ := by
+  simpa using
+    (discOffset_tail_add_start_le (f := f) (d := d) (m := m) (k := k) (n₁ := n₁) (n₂ := n₂))
+
 example : discOffset f d (m + k) n = discOffset (fun t => f (t + k * d)) d m n := by
   simpa using (discOffset_add_start (f := f) (d := d) (m := m) (k := k) (n := n))
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: “Cut then shift” coherence: prove that cutting a tail and then shifting the start agrees with shifting first and cutting after, at the level of `apSumOffset` and at the packaged `discOffset` inequalities, so longer normal-form pipelines can reorder these rewrites without manual algebra.

Summary:
- Add `discOffset_tail_add_start_eq_natAbs_sub` and `discOffset_tail_add_start_le`, packaging the existing sum-level lemma `apSumOffset_tail_add_start_coherent` into a `discOffset`-native normal form and triangle bound.
- Add a stable-surface regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.

CI:
- `make ci`