### PR TITLE
Tao2015: ReductionOutput UpTo witness extraction

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/Tao2015.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/Tao2015.lean
@@ -1140,6 +1140,21 @@ theorem discUpTo_eq_discOffsetUpTo (out : ReductionOutput f) (N : ℕ) :
   intro n hn
   simpa using out.disc_eq_discOffset (f := f) (n := n)
 
+/-- Witness extraction wrapper (UpTo-level): from a strict inequality on the offset max discrepancy
+we can extract a single witness `n ≤ N` achieving the bound.
+
+This is a consumer convenience lemma: it keeps Stage-2/3 code in the nucleus normal form and avoids
+opening `Finset.sup` definitions.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) —
+“`ReductionOutput` witness extraction wrapper (UpTo-level)”.
+-/
+theorem exists_le_lt_discOffset_of_lt_discOffsetUpTo (out : ReductionOutput f) (N C : ℕ)
+    (h : C < discOffsetUpTo f out.d out.m N) :
+    ∃ n ≤ N, C < discOffset f out.d out.m n := by
+  exact (lt_discOffsetUpTo_iff_exists_lt_discOffset (f := f) (d := out.d) (m := out.m)
+    (N := N) (C := C)).1 h
+
 /-- Bounded discrepancy along the reduced step is equivalent to a uniform bound on the bundled offset
 discrepancy family.
 

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -492,8 +492,10 @@ Goal: build a *directed* lemma scaffold (not lemma-sprawl). Each checkbox should
   `discOffsetUpTo f d m N = discUpTo (fun k => f (k + m*d)) d N`.
   (Implemented as `discOffsetUpTo_eq_discUpTo_shift_mul` in `MoltResearch/Discrepancy/Basic.lean`, with stable-surface regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
-- [ ] `ReductionOutput` witness extraction wrapper (UpTo-level): package a lemma that from
+- [x] `ReductionOutput` witness extraction wrapper (UpTo-level): package a lemma that from
   `C < discOffsetUpTo f d m N` produces a witness `n ≤ N` with `C < discOffset f d m n` *in the exact nucleus normal form*, so Stage-2 code never needs to open `sSup`/`Finset` definitions.
+  (Implemented as `Tao2015.ReductionOutput.exists_le_lt_discOffset_of_lt_discOffsetUpTo` in
+  `Conjectures/C0002_erdos_discrepancy/src/Tao2015.lean`.)
 
 - [ ] Residue-class + UpTo bridge: after residue splitting at modulus `r`, add a lemma that relates the residue-class `UpTo` objects to the global `discOffsetUpTo`, e.g. a canonical bound of the form
   `discOffsetUpTo f d m (r*(N+1)) ≤ ∑ q in Finset.range r, discOffsetUpTo f (r*d) (m+q) N`.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `ReductionOutput` witness extraction wrapper (UpTo-level)

What changed:
- Added `Tao2015.ReductionOutput.exists_le_lt_discOffset_of_lt_discOffsetUpTo`:
  from `C < discOffsetUpTo f out.d out.m N` extracts a witness `n ≤ N` with `C < discOffset f out.d out.m n`.
  This keeps Stage-2/3 consumer code in the nucleus normal form without unfolding `Finset.sup`.
- Marked the checklist item complete in the card.

CI:
- `make ci`
