### PR TITLE
Discrepancy: argmax wrapper for discOffsetUpTo_modEq

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -72,6 +72,12 @@ The goal is to pair verified artifacts with learning scaffolding.
   “take the maximum discrepancy over `n ≤ N` in the residue class `n ≡ r [MOD q]`”. When you want to
   compare it to the unrestricted max, use the wrapper lemma
   `discOffsetUpTo_modEq_le_discOffsetUpTo`.
+
+- **API note (argmax in a residue class):** when you need an *explicit* maximizer in the residue class
+  (for later pigeonhole/combinatorial arguments), use
+  `exists_discOffsetUpTo_modEq_argmax`. It returns `n ≤ N` with `n ≡ r [MOD q]`, the equality
+  `discOffset … n = discOffsetUpTo_modEq …`, and a comparison proof
+  `∀ n' ≤ N, n' ≡ r [MOD q] → discOffset … n' ≤ discOffset … n`.
 - **API note (argmax witness for `discOffsetUpTo`):** the lemma
   `exists_discOffset_eq_discOffsetUpTo` returns a witness `n ≤ N` together with
   the *argmax* comparison fact `∀ n' ≤ N, discOffset … n' ≤ discOffset … n`, and

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -1668,6 +1668,37 @@ lemma exists_discOffset_eq_discOffsetUpTo_modEq (f : ℕ → ℤ) (d m N q r : �
   refine ⟨n, hnle, hmod, ?_⟩
   simpa [discOffsetUpTo_modEq] using hEq
 
+/-- `Argmax in a residue class` convenience wrapper:
+
+Returns an explicit maximizer `n` for `discOffsetUpTo_modEq` together with a comparison proof that
+any other candidate `n' ≤ N` in the same residue class satisfies `discOffset … n' ≤ discOffset … n`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — “Argmax in a residue class” convenience lemma.
+-/
+lemma exists_discOffsetUpTo_modEq_argmax (f : ℕ → ℤ) (d m N q r : ℕ)
+    (hne : ((Finset.range (N + 1)).filter (fun n => n ≡ r [MOD q])).Nonempty) :
+    ∃ n ≤ N, n ≡ r [MOD q] ∧
+      discOffset f d m n = discOffsetUpTo_modEq f d m N q r ∧
+      ∀ n' ≤ N, n' ≡ r [MOD q] → discOffset f d m n' ≤ discOffset f d m n := by
+  classical
+  rcases exists_discOffset_eq_sup_filter_modEq (f := f) (d := d) (m := m) (N := N) (q := q) (r := r) hne with
+    ⟨n, hnle, hmod, hEq⟩
+  refine ⟨n, hnle, hmod, ?_, ?_⟩
+  · simpa [discOffsetUpTo_modEq] using hEq
+  · intro n' hn'le hn'mod
+    have hn'mem :
+        n' ∈ (Finset.range (N + 1)).filter (fun t => t ≡ r [MOD q]) := by
+      refine Finset.mem_filter.2 ?_
+      refine ⟨?_, hn'mod⟩
+      exact Finset.mem_range.2 (Nat.lt_succ_of_le hn'le)
+    have hleSup :
+        discOffset f d m n' ≤
+          ((Finset.range (N + 1)).filter (fun t => t ≡ r [MOD q])).sup (fun t => discOffset f d m t) := by
+      exact Finset.le_sup (s := (Finset.range (N + 1)).filter (fun t => t ≡ r [MOD q]))
+        (f := fun t => discOffset f d m t) hn'mem
+    -- Use the witness equality `hEq` to identify the supremum with `discOffset … n`.
+    simpa [hEq] using hleSup
+
 /-- Definitional lemma exposing the definition. -/
 lemma discOffset_eq_natAbs_apSumOffset (f : ℕ → ℤ) (d m n : ℕ) :
     discOffset f d m n = Int.natAbs (apSumOffset f d m n) :=

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -5017,6 +5017,17 @@ example (f : ℕ → ℤ) (d m N q r : ℕ) :
   simpa using (discOffsetUpTo_modEq_le_discOffsetUpTo (f := f) (d := d) (m := m) (N := N) (q := q) (r := r))
 
 /-!
+## NEW (Track B): “argmax in a residue class” regression tests
+-/
+
+example (f : ℕ → ℤ) (d m N q r : ℕ)
+    (hne : ((Finset.range (N + 1)).filter (fun n => n ≡ r [MOD q])).Nonempty) :
+    ∃ n ≤ N, n ≡ r [MOD q] ∧
+      discOffset f d m n = discOffsetUpTo_modEq f d m N q r ∧
+      ∀ n' ≤ N, n' ≡ r [MOD q] → discOffset f d m n' ≤ discOffset f d m n := by
+  simpa using (exists_discOffsetUpTo_modEq_argmax (f := f) (d := d) (m := m) (N := N) (q := q) (r := r) hne)
+
+/-!
 ## `disc` wrapper regression tests
 
 These ensure the homogeneous wrapper `disc` stays coherent with the offset wrapper `discOffset`.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: “Argmax in a residue class” convenience lemma (discOffsetUpTo): strengthen the existing `…_modEq` witness lemmas with a wrapper returning an explicit maximizer `n` *and* a comparison proof `∀ n' ≤ N, discOffset … n' ≤ discOffset … n` suitable for later pigeonhole arguments.

What changed
- Added `exists_discOffsetUpTo_modEq_argmax` in `MoltResearch/Discrepancy/Basic.lean`.
  - Returns a residue-class maximizer `n` for `discOffsetUpTo_modEq`.
  - Provides the comparison lemma for any other `n' ≤ N` in the same residue class.
- Added a compile-only regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean` (imports the stable surface `MoltResearch.Discrepancy`).

Notes
- No new `[simp]` lemmas.
