### PR TITLE
Track B: mark translation-invariance boundedness item done

### DIFF
--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -1296,8 +1296,9 @@ Definition of done:
 - [x] Residue-class decomposition (sum-level) for `apSumFrom`: complement the existing residue API with an *affine* `apSumFrom` equality lemma splitting into `r` residue classes (with a stable regression example), so papers’ “split an affine AP into r progressions” step is available without first normalizing to offsets.
   (Implemented in `MoltResearch/Discrepancy/Residue.lean` as `apSumFrom_mul_len_succ_eq_sum_range` (and tail wrapper), with stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
-- [ ] “Translation invariance in m” for boundedness: prove a clean equivalence like
+- [x] “Translation invariance in m” for boundedness: prove a clean equivalence like
   `BoundedDiscOffset f d m B ↔ BoundedDiscOffset (fun k => f (k + m*d)) d 0 B` (and Exists/Unbounded analogues), so later proofs can reset `m := 0` as a normal form.
+  (Implemented as `boundedDiscOffset_shift_mul_start` in `MoltResearch/Discrepancy/Basic.lean`, with a stable-surface regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
 ### Track C - Conjecture stub + equivalences (backlog)
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: “Translation invariance in m” for boundedness

This PR syncs the Track B checklist: the item is now implemented as
`boundedDiscOffset_shift_mul_start` (in `MoltResearch/Discrepancy/Basic.lean`) and already has
a stable-surface regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.

No code changes; this just prevents the PR-factory card picker from repeatedly selecting an already-finished item.
