### PR TITLE
Track C: stage3OutOf start normal form

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -180,6 +180,12 @@ theorem stage3Out_start_eq_m_mul_d (f : ℕ → ℤ) (hf : IsSignSequence f) :
       (stage3Out (f := f) (hf := hf)).m * (stage3Out (f := f) (hf := hf)).d := by
   rfl
 
+/-- Explicit-assumption analogue of `stage3Out_start_eq_m_mul_d`. -/
+theorem stage3OutOf_start_eq_m_mul_d (inst : Stage2Assumption) (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    (stage3OutOf inst (f := f) (hf := hf)).start =
+      (stage3OutOf inst (f := f) (hf := hf)).m * (stage3OutOf inst (f := f) (hf := hf)).d := by
+  rfl
+
 /-- Recover the offset parameter `m` by dividing the Stage-3 start index by the Stage-3 step size.
 
 This is a tiny arithmetic convenience lemma: by definition, `start = m * d`.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Added an explicit-assumption analogue of stage3Out_start_eq_m_mul_d in the minimal Stage-3 entry module.
- This keeps the start-index normal form available when downstream code uses stage3OutOf instead of the typeclass-based stage3Out.
