### PR TITLE
Track C: fix Tao2015Extras witness lemma

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/Tao2015Extras.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/Tao2015Extras.lean
@@ -55,6 +55,16 @@ theorem hasDiscrepancyAtLeastAlong_of_le (g : ℕ → ℤ) (d : ℕ) {C C' : ℕ
   rintro ⟨n, hn⟩
   exact ⟨n, lt_of_le_of_lt hC hn⟩
 
+/-- Monotonicity: if `discOffset f d m` is bounded by `B`, then it is bounded by any larger bound
+`B' ≥ B`.
+
+This is just the definition of `BoundedDiscOffset` plus transitivity of `≤`.
+-/
+theorem boundedDiscOffset_of_le (f : ℕ → ℤ) (d m : ℕ) {B B' : ℕ} (hBB' : B ≤ B') :
+    BoundedDiscOffset f d m B → BoundedDiscOffset f d m B' := by
+  intro h n
+  exact le_trans (h n) hBB'
+
 
 /-
 Note: the bounded-discrepancy-along nucleus normal form lives in `Tao2015` as
@@ -292,7 +302,8 @@ theorem unboundedDiscOffset_iff_forall_exists_natAbs_apSumOffset_gt'_witness_pos
   constructor
   · intro hunb B
     simpa using
-      (forall_exists_natAbs_apSumOffset_gt_witness_pos (f := f) (d := d) (m := m) hunb B)
+      (UnboundedDiscOffset.forall_exists_natAbs_apSumOffset_gt_witness_pos (f := f) (d := d) (m := m)
+        hunb B)
   · intro h
     refine
       (unboundedDiscOffset_iff_forall_exists_natAbs_apSumOffset_gt' (f := f) (d := d) (m := m)).2


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Fix a broken reference in Tao2015Extras: qualify the witness-positivity helper via UnboundedDiscOffset.
- Add a tiny monotonicity helper: BoundedDiscOffset is monotone in the bound parameter.
