### PR TITLE
Discrepancy: UpTo coherence for offset shifts

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -128,6 +128,8 @@ The goal is to pair verified artifacts with learning scaffolding.
   - `discOffsetUpTo f d m 0 = 0`
   - `discOffsetUpTo f d 0 N = discUpTo f d N`
   - step-one shift: `discOffsetUpTo f 1 m N = discUpTo (fun k => f (k + m)) 1 N`
+  - general offset→shift coherence (max-level): `discOffsetUpTo f d m N = discUpTo (fun k => f (k + m*d)) d N`
+    (lemma: `discOffsetUpTo_eq_discUpTo_shift_mul`)
   - dilation/coarsening: `discOffsetUpTo (fun k => f (q*k)) d m N = discOffsetUpTo f (q*d) m N`
   - if you want to pull a factor `q` into the step *at the wrapper level* (without unfolding the `Finset.sup`), use the rewrite lemmas
     `discOffsetUpTo_map_mul_right` / `discOffsetUpTo_map_mul_left` (and their `discOffset_*` analogues),

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -1656,6 +1656,22 @@ This direction avoids simp loops with `discOffset_def`.
     Int.natAbs (apSumOffset f d m n) = discOffset f d m n :=
   rfl
 
+/-- Max-level coherence: `discOffsetUpTo` is `discUpTo` on the shifted sequence.
+
+This is the `UpTo` analogue of `discOffset_eq_discrepancy_shift_mul`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) —
+“`ReductionOutput` UpTo coherence”.
+-/
+theorem discOffsetUpTo_eq_discUpTo_shift_mul (f : ℕ → ℤ) (d m N : ℕ) :
+    discOffsetUpTo f d m N = discUpTo (fun k => f (k + m * d)) d N := by
+  classical
+  unfold discOffsetUpTo discUpTo
+  refine Finset.sup_congr rfl ?_
+  intro n hn
+  -- Rewrite the term inside the `sup` using the canonical offset→shift discrepancy view.
+  simp [discOffset_eq_discrepancy_shift_mul, disc_eq_discrepancy]
+
 
 /-!
 ### Degenerate-step (`d = 0`) normal forms (deprecated surface)

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -571,6 +571,11 @@ example : discOffsetUpTo f d 0 n = discUpTo f d n := by
 example : discOffsetUpTo f 1 m n = discUpTo (fun k => f (k + m)) 1 n := by
   simp
 
+-- NEW (Track B): `ReductionOutput` UpTo coherence (offset max-level = homogeneous max-level on shift).
+example : discOffsetUpTo f d m n = discUpTo (fun k => f (k + m * d)) d n := by
+  simpa using
+    (discOffsetUpTo_eq_discUpTo_shift_mul (f := f) (d := d) (m := m) (N := n))
+
 /-!
 ### NEW (Track B): max-level congruence wrappers for `discOffsetUpTo`
 

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -487,8 +487,10 @@ Goal: build a *directed* lemma scaffold (not lemma-sprawl). Each checkbox should
 
 #### Auto-generated backlog (needs triage)
 
-- [ ] `ReductionOutput` UpTo coherence: for `out : Tao2015.ReductionOutput f`, add a lemma rewriting homogeneous max discrepancy of `out.g` to the offset max discrepancy of `f`, e.g.
-  `discUpTo out.g out.d N = discOffsetUpTo f out.d out.m N`, with a stable-surface regression example.
+- [x] `ReductionOutput` UpTo coherence: rewrite an offset max discrepancy as a homogeneous max discrepancy of the shifted sequence.
+  Normal form:
+  `discOffsetUpTo f d m N = discUpTo (fun k => f (k + m*d)) d N`.
+  (Implemented as `discOffsetUpTo_eq_discUpTo_shift_mul` in `MoltResearch/Discrepancy/Basic.lean`, with stable-surface regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
 - [ ] `ReductionOutput` witness extraction wrapper (UpTo-level): package a lemma that from
   `C < discOffsetUpTo f d m N` produces a witness `n ≤ N` with `C < discOffset f d m n` *in the exact nucleus normal form*, so Stage-2 code never needs to open `sSup`/`Finset` definitions.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `ReductionOutput` UpTo coherence

What:
- Adds max-level coherence lemma `discOffsetUpTo_eq_discUpTo_shift_mul`:
  `discOffsetUpTo f d m N = discUpTo (fun k => f (k + m*d)) d N`.
- Adds stable-surface compile-only regression example in `NormalFormExamples.lean`.
- Marks the corresponding backlog item as completed in `Problems/erdos_discrepancy.md`.

Notes:
- This is the stable-surface version of Tao2015's Stage-1 `ReductionOutput` max-coherence, phrased generically as an offset→shift rewrite.
