### PR TITLE
Discrepancy: discOffset step/offset coercion normal form

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -186,6 +186,10 @@ The goal is to pair verified artifacts with learning scaffolding.
   - `card_apSupport_le` gives the always-true bound `(apSupport d m n).card ≤ n` (since it is an image of `Finset.range n`), and
   - `card_apSupport_eq` (or the older `card_apSupport`) gives the exact value `(apSupport d m n).card = n` assuming `d > 0` (injectivity of `i ↦ (m+i+1)*d`).
 - **API note (shift–dilation coherence):** when you both (i) push an offset shift into the summand and (ii) pull a factor `q` into the step, use the commutation lemma `apSumOffset_shift_mul_right_comm` (and the wrapper `discOffset_shift_mul_right_comm`) to avoid redoing index algebra. Conceptually: “shift then dilate” = “dilate then shift (with scaled offset)”.
+- **API note (step/offset coercion normal form):** if your summand is presented with an *affine* shift by a multiple of the step, normalize at the wrapper level:
+  - `discOffset_map_add_mul` rewrites `discOffset (fun k => f (k + t*d)) d m n` to `discOffset f d (m+t) n`, and
+  - `discOffset_map_add_eq` is the variant for an explicitly named shift `a` with hypothesis `a = t*d`, rewriting `discOffset (fun k => f (a + k)) d m n`.
+  These are intentionally not `[simp]` to avoid rewrite loops.
 - **API note (paper interval normalization):** many downstream proofs naturally produce paper-style terms like `Int.natAbs ((Finset.Icc (m+1) (m+n)).sum ...)`. The stable surface exports simp lemmas rewriting these directly to `discOffset f d m n`, so endpoint algebra can be normalized by `simp` without manually rewriting `discOffset_eq_natAbs_sum_Icc` back and forth.
 - **API note (affine interval sum → `apSumOffset`):** if you have an interval sum with an extra affine offset in the summand,
   `∑ i ∈ Finset.Icc (m+1) (m+n), f (a + i*d)`,

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -1002,6 +1002,42 @@ lemma discOffset_step_mul_left (f : ℕ → ℤ) (q d m n : ℕ) :
     discOffset f (q * d) m n = discOffset (fun k => f (q * k)) d m n := by
   simpa using (discOffset_map_mul_left (f := f) (q := q) (d := d) (m := m) (n := n)).symm
 
+/-!
+### Step/offset coercion normal form (`discOffset`)
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — Step/offset coercion normal form.
+
+The core lemma is `apSumOffset_map_add_mul`: shifting the *sequence* by a multiple of the step `d`
+corresponds to shifting the offset parameter `m`.
+
+We package the corresponding rewrite at the `discOffset` wrapper level.
+
+These are plain rewrite lemmas (not `[simp]`) to avoid rewrite loops.
+-/
+
+/-- Wrapper-level shift normal form: shifting the input by `t*d` shifts the offset `m` by `t`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — Step/offset coercion normal form.
+-/
+lemma discOffset_map_add_mul (f : ℕ → ℤ) (t d m n : ℕ) :
+    discOffset (fun k => f (k + t * d)) d m n = discOffset f d (m + t) n := by
+  unfold discOffset
+  simpa using congrArg Int.natAbs (apSumOffset_map_add_mul (f := f) (k := t) (d := d) (m := m) (n := n))
+
+/-- Preferred rewrite lemma for affine shifts at the `discOffset` level.
+
+This is the form typically used in normal-form pipelines: if `a` is explicitly presented as a
+multiple of `d`, then `discOffset (fun k => f (a + k)) d m n` can be rewritten by shifting `m`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — Step/offset coercion normal form.
+-/
+lemma discOffset_map_add_eq (f : ℕ → ℤ) (a t d m n : ℕ) (ha : a = t * d) :
+    discOffset (fun k => f (a + k)) d m n = discOffset f d (m + t) n := by
+  subst ha
+  -- Commute the addition so we can apply `discOffset_map_add_mul`.
+  simpa [Nat.add_comm, Nat.add_left_comm, Nat.add_assoc] using
+    (discOffset_map_add_mul (f := f) (t := t) (d := d) (m := m) (n := n))
+
 /-- Shift–dilation coherence for the discrepancy wrapper `discOffset`.
 
 Checklist item: Problems/erdos_discrepancy.md (Track B) — Shift–dilation coherence lemma.

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -75,6 +75,17 @@ example (g : ℕ → ℤ) (h : ∀ x ∈ apSupport d m n, f x = g x) :
   simpa using (discOffset_congr_support (f := f) (g := g) (d := d) (m := m) (n := n) h)
 
 /-!
+### NEW (Track B): step/offset coercion normal form (`discOffset`)
+
+Compile-only regression test: if the input sequence is shifted by a multiple of the step `d`, the
+normal form shifts the offset parameter `m`.
+-/
+
+example (ha : a = k * d) :
+    discOffset (fun t => f (a + t)) d m n = discOffset f d (m + k) n := by
+  simpa using (discOffset_map_add_eq (f := f) (a := a) (t := k) (d := d) (m := m) (n := n) ha)
+
+/-!
 ### NEW (Track B): `discOffsetUpTo` dilation/coarsening convenience wrappers
 
 Compile-only regression test: `simp` should rewrite a dilated `discOffsetUpTo` by pulling the


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Step/offset coercion normal form: add a preferred rewrite lemma converting

Summary:
- Added `discOffset_map_add_mul` / `discOffset_map_add_eq` wrapper lemmas (no `[simp]`) to rewrite affine shifts by multiples of the step `d` at the `discOffset` level.
- Added stable-surface regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean`.

Notes:
- The core proof is a `Int.natAbs` wrapper around the existing `apSumOffset_map_add_mul` lemma.