### PR TITLE
Track C: stage3OutOf_eq_stage3Out rewrite

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -118,6 +118,22 @@ Stage-2 start index stored inside `stage2OutOf inst`.
     (stage3OutOf inst (f := f) (hf := hf)).start = (stage2OutOf inst (f := f) (hf := hf)).start := by
   rfl
 
+/-- If we register an explicit assumption `inst` as the local typeclass instance, then the
+explicit Stage-3 output `stage3OutOf inst` agrees definitionally with the typeclass-based output
+`stage3Out`.
+
+This is useful when consumer code wants to pass `inst` explicitly but also reuse lemmas phrased in
+terms of `stage3Out`.
+-/
+theorem stage3OutOf_eq_stage3Out (inst : Stage2Assumption) (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    stage3OutOf inst (f := f) (hf := hf) =
+      (by
+        classical
+        letI : Stage2Assumption := inst
+        exact stage3Out (f := f) (hf := hf)) := by
+  classical
+  rfl
+
 /-- The Stage-2 output stored inside `stage3Out` is definitionally the Stage-2 output produced by
 Stage 2.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add stage3OutOf_eq_stage3Out: a definitional rewrite lemma bridging explicit Stage2Assumption passing (stage3OutOf) with the typeclass-based stage3Out API.
- Keeps the Stage-3 hard-gate minimal entry module easier to consume without importing the larger Stage-3 convenience layer.
