### PR TITLE
Track B: discOffset affine shift normal form via d ∣ a

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -50,6 +50,10 @@ The goal is to pair verified artifacts with learning scaffolding.
   - `discUpTo f 0 N` / `discOffsetUpTo f 0 m N` simplify to a `Finset.sup` of the same multiplicative form
 
   **Argument-order coherence:** `apSumFrom` uses `(a d n)` (“start, step, length”), while the historical offset nucleus uses `apSumOffset f d m n`. When you want to line up parameters across the affine/offset nuclei, use the definitional aliases `apSumOffset' f m d n`, `discOffset' f m d n`, and `discOffsetUpTo' f m d N`.
+
+  **Step/offset coercion normal form:** affine shifts of the input sequence by a multiple of the step should be pushed into the offset parameter `m` rather than kept in the summand. Prefer the wrapper-level rewrite lemmas (not `[simp]`):
+  - `discOffset_map_add_eq` when you have an explicit factorization `a = t*d`.
+  - `discOffset_map_add_dvd` when you have `0 < d` and `d ∣ a` (it produces the canonical `m + a / d` offset shift).
 - **API note (reverse/reindex normal form, sum-level):** if you need to “reverse the order” of an offset AP sum without doing raw `Finset` algebra, use
   `apSumOffset_eq_sum_range_reverse`:
   `apSumOffset f d m n = ∑ i in range n, f ((m + (n - i)) * d)`.

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -1038,6 +1038,30 @@ lemma discOffset_map_add_eq (f : ℕ → ℤ) (a t d m n : ℕ) (ha : a = t * d)
   simpa [Nat.add_comm, Nat.add_left_comm, Nat.add_assoc] using
     (discOffset_map_add_mul (f := f) (t := t) (d := d) (m := m) (n := n))
 
+/-- Preferred rewrite lemma for affine shifts at the `discOffset` level, using a `Nat` divisibility
+hypothesis.
+
+If `a` is a multiple of `d`, then `discOffset (fun k => f (a + k)) d m n` rewrites by shifting the
+offset parameter `m` by `a / d`.
+
+We keep the explicit `0 < d` hypothesis so the division normal form is meaningful.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — Step/offset coercion normal form.
+-/
+lemma discOffset_map_add_dvd (f : ℕ → ℤ) (a d m n : ℕ) (hd : 0 < d) (ha : d ∣ a) :
+    discOffset (fun k => f (a + k)) d m n = discOffset f d (m + a / d) n := by
+  rcases ha with ⟨t, rfl⟩
+  have ht : d * t = t * d := by simpa [Nat.mul_comm]
+  have hdiv : d * t / d = t := Nat.mul_div_right t hd
+  calc
+    discOffset (fun k => f (d * t + k)) d m n
+        = discOffset f d (m + t) n := by
+            simpa using
+              (discOffset_map_add_eq (f := f) (a := d * t) (t := t) (d := d) (m := m) (n := n) ht)
+    _ = discOffset f d (m + d * t / d) n := by
+            -- `simp` rewrites `d * t / d` to `t`.
+            simp [hdiv]
+
 /-- Shift–dilation coherence for the discrepancy wrapper `discOffset`.
 
 Checklist item: Problems/erdos_discrepancy.md (Track B) — Shift–dilation coherence lemma.

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -85,6 +85,11 @@ example (ha : a = k * d) :
     discOffset (fun t => f (a + t)) d m n = discOffset f d (m + k) n := by
   simpa using (discOffset_map_add_eq (f := f) (a := a) (t := k) (d := d) (m := m) (n := n) ha)
 
+-- Variant preferred form: use the `Nat`-level divisibility hypothesis and shift by `a / d`.
+example (hd : 0 < d) (ha : d ∣ a) :
+    discOffset (fun t => f (a + t)) d m n = discOffset f d (m + a / d) n := by
+  simpa using (discOffset_map_add_dvd (f := f) (a := a) (d := d) (m := m) (n := n) hd ha)
+
 /-!
 ### NEW (Track B): `discOffsetUpTo` dilation/coarsening convenience wrappers
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Step/offset coercion normal form: add a preferred rewrite lemma converting

What changed
- Added `discOffset_map_add_dvd` (requires `0 < d` and `d ∣ a`) as the preferred wrapper-level affine-shift rewrite lemma producing the canonical `m + a / d` offset shift.
- Added a stable-surface regression example in `MoltResearch/Discrepancy/NormalFormExamples.lean` showing intended usage under `import MoltResearch.Discrepancy`.
- Updated `Learning/EDUCATIONAL_OVERLAYS.md` with a short API note describing the preferred rewrite lemmas for step/offset coercion.

Notes
- Kept this as a plain rewrite lemma (not `[simp]`) to avoid rewrite loops.