### PR TITLE
Track C: Stage 2 d>0 packaging for bound negation

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2ProofCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2ProofCore.lean
@@ -134,6 +134,21 @@ theorem stage2_exists_params_one_le_unboundedDiscOffset (f : ℕ → ℤ) (hf : 
       stage2_one_le_d (f := f) (hf := hf), ?_⟩
   exact stage2_unboundedDiscOffset (f := f) (hf := hf)
 
+/-- Existential packaging: Stage 2 yields concrete parameters `d, m` with `d > 0` such that there is
+no bundled offset bound at those parameters.
+
+Normal form:
+`∃ d m, d > 0 ∧ ¬ ∃ B, BoundedDiscOffset f d m B`.
+
+This is a strict-positivity variant of `stage2_exists_params_one_le_not_exists_boundedDiscOffset`.
+-/
+theorem stage2_exists_params_d_pos_not_exists_boundedDiscOffset (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    ∃ d m : ℕ, d > 0 ∧ ¬ ∃ B : ℕ, BoundedDiscOffset f d m B := by
+  refine
+    ⟨stage2_d (f := f) (hf := hf), stage2_m (f := f) (hf := hf),
+      stage2_d_pos (f := f) (hf := hf), ?_⟩
+  exact stage2_not_exists_boundedDiscOffset (f := f) (hf := hf)
+
 /-- Existential packaging: Stage 2 yields concrete parameters `d, m` with `1 ≤ d` such that there is
 no bundled offset bound at those parameters.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a strict-positivity (d > 0) existential packaging lemma for the Stage-2 bound-negation normal form.
- Reuse the existing deterministic Stage-2 projections and the proved wrapper `stage2_not_exists_boundedDiscOffset` to keep this layer thin.
