### PR TITLE
Track C: Stage3OutOf step-size side conditions

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -213,6 +213,24 @@ theorem stage3Out_d_ne_zero (f : ℕ → ℤ) (hf : IsSignSequence f) :
     (stage3Out (f := f) (hf := hf)).d ≠ 0 := by
   exact Nat.ne_of_gt (stage3Out_d_pos (f := f) (hf := hf))
 
+/-- Convenience lemma: the explicit-assumption Stage-3 reduced step size is positive.
+
+This is the explicit-assumption analogue of `stage3Out_d_pos`.
+-/
+theorem stage3OutOf_d_pos (inst : Stage2Assumption) (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    (stage3OutOf inst (f := f) (hf := hf)).d > 0 := by
+  have h1 : 1 ≤ (stage3OutOf inst (f := f) (hf := hf)).d := by
+    simpa using (Stage2Output.one_le_d (out := (stage3OutOf inst (f := f) (hf := hf)).out2))
+  exact lt_of_lt_of_le Nat.zero_lt_one h1
+
+/-- Convenience lemma: the explicit-assumption Stage-3 reduced step size is nonzero.
+
+This is the explicit-assumption analogue of `stage3Out_d_ne_zero`.
+-/
+theorem stage3OutOf_d_ne_zero (inst : Stage2Assumption) (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    (stage3OutOf inst (f := f) (hf := hf)).d ≠ 0 := by
+  exact Nat.ne_of_gt (stage3OutOf_d_pos (inst := inst) (f := f) (hf := hf))
+
 -- Note: the simp lemma `stage3Out_out2` is enough to rewrite projections like
 -- `(stage3Out ...).out2.d` to `(stage2Out ...).d`, but we also provide `[simp]` lemmas for the
 -- common projections `.d/.m/.g` so consumers can rewrite without reaching through `.out2`.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add stage3OutOf_d_pos and stage3OutOf_d_ne_zero (explicit-assumption analogues of stage3Out_d_pos / stage3Out_d_ne_zero).
- Makes it easier for downstream code using stage3OutOf to discharge step-size side conditions without rewriting through stage2OutOf.
