### PR TITLE
Track C: start-index alias for tail-nucleus negation

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2CoreExtras.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2CoreExtras.lean
@@ -184,6 +184,15 @@ theorem not_exists_forall_natAbs_apSumFrom_mul_le (out : Stage2Output f) :
         (f := f) (d := out.d) (m := out.m)).1
       hunb
 
+/-- Start-index phrasing of `not_exists_forall_natAbs_apSumFrom_mul_le`.
+
+This is just `not_exists_forall_natAbs_apSumFrom_mul_le` under the more discoverable name that
+matches the Stage-3 interface.
+-/
+theorem not_exists_forall_natAbs_apSumFrom_start_le (out : Stage2Output f) :
+    ¬ ∃ B : ℕ, ∀ n : ℕ, Int.natAbs (apSumFrom f out.start out.d n) ≤ B := by
+  simpa using out.not_exists_forall_natAbs_apSumFrom_mul_le (f := f)
+
 /-- Tail-nucleus witness form: Stage 2 yields arbitrarily large affine-tail nuclei
 `Int.natAbs (apSumFrom f out.start out.d n)`.
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
@@ -135,7 +135,7 @@ theorem stage3_not_exists_forall_natAbs_apSumFrom_start_le (f : ℕ → ℤ) (hf
                 (stage3Out (f := f) (hf := hf)).out2.d n) ≤ B := by
   let out := stage3Out (f := f) (hf := hf)
   -- Delegate to the Stage-2 core-extras lemma (phrased using the bundled start index).
-  simpa [out] using out.out2.not_exists_forall_natAbs_apSumFrom_mul_le (f := f)
+  simpa [out] using out.out2.not_exists_forall_natAbs_apSumFrom_start_le (f := f)
 
 /-- Paper-notation normal form: there is no uniform bound on the shifted progression sums
 `∑ i ∈ Icc (m+1) (m+n), f (i*d)` at the deterministic Stage-2 parameters stored in `stage3Out`.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a Stage2Output alias lemma with the start-index name for the negation-normal-form tail-nucleus bound statement.
- Switch the Stage-3 entry-core wrapper to use the new start-index lemma name (clearer API symmetry with Stage 3).
