### PR TITLE
Track C: Stage2Output constructor from offset witness

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Boundary.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Boundary.lean
@@ -42,6 +42,25 @@ structure Stage2Output (f : ℕ → ℤ) : Type where
   out1 : Tao2015.ReductionOutput f
   unbounded : Tao2015.UnboundedDiscrepancyAlong out1.g out1.d
 
+namespace Stage2Output
+
+variable {f : ℕ → ℤ}
+
+/-- Constructor: build a Stage-2 output from a Stage-1 reduction output plus an unbounded bundled
+offset discrepancy witness for the original sequence at the parameters carried by the reduction.
+
+This packages the reverse direction of the Stage-1 contract
+`ReductionOutput.unboundedDiscrepancyAlong_iff_unboundedDiscOffset`.
+-/
+def ofUnboundedDiscOffset (out1 : Tao2015.ReductionOutput f)
+    (hunbOffset : Tao2015.UnboundedDiscOffset f out1.d out1.m) :
+    Tao2015.Stage2Output f :=
+  { out1 := out1
+    unbounded :=
+      ((out1.unboundedDiscrepancyAlong_iff_unboundedDiscOffset (f := f))).2 hunbOffset }
+
+end Stage2Output
+
 
 /-!
 ## Stage 2 output lemmas

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Stub.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Stub.lean
@@ -167,23 +167,6 @@ theorem stage2Stub_not_exists_forall_natAbs_sum_Icc_one_le (f : ℕ → ℤ)
         (f := f) (d := 1) (m := 0)).1
       hunb
 
-/-- Derived form of the Stage-2 stub assumption: unbounded discrepancy along the reduced sequence.
-
-We keep the axiom itself in the bundled offset normal form (`UnboundedDiscOffset`) because it is
-stable under changes to the internal definition of the reduced sequence `out1.g`.
--/
-theorem stage2Stub_unbounded (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    Tao2015.UnboundedDiscrepancyAlong
-      (stage2Stub_out1 (f := f) (hf := hf)).g
-      (stage2Stub_out1 (f := f) (hf := hf)).d := by
-  classical
-  let out1 := stage2Stub_out1 (f := f) (hf := hf)
-  have hunbOffset : Tao2015.UnboundedDiscOffset f out1.d out1.m := by
-    simpa [out1] using (stage2Stub_unboundedDiscOffset (f := f) (hf := hf))
-  have hunbAlong : Tao2015.UnboundedDiscrepancyAlong out1.g out1.d := by
-    exact ((out1.unboundedDiscrepancyAlong_iff_unboundedDiscOffset (f := f))).2 hunbOffset
-  simpa [out1] using hunbAlong
-
 /-- Default (Conjectures-only) Stage-2 output produced by the stub assumption.
 
 This is the concrete `Stage2Output` used by the low-priority default instance
@@ -195,10 +178,10 @@ default Stage-1 wiring without rewriting the typeclass instance boilerplate.
 noncomputable def stage2Stub_out (f : ℕ → ℤ) (hf : IsSignSequence f) : Stage2Output f := by
   classical
   let out1 := stage2Stub_out1 (f := f) (hf := hf)
-  refine { out1 := out1
-           unbounded := ?_ }
-  -- TODO (real Tao2015 Stage 2): replace `stage2Stub_unboundedDiscOffset` with the first verified reduction step.
-  simpa [out1] using (stage2Stub_unbounded (f := f) (hf := hf))
+  have hunbOffset : Tao2015.UnboundedDiscOffset f out1.d out1.m := by
+    -- TODO (real Tao2015 Stage 2): replace `stage2Stub_unboundedDiscOffset` with the first verified reduction step.
+    simpa [out1] using (stage2Stub_unboundedDiscOffset (f := f) (hf := hf))
+  exact Stage2Output.ofUnboundedDiscOffset (f := f) out1 hunbOffset
 
 instance (priority := 10000) instStage2Assumption : Stage2Assumption where
   stage2_nonempty f hf := by


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Added Stage2Output.ofUnboundedDiscOffset constructor to build a Stage-2 output directly from an unbounded offset-discrepancy witness.
- Refactored the default Stage-2 stub output to use the constructor (removing a redundant derived lemma).
- Hard gate: lake build Conjectures.C0002_erdos_discrepancy.src.ErdosDiscrepancy
