### PR TITLE
EDP Track B: discOffsetUpTo simp normalization regressions

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -86,6 +86,25 @@ example (f : ℕ → ℤ) (q d m N : ℕ) :
   simp
 
 /-!
+### NEW (Track B): `discOffsetUpTo` simplification under `m = 0` / `N = 0`
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — API polish for the `discOffsetUpTo` wrapper.
+
+Compile-only regressions: under the stable import surface, `simp` should normalize away a spurious
+`m = 0` start offset and compute the degenerate cutoff `N = 0`, without users having to unfold
+`discOffsetUpTo`.
+-/
+
+example : discOffsetUpTo f d 0 n = discUpTo f d n := by
+  simp
+
+example : discOffsetUpTo f 1 0 n = discUpTo f 1 n := by
+  simp
+
+example : discOffsetUpTo f 1 0 0 = 0 := by
+  simp
+
+/-!
 ### NEW (Track B): step-positivity witness normal forms
 
 These are compile-only regression tests for the “reduce early to `d ≥ 1`” API.

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -515,7 +515,8 @@ Goal: build a *directed* lemma scaffold (not lemma-sprawl). Each checkbox should
 - [x] “Coarsen to gcd/lcm” normalization lemma (UpTo-level): complement `disc_lcm_step_le_left/right` with an `UpTo` analogue that bounds `discUpTo f (lcm d d') N` in terms of `discUpTo f d N` / `discUpTo f d' N` (packaged triangle-inequality style), with a stable regression example.
   (Implemented as `discUpTo_lcm_step_le_left/right` in `MoltResearch/Discrepancy/StepScaling.lean`, with stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
-- [ ] API polish: add a minimal simp lemma set normalizing `discOffsetUpTo` under `d=1` and `m=0` (and `N=0`) *without unfolding*, so later code can `simp` these away under the stable import surface.
+- [x] API polish: add a minimal simp lemma set normalizing `discOffsetUpTo` under `d=1` and `m=0` (and `N=0`) *without unfolding*, so later code can `simp` these away under the stable import surface.
+  (Implemented as `discOffsetUpTo_zero_start` and `discOffsetUpTo_zero` in `MoltResearch/Discrepancy/Basic.lean`, with stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean`.)
 
 #### Track C - Tao2015 "build the plane" (context; Track C checklist below)
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: API polish: add a minimal simp lemma set normalizing `discOffsetUpTo` under `d=1` and `m=0` (and `N=0`) *without unfolding*

What changed
- Add stable-surface regression examples showing `simp` normalizes `discOffsetUpTo f d 0 N` to `discUpTo f d N`, and computes the degenerate cutoff `N = 0`.
- Mark the corresponding Track B checklist item as done (lemmas already live in `MoltResearch/Discrepancy/Basic.lean` as `discOffsetUpTo_zero_start` / `discOffsetUpTo_zero`).

Notes
- No new lemmas were added; this is a regression/examples + checklist bookkeeping PR.
