### PR TITLE
Discrepancy: endpoint normalization wrappers for discOffsetUpTo witnesses

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -80,6 +80,10 @@ The goal is to pair verified artifacts with learning scaffolding.
   then `simpa [hnEq]` rewrites the max value to the chosen witness, and `hmax`
   supplies all “≤ maximizer” inequalities without redoing `Finset.sup` reasoning.
 
+- **API note (endpoint normalization in `discOffsetUpTo` witnesses):** after extracting a witness `n ≤ N`, goals/hypotheses often contain endpoint algebra like
+  `n ≤ r*(N+1)` / `n < r*(N+1)` (or commuted `((N+1)*r)` forms). Use the stable-surface simp wrappers in `MoltResearch/Discrepancy/Basic.lean` to normalize these to the right-associated form
+  `n ≤ r*N + r` / `n < r*N + r` so downstream `simp`/`linarith` steps can match other lemmas without manual `Nat.mul_add`/`Nat.add_assoc` rewriting.
+
 - **API note (single-witness strict inequality, max-level):** if you *only* need a witness for a strict inequality (rather than an argmax + comparison), use
   `lt_discOffsetUpTo_iff_exists_lt_discOffset`:
   `C < discOffsetUpTo f d m N ↔ ∃ n ≤ N, C < discOffset f d m n`.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -1149,6 +1149,41 @@ lemma discOffsetUpTo_length_mul_succ_comm (f : ℕ → ℤ) (d m q N : ℕ) :
     (rfl : discOffsetUpTo f d m (q * (N + 1)) = discOffsetUpTo f d m (q * (N + 1)))
 
 /-!
+### Endpoint-normalization wrappers for `discOffsetUpTo` witnesses
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) —
+Endpoint-normalization wrappers for `discOffsetUpTo` witnesses.
+
+These are intentionally tiny, `simp`-friendly lemmas that normalize common endpoint algebra that
+shows up when extracting witnesses for `UpTo`/residue constructions.
+
+In practice, downstream proofs often produce hypotheses like `n ≤ r * (N+1)` (or the commuted
+variant), while the `simp`/API surface tends to prefer the expanded `r*N + r` form.
+
+We provide equivalences for both `≤` and `<`, and for both multiplication conventions.
+
+We keep these as proposition-level rewrite lemmas (rather than tagging the arithmetic identities
+itself) so that `simp` can rewrite goals/hypotheses directly.
+-/
+
+@[simp] lemma le_mul_succ_iff (n r N : ℕ) :
+    n ≤ r * (N + 1) ↔ n ≤ r * N + r := by
+  -- `Nat.mul_succ` expands `r * (N+1)`.
+  simpa [Nat.mul_succ, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm]
+
+@[simp] lemma lt_mul_succ_iff (n r N : ℕ) :
+    n < r * (N + 1) ↔ n < r * N + r := by
+  simpa [Nat.mul_succ, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm]
+
+@[simp] lemma le_succ_mul_iff (n r N : ℕ) :
+    n ≤ (N + 1) * r ↔ n ≤ N * r + r := by
+  simpa [Nat.succ_mul, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm]
+
+@[simp] lemma lt_succ_mul_iff (n r N : ℕ) :
+    n < (N + 1) * r ↔ n < N * r + r := by
+  simpa [Nat.succ_mul, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm]
+
+/-!
 ### `discOffsetUpTo` argument-order coherence helper (API coherence)
 
 The historical argument order for the offset-up-to wrapper is `(d m N)`, matching `discOffset`.

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -247,6 +247,20 @@ example : discOffsetUpTo f d m (q * n) = discOffsetUpTo f d m (n * q) := by
 example : discOffsetUpTo f d m (q * (n + 1)) = discOffsetUpTo f d m ((n + 1) * q) := by
   simpa using (discOffsetUpTo_length_mul_succ_comm (f := f) (d := d) (m := m) (q := q) (N := n))
 
+/-!
+### NEW (Track B): endpoint-normalization wrappers for `discOffsetUpTo` witnesses
+
+Compile-only regression tests: `simp` should normalize endpoint algebra inside `<`/`≤` hypotheses
+and goals of the form `… ≤ r*(N+1)` / `… < r*(N+1)` (and the commuted variants).
+-/
+
+example (r N n : ℕ) (h : n ≤ r * (N + 1)) : n ≤ r * N + r := by
+  -- The wrapper lemma is `[simp]` so this is a `simp`-normal form step.
+  simpa using (show n ≤ r * (N + 1) from h)
+
+example (r N n : ℕ) (h : n < (N + 1) * r) : n < N * r + r := by
+  simpa using (show n < (N + 1) * r from h)
+
 -- NEW (Track B): nucleus API coherence (disc/discrepancy wrappers)
 example : disc f d n = discrepancy f d n := by
   rfl


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Endpoint-normalization wrappers for `discOffsetUpTo` witnesses

Adds small `[simp]` lemmas normalizing endpoint algebra in witness hypotheses/goals:
- `n ≤ r*(N+1)` / `n < r*(N+1)` ↔ `n ≤ r*N + r` / `n < r*N + r`
- and the commuted `((N+1)*r)` variants.

Also adds stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean`.
