### PR TITLE
Discrepancy: export Nat/Int cast simp on stable surface

### DIFF
--- a/MoltResearch/Discrepancy.lean
+++ b/MoltResearch/Discrepancy.lean
@@ -6,6 +6,7 @@ import MoltResearch.Discrepancy.Parity
 import MoltResearch.Discrepancy.Residue
 import MoltResearch.Discrepancy.Offset
 import MoltResearch.Discrepancy.CoherenceSimp
+import MoltResearch.Discrepancy.CastSimp
 import MoltResearch.Discrepancy.Affine
 import MoltResearch.Discrepancy.AffineTail
 import MoltResearch.Discrepancy.Const

--- a/MoltResearch/Discrepancy/CastSimp.lean
+++ b/MoltResearch/Discrepancy/CastSimp.lean
@@ -1,10 +1,13 @@
 import MoltResearch.Discrepancy.Basic
 
 /-!
-# `CastSimp`: opt-in simp lemmas for common `Nat`/`Int` cast shapes
+# `CastSimp`: simp lemmas for common `Nat`/`Int` cast shapes
 
-This module is **opt-in**: it provides a *minimal*, loop-free collection of `[simp]` lemmas that
-normalize common coercion patterns between `Nat` and `Int`.
+This module provides a *minimal*, loop-free collection of `[simp]` lemmas that normalize common
+coercion patterns between `Nat` and `Int`.
+
+As of Track B “Nat arithmetic in summands” admission control, these lemmas are part of the **stable
+import surface** via `import MoltResearch.Discrepancy`.
 
 Motivation (Track B checklist item): in nucleus-level algebra around `apSumOffset`/`discOffset`,
 proof scripts often accumulate ad-hoc `norm_cast` / `zify` sequences just to rewrite

--- a/MoltResearch/Discrepancy/Examples.lean
+++ b/MoltResearch/Discrepancy/Examples.lean
@@ -165,6 +165,27 @@ theorem exists_signSequence_unbounded_discrepancy_witnessPos :
     exact Nat.lt_succ_self C
   exact (HasDiscrepancyAtLeast.iff_nonempty_witnessPos (f := fun _ => (1 : ℤ)) (C := C)).1 h
 
+/-!
+### Stable-surface simp regression: `Nat` cast coherence
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — minimize simp churn for `Nat` arithmetic in summands.
+
+These should remain one-line `simp` proofs under:
+
+```lean
+import MoltResearch.Discrepancy
+```
+-/
+
+example (m n : ℕ) : (m : ℤ) + (n : ℤ) = ((m + n : ℕ) : ℤ) := by
+  simp
+
+example (m n : ℕ) : (m : ℤ) * (n : ℤ) = ((m * n : ℕ) : ℤ) := by
+  simp
+
+example (n : ℕ) : (n : ℤ) + 1 = ((n + 1 : ℕ) : ℤ) := by
+  simp
+
 /-! ### Affine discrepancy for the constant `+1` sequence -/
 
 /-! #### Offset-tail ↔ affine-tail bridge (regression)


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Minimize simp churn for `Nat` arithmetic in summands: add a *loop-free* simp lemma set (exported on the stable surface) normalizing common shapes like

Summary:
- Expose the existing loop-free `Nat`/`Int` cast-contraction simp lemmas (`CastSimp`) on the stable surface by importing it from `MoltResearch.Discrepancy`.
- Add small stable-surface regression examples in `MoltResearch/Discrepancy/Examples.lean` proving the cast-normalization lemmas via one-line `simp`.

Notes:
- Kept the simp set minimal/terminating (no subtraction-cast rules), matching the anti-sprawl + loop-free simp constraints.
