### PR TITLE
Track C: simplify Stage-2 start divisibility proof

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
@@ -60,8 +60,7 @@ theorem start_eq_m_mul_d (out : Stage2Output f) : out.start = out.m * out.d := b
 
 /-- The Stage-2 start index is a multiple of the Stage-2 step size. -/
 theorem d_dvd_start (out : Stage2Output f) : out.d ∣ out.start := by
-  refine ⟨out.m, ?_⟩
-  simp [Stage2Output.start, Nat.mul_comm]
+  simp [Stage2Output.start]
 
 /-- The Stage-2 start index has remainder `0` modulo the Stage-2 step size.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Simplified the Stage2Output.d_dvd_start proof in TrackCStage2Core by unfolding start and letting simp close the goal.
- No API or statement changes; this just trims proof noise in the core Stage-2 boundary layer.
