### PR TITLE
Track C: fix Stage-2 core extras build

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2CoreExtras.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2CoreExtras.lean
@@ -98,20 +98,13 @@ theorem boundedDiscOffset_iff_forall_natAbs_apSumFrom_start_le (out : Stage2Outp
 -- Note: `Stage2Output.d_dvd_start` and `Stage2Output.start_mod_d` live in
 -- `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Core` (hard-gate surface).
 
-/-- Adding the start index does not change residues modulo the step size.
-
-Since `out.start` is a multiple of `out.d`, we have
-`(n + out.start) % out.d = n % out.d`.
--/
-theorem add_start_mod_d (out : Stage2Output f) (n : ℕ) :
-    (n + out.start) % out.d = n % out.d := by
-  have hstart : out.start % out.d = 0 := out.start_mod_d (f := f)
-  simp [Nat.add_mod, hstart]
+-- Note: `Stage2Output.add_start_mod_d` now lives in `TrackCStage2Core.lean` (hard-gate surface).
 
 /-- Variant of `add_start_mod_d` with the start index on the left. -/
 theorem start_add_mod_d (out : Stage2Output f) (n : ℕ) :
     (out.start + n) % out.d = n % out.d := by
-  simpa [Nat.add_comm] using out.add_start_mod_d (f := f) (n := n)
+  -- Commute the start index to the right and reuse the core lemma.
+  simp [Nat.add_comm, out.add_start_mod_d (f := f) (n := n)]
 
 /-- Adding the start index increases quotients by the offset parameter.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Fixes Conjectures.C0002_erdos_discrepancy Stage-2 extras module so it builds again (removes a duplicate add_start_mod_d lemma).
- start_add_mod_d now reuses the core add_start_mod_d lemma after commuting the start index.
- No changes to the Track C hard-gate ErdosDiscrepancy target (still builds cleanly).
