### PR TITLE
Track C: Stage2 stub axiom binds out1

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Stub.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Stub.lean
@@ -88,9 +88,8 @@ Downstream developments are expected to replace this axiom by providing a verifi
 `Stage2Assumption` instance.
 -/
 axiom stage2Stub_unbounded (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    Tao2015.UnboundedDiscrepancyAlong
-      (stage2Stub_out1 (f := f) (hf := hf)).g
-      (stage2Stub_out1 (f := f) (hf := hf)).d
+    let out1 := stage2Stub_out1 (f := f) (hf := hf)
+    Tao2015.UnboundedDiscrepancyAlong out1.g out1.d
 
 instance instStage2Assumption : Stage2Assumption where
   stage2_nonempty f hf := by


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Refactor the Stage-2 axiom stub stage2Stub_unbounded to bind the canonical Stage-1 reduction output once.
- This removes duplicated occurrences of stage2Stub_out1 in the axiom statement and keeps downstream rewriting cleaner.
