### PR TITLE
Track C: stage2OutOf unbounded discOffset wrapper

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2ProofCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2ProofCore.lean
@@ -63,6 +63,15 @@ theorem stage2OutOf_hasDiscrepancyAtLeast (inst : Stage2Assumption) (f : ℕ →
   simpa using
     (Stage2Output.hasDiscrepancyAtLeast (f := f) (stage2OutOf inst (f := f) (hf := hf)) C)
 
+/-- Explicit-assumption variant of `stage2_unboundedDiscOffset`. -/
+theorem stage2OutOf_unboundedDiscOffset (inst : Stage2Assumption) (f : ℕ → ℤ)
+    (hf : IsSignSequence f) :
+    UnboundedDiscOffset f
+      (stage2OutOf inst (f := f) (hf := hf)).d
+      (stage2OutOf inst (f := f) (hf := hf)).m := by
+  let out := stage2OutOf inst (f := f) (hf := hf)
+  simpa [out] using (Stage2Output.unboundedDiscOffset (f := f) out)
+
 /-- Consumer-facing shortcut: Stage 2 yields the usual surface statement
 `∀ C, HasDiscrepancyAtLeast f C`.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add an explicit-assumption wrapper stage2OutOf_unboundedDiscOffset in TrackCStage2ProofCore.
- This exposes the Stage-2 unbounded discOffset witness when passing Stage2Assumption explicitly (no local typeclass instance needed).
