### PR TITLE
Discrepancy: HasDiscrepancyAtLeast ↔ discOffset witness (lt form)

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -135,6 +135,10 @@ The goal is to pair verified artifacts with learning scaffolding.
 - **API note (monotone-in-`C`):** `HasDiscrepancyAtLeast f C` is **antitone** in `C` (the witness inequality is `> C`).
   Use `HasDiscrepancyAtLeast.mono` to *lower* the bound, and the contrapositive lemma
   `HasDiscrepancyAtLeast.not_mono` to *raise* bounds under negation (useful for boundedness normal forms).
+- **API note (`HasDiscrepancyAtLeast` ↔ `discOffset` witness):** when you want to “jump to the nucleus” without unfolding,
+  use `HasDiscrepancyAtLeast_iff_exists_discOffset_zero_start_lt`:
+  `HasDiscrepancyAtLeast f C ↔ ∃ d n, d > 0 ∧ C < discOffset f d 0 n`.
+  This is the clean bridge between the global predicate and the `discOffset` witness form.
 - **API note (boundedness monotonicity, `B`):** for the boundedness predicates,
   `BoundedDiscOffset f d m B` and `BoundedDiscrepancyAlong f d len B` are monotone in the bound parameter `B`.
   Use `BoundedDiscOffset.mono_B` / `BoundedDiscrepancyAlong.mono_B` to enlarge bounds, and the contrapositive

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -3509,6 +3509,17 @@ lemma HasDiscrepancyAtLeast_iff_exists_discOffset_zero_start {f : ℕ → ℤ} {
   -- Reduce to the existing offset-sum normal form and rewrite the absolute-value wrapper.
   simpa using (HasDiscrepancyAtLeast_iff_exists_apSumOffset_zero_start (f := f) (C := C))
 
+/-- Normal form: rewrite `HasDiscrepancyAtLeast` into the `discOffset` wrapper using `Nat.lt`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — stable-surface lemma:
+`HasDiscrepancyAtLeast f C` ↔ `∃ d > 0, ∃ n, C < discOffset f d 0 n`.
+-/
+lemma HasDiscrepancyAtLeast_iff_exists_discOffset_zero_start_lt {f : ℕ → ℤ} {C : ℕ} :
+    HasDiscrepancyAtLeast f C ↔
+      ∃ d n : ℕ, d > 0 ∧ C < discOffset f d 0 n := by
+  simpa [gt_iff_lt] using
+    (HasDiscrepancyAtLeast_iff_exists_discOffset_zero_start (f := f) (C := C))
+
 -- Backwards-compatibility: earlier versions used the slightly confusing names
 -- `HasDiscrepancyAtLeast_iff_exists_apSumOffset_zero` and
 -- `HasDiscrepancyAtLeast_iff_exists_apSumOffset_zero_m`; the deprecated aliases live in

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -117,6 +117,17 @@ example : (HasAffineDiscrepancyAtLeast f C ↔ Nonempty (AffineDiscrepancyWitnes
   simpa using (HasAffineDiscrepancyAtLeast.iff_nonempty_witnessGeOne (f := f) (C := C))
 
 /-!
+### NEW (Track B): `HasDiscrepancyAtLeast` witness normal form (`discOffset`, `Nat.lt`)
+
+Compile-only regression: under the stable surface `import MoltResearch.Discrepancy`, users can move
+between `HasDiscrepancyAtLeast` and the nucleus `discOffset` witness form without unfolding.
+-/
+
+example : (HasDiscrepancyAtLeast f C ↔ ∃ d n : ℕ, d > 0 ∧ C < discOffset f d 0 n) := by
+  simpa using
+    (HasDiscrepancyAtLeast_iff_exists_discOffset_zero_start_lt (f := f) (C := C))
+
+/-!
 ### NEW (Track B): `HasDiscrepancyAtLeast` monotone-in-`C` API
 
 Compile-only regression: we can move bounds around (including under negation) without unfolding


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Stable-surface lemma: `HasDiscrepancyAtLeast f C` (global predicate) ↔ `∃ d > 0, ∃ n, C < discOffset f d 0 n` (or the repo’s chosen nucleus witness form), so users can jump between “exists step/start” and the nucleus `discOffset` witness without unfolding.

Summary:
- Add `HasDiscrepancyAtLeast_iff_exists_discOffset_zero_start_lt`, a `Nat.lt`-oriented normal form for the `discOffset` nucleus witness.
- Add a compile-only regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean` under the stable surface (`import MoltResearch.Discrepancy`).
- Update `Learning/EDUCATIONAL_OVERLAYS.md` with a short API note about the new bridge lemma.

Notes:
- Proof is a small wrapper around the existing `..._zero_start` lemma (flipping `>` to `<` via `gt_iff_lt`).
- No opportunistic extra lemmas; `[simp]` unchanged.