### PR TITLE
Discrepancy: boundedness translation invariance in m

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -99,6 +99,12 @@ The goal is to pair verified artifacts with learning scaffolding.
   `BoundedDiscOffsetExists f d m ↔ ∃ B, ∀ N, discOffsetUpTo f d m N ≤ B`.
   This packages the fixed-`B` bridge `boundedDiscOffset_iff_forall_discOffsetUpTo_le` into a single ergonomic equivalence.
 
+- **API note (translation invariance in `m`, boundedness-level):** to reset the start parameter to the
+  normal form `m := 0`, use `boundedDiscOffset_shift_mul_start`:
+  `BoundedDiscOffset f d m B ↔ BoundedDiscOffset (fun k => f (k + m*d)) d 0 B`.
+  This is proved via the stable normal form `discOffset_eq_discrepancy_shift_mul`, so downstream code
+  can perform the rewrite without unfolding `discOffset`.
+
 - **API note (boundedness bridge, `UpTo` ↔ witnesses):** when you want to move *a fixed bound* `B` between the two quantifier normal forms,
   - `(∀ N, discOffsetUpTo f d m N ≤ B)` and
   - `(∀ n, discOffset f d m n ≤ B)`,

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -1795,6 +1795,28 @@ theorem boundedDiscOffset_iff_forall_discOffsetUpTo_le (f : ℕ → ℤ) (d m B 
     exact le_trans hle hUpTo
 
 /-!
+### Translation invariance in `m` for boundedness
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — “Translation invariance in m” for boundedness.
+-/
+
+/-- `BoundedDiscOffset f d m B` is equivalent to bounding the shifted function with start `m := 0`:
+`BoundedDiscOffset (fun k => f (k + m*d)) d 0 B`.
+
+This lets downstream proofs reset `m := 0` as a normal form without unfolding `discOffset`.
+-/
+theorem boundedDiscOffset_shift_mul_start (f : ℕ → ℤ) (d m B : ℕ) :
+    BoundedDiscOffset f d m B ↔ BoundedDiscOffset (fun k => f (k + m * d)) d 0 B := by
+  unfold BoundedDiscOffset
+  constructor
+  · intro h n
+    have hn : discOffset f d m n ≤ B := h n
+    simpa [discOffset_eq_discrepancy_shift_mul] using hn
+  · intro h n
+    have hn : discOffset (fun k => f (k + m * d)) d 0 n ≤ B := h n
+    simpa [discOffset_eq_discrepancy_shift_mul] using hn
+
+/-!
 ### Bridge: boundedness of `discOffsetUpTo` ↔ boundedness of all `discOffset` witnesses
 
 Checklist item: Problems/erdos_discrepancy.md (Track B) —

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -1208,6 +1208,12 @@ example (f : ℕ → ℤ) (d m : ℕ) :
   simpa using
     (boundedDiscOffsetExists_iff_exists_forall_discOffsetUpTo_le (f := f) (d := d) (m := m))
 
+-- Regression (Track B): translation invariance in `m` for boundedness.
+example (f : ℕ → ℤ) (d m B : ℕ) :
+    BoundedDiscOffset f d m B ↔ BoundedDiscOffset (fun k => f (k + m * d)) d 0 B := by
+  simpa using
+    (boundedDiscOffset_shift_mul_start (f := f) (d := d) (m := m) (B := B))
+
 -- Regression (Track B / concatenation inequality for `discOffsetUpTo`): a sharper bound that
 -- isolates the tail segment.
 example :


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: “Translation invariance in m” for boundedness

What changed
- Added `boundedDiscOffset_shift_mul_start`: `BoundedDiscOffset f d m B ↔ BoundedDiscOffset (fun k => f (k + m*d)) d 0 B`.
- Added a stable-surface compile-only regression in `NormalFormExamples.lean`.

Notes
- Proof is via the existing normal form `discOffset_eq_discrepancy_shift_mul`, so downstream code can reset `m := 0` without unfolding `discOffset`.
