### PR TITLE
Track C: lower priority Stage2Assumption stub

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Stub.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Stub.lean
@@ -139,7 +139,7 @@ instance instStage2Assumption : Stage2Assumption where
   stage2_nonempty f hf := by
     exact ⟨stage2Stub_out (f := f) (hf := hf)⟩
 
-attribute [instance 10] instStage2Assumption
+attribute [instance 10000] instStage2Assumption
 
 /-- **Conjecture stub:** Stage 2 of Tao 2015.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Lower the instance priority of the default Conjectures-only Stage2Assumption stub so downstream verified instances are preferred when present.
- No logical changes to the Stage-2 API; this only affects typeclass resolution order.
