### PR TITLE
Discrepancy: residue-class UpTo ≤ discOffsetUpTo bridge

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -67,6 +67,11 @@ The goal is to pair verified artifacts with learning scaffolding.
 - **API note (endpoint-algebra wrappers):** three-segment concatenation is available as `discOffset_add_add_le`, but downstream goals often appear with right-associated endpoints. Use `discOffset_add_add_le_assoc` when your goal has length `n₁ + (n₂ + n₃)` and/or third-start index `m + (n₁ + n₂)` so you can `simpa` without manual `Nat.add_assoc` reassociation.
 - **API note:** `discOffsetUpTo` is monotone in the cutoff. Use `discOffsetUpTo_mono` for an arbitrary `N ≤ N'`, or the convenience wrapper `discOffsetUpTo_le_add` for the common “extend by `K`” case `N ≤ N+K`.
   If your goal is stated with `Nat.succ N` instead of `N+1`, use the wrapper `discOffsetUpTo_le_succNat`.
+
+- **API note (residue-class `UpTo` bridge):** the wrapper `discOffsetUpTo_modEq f d m N q r` packages
+  “take the maximum discrepancy over `n ≤ N` in the residue class `n ≡ r [MOD q]`”. When you want to
+  compare it to the unrestricted max, use the wrapper lemma
+  `discOffsetUpTo_modEq_le_discOffsetUpTo`.
 - **API note (argmax witness for `discOffsetUpTo`):** the lemma
   `exists_discOffset_eq_discOffsetUpTo` returns a witness `n ≤ N` together with
   the *argmax* comparison fact `∀ n' ≤ N, discOffset … n' ≤ discOffset … n`, and

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -1602,6 +1602,22 @@ Checklist item: Problems/erdos_discrepancy.md (Track B) — “Residue-class `Up
 def discOffsetUpTo_modEq (f : ℕ → ℤ) (d m N q r : ℕ) : ℕ :=
   ((Finset.range (N + 1)).filter (fun n => n ≡ r [MOD q])).sup (fun t => discOffset f d m t)
 
+/-- Residue-class + `UpTo` bridge: restricting to a residue class can only decrease the max-level value.
+
+This is the canonical inequality relating the residue-class `UpTo` wrapper `discOffsetUpTo_modEq` to
+`discOffsetUpTo`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — “Residue-class + UpTo bridge”.
+-/
+lemma discOffsetUpTo_modEq_le_discOffsetUpTo (f : ℕ → ℤ) (d m N q r : ℕ) :
+    discOffsetUpTo_modEq f d m N q r ≤ discOffsetUpTo f d m N := by
+  classical
+  unfold discOffsetUpTo_modEq discOffsetUpTo
+  refine Finset.sup_le ?_
+  intro n hn
+  have hn' : n ∈ Finset.range (N + 1) := (Finset.mem_filter.1 hn).1
+  exact Finset.le_sup (s := Finset.range (N + 1)) (f := fun t => discOffset f d m t) hn'
+
 /-- In a fixed residue class modulo `q`, the maximum in `discOffsetUpTo_modEq` is attained by some `n ≤ N`.
 
 This is a packaged, stable wrapper around `exists_discOffset_eq_sup_filter_modEq` that avoids having

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -4995,6 +4995,14 @@ example (f : ℕ → ℤ) (d m q N : ℕ) (hq : q > 0) :
       (N := N) hq)
 
 /-!
+## NEW (Track B): residue-class + `UpTo` bridge regression tests
+-/
+
+example (f : ℕ → ℤ) (d m N q r : ℕ) :
+    discOffsetUpTo_modEq f d m N q r ≤ discOffsetUpTo f d m N := by
+  simpa using (discOffsetUpTo_modEq_le_discOffsetUpTo (f := f) (d := d) (m := m) (N := N) (q := q) (r := r))
+
+/-!
 ## `disc` wrapper regression tests
 
 These ensure the homogeneous wrapper `disc` stays coherent with the offset wrapper `discOffset`.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Residue-class + UpTo bridge: after residue splitting at modulus `r`, add a lemma that relates the residue-class `UpTo` objects to the global `discOffsetUpTo`, e.g. a canonical bound of the form

Summary:
- Add lemma `discOffsetUpTo_modEq_le_discOffsetUpTo`: the residue-class `UpTo` wrapper is bounded by the global `discOffsetUpTo`.
- Add stable-surface regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.

Notes:
- This is an inequality-only bridge (no new `[simp]` rules).
