### PR TITLE
Track B: check off stable-surface HasDiscrepancyAtLeast↔discOffset lemma

### DIFF
--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -520,7 +520,8 @@ Goal: build a *directed* lemma scaffold (not lemma-sprawl). Each checkbox should
 
 #### Auto-generated backlog (needs triage)
 
-- [ ] Stable-surface lemma: `HasDiscrepancyAtLeast f C` (global predicate) ↔ `∃ d > 0, ∃ n, C < discOffset f d 0 n` (or the repo’s chosen nucleus witness form), so users can jump between “exists step/start” and the nucleus `discOffset` witness without unfolding.
+- [x] Stable-surface lemma: `HasDiscrepancyAtLeast f C` (global predicate) ↔ `∃ d > 0, ∃ n, C < discOffset f d 0 n` (or the repo’s chosen nucleus witness form), so users can jump between “exists step/start” and the nucleus `discOffset` witness without unfolding.
+  - Implemented as `HasDiscrepancyAtLeast_iff_exists_discOffset_zero_start_lt` in `MoltResearch/Discrepancy/Basic.lean`; regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.
 
 - [ ] Step/offset coercion normal form: add a preferred rewrite lemma converting
   `discOffset (fun k => f (a + k)) d m n` into `discOffset f d (m + a/d) n` under the appropriate divisibility hypothesis (or an explicit `a = t*d`), so affine shifts compose cleanly at the `discOffset` level.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Stable-surface lemma: `HasDiscrepancyAtLeast f C` ↔ `∃ d > 0, ∃ n, C < discOffset f d 0 n`

This PR marks the auto-generated backlog item as completed and records the stable lemma name:
- `HasDiscrepancyAtLeast_iff_exists_discOffset_zero_start_lt` in `MoltResearch/Discrepancy/Basic.lean`
- regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`

No code changes.
