### PR TITLE
Discrepancy: Nat simp normal forms for summands

### DIFF
--- a/MoltResearch/Discrepancy.lean
+++ b/MoltResearch/Discrepancy.lean
@@ -1,5 +1,6 @@
 import MoltResearch.Discrepancy.Basic
 import MoltResearch.Discrepancy.EndpointSimp
+import MoltResearch.Discrepancy.NatSimp
 import MoltResearch.Discrepancy.SignSequenceCoercions
 import MoltResearch.Discrepancy.Periodic
 import MoltResearch.Discrepancy.Parity

--- a/MoltResearch/Discrepancy/NatSimp.lean
+++ b/MoltResearch/Discrepancy/NatSimp.lean
@@ -1,0 +1,49 @@
+import MoltResearch.Discrepancy.Basic
+
+/-!
+# Nat simp lemmas for discrepancy summands
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) —
+“Minimize simp churn for `Nat` arithmetic in summands”.
+
+Goal: provide a **tiny, loop-free** `[simp]` surface for the endpoint arithmetic that commonly
+appears *inside* discrepancy summands, e.g.
+
+- `(m + (i+1)) * d`  →  `(m + i + 1) * d`
+- `a + (m + (i+1)) * d`  →  `a + (m + i + 1) * d`
+
+Design constraints:
+- Orientation is directed toward the canonical `… + i + 1` form.
+- Avoid commutativity (`Nat.add_comm`) under binders.
+- Keep the set small: this is for predictable simp normalization, not arithmetic automation.
+-/
+
+namespace MoltResearch
+
+/-! ## Canonical endpoint normal forms (`Nat`) -/
+
+/-- Normalize `m + (i+1)` into the associativity-friendly `m + i + 1` form.
+
+We prefer this over rewriting to `Nat.succ (m+i)` since the discrepancy API tends to use `+ 1`
+endpoints.
+-/
+@[simp] lemma add_add_one' (m i : ℕ) : m + (i + 1) = m + i + 1 := by
+  simp [Nat.add_assoc]
+
+/-- Normalize the common summand index shape `(m + (i+1)) * d`.
+
+This lemma is intentionally *not* stated with `Nat.succ` to avoid triggering `Nat.add_succ`/
+`Nat.succ_add` loops.
+-/
+@[simp] lemma add_add_one_mul (m i d : ℕ) : (m + (i + 1)) * d = (m + i + 1) * d := by
+  simp
+
+/-- Normalize the common affine summand index shape `a + (m + (i+1)) * d`.
+
+This is the main “simp-churn reducer”: it keeps the binder arithmetic in a canonical associative
+shape without forcing users to manually apply `Nat.add_assoc`.
+-/
+@[simp] lemma add_add_one_mul_add_left (a m i d : ℕ) : a + (m + (i + 1)) * d = a + (m + i + 1) * d := by
+  simp
+
+end MoltResearch

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -41,6 +41,20 @@ example {α : Type} [CoeTC α ℤ] (g : ℕ → α) (hg : ∀ n, (g n : ℤ) = 1
 variable (f : ℕ → ℤ) (a b d k m n n₁ n₂ p C : ℕ)
 
 /-!
+### NEW (Track B): `Nat` arithmetic simp normalization (summand churn)
+
+Compile-only regression tests: under the stable surface `import MoltResearch.Discrepancy`, `simp`
+should normalize common endpoint arithmetic *inside* summands without manual `Nat.add_assoc` noise.
+-/
+
+example (f : ℕ → ℤ) (a m i d : ℕ) :
+    f (a + (m + (i + 1)) * d) = f (a + (m + i + 1) * d) := by
+  simp
+
+example (m i d : ℕ) : (m + (i + 1)) * d = (m + i + 1) * d := by
+  simp
+
+/-!
 ### NEW (Track B): `discAlong` / `discOffset` bridge coherence
 
 Compile-only regression tests: downstream code should be able to move between the along-`d`


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Minimize simp churn for `Nat` arithmetic in summands: add a *loop-free* simp lemma set (exported on the stable surface) normalizing common shapes like

Summary:
- Add `MoltResearch.Discrepancy.NatSimp`: a tiny directed `[simp]` surface for normalizing common endpoint arithmetic inside summands.
- Import this module into the stable surface `import MoltResearch.Discrepancy`.
- Add compile-only regression examples in `MoltResearch.Discrepancy.NormalFormExamples` showing `simp` normalizes the intended shapes.

Notes:
- Orientation is deliberately one-way toward the `m + i + 1` normal form to avoid simp loops / commutativity churn under binders.