### PR TITLE
Tao2015: ReductionOutput discUpTo coherence

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/Tao2015.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/Tao2015.lean
@@ -1114,6 +1114,18 @@ theorem forall_discrepancy_le_iff_forall_discOffset_le (out : ReductionOutput f)
   · intro h n
     exact (out.discrepancy_le_iff_discOffset_le (f := f) (n := n) (B := B)).2 (h n)
 
+/-- Coherence: max homogeneous discrepancy of the reduced sequence up to `N` equals the max offset
+wrapper discrepancy of the original sequence up to `N`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — “Max discrepancy up to N” API.
+-/
+theorem discUpTo_eq_discOffsetUpTo (out : ReductionOutput f) (N : ℕ) :
+    discUpTo out.g out.d N = discOffsetUpTo f out.d out.m N := by
+  classical
+  unfold discUpTo discOffsetUpTo
+  -- Reduce to pointwise coherence of the discrepancy wrappers.
+  simp [disc_eq_discrepancy, out.discrepancy_eq_discOffset_via_contract (f := f)]
+
 /-- Coherence: the stable wrapper `disc` for the reduced sequence equals the bundled offset wrapper
 for the original sequence.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `ReductionOutput` UpTo coherence: for `out : Tao2015.ReductionOutput f`, add a lemma rewriting homogeneous max discrepancy of `out.g` to the offset max discrepancy of `f`.

What changed
- Added `Tao2015.ReductionOutput.discUpTo_eq_discOffsetUpTo`, a finitary `discUpTo`/`discOffsetUpTo` coherence lemma using the existing pointwise bridge `discrepancy_eq_discOffset_via_contract`.

Notes
- This lives in the Track C (Conjectures) stage interface file and does not add any new `MoltResearch/Discrepancy/*` lemmas.
