### PR TITLE
Discrepancy: paper cut-at-k wrapper (Icc → apSumOffset split)

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -262,6 +262,13 @@ example : discOffset f d (m + k) n = discOffset (fun t => f (t + k * d)) d m n :
 example : discOffset' f m d n = discOffset f d m n := by
   rfl
 
+-- NEW (Track B): cut-at-`k` API coherence (paper endpoints → nucleus split form).
+example (hk : m < k) (hkn : k ≤ m + n) :
+    (Finset.Icc (m + 1) (m + n)).sum (fun i => f (i * d)) =
+      apSumOffset f d m (k - m) + apSumOffset f d k (m + n - k) := by
+  simpa using
+    (sum_Icc_eq_apSumOffset_split_at_of_lt (f := f) (d := d) (m := m) (n := n) (k := k) hk hkn)
+
 -- NEW (Track B): nucleus API coherence (argument order) for `discOffsetUpTo`.
 example : discOffsetUpTo' f m d n = discOffsetUpTo f d m n := by
   rfl

--- a/MoltResearch/Discrepancy/Offset.lean
+++ b/MoltResearch/Discrepancy/Offset.lean
@@ -2499,6 +2499,37 @@ lemma apSumOffset_split_at (f : ℕ → ℤ) (d : ℕ) {m k n : ℕ}
     (apSumOffset_eq_add_apSumOffset_of_le (f := f) (d := d) (m := m) (k := k) (n := m + n)
       hmk hkn)
 
+/-!
+### Cut-at-`k` bridge (paper endpoints → nucleus normal form)
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — Cut-at-`k` API coherence (paper endpoints).
+
+Downstream arguments often come with a paper-style interior cut hypothesis `m < k ∧ k ≤ m + n`
+while the nucleus lemmas are stated using `m ≤ k`. This wrapper keeps the cut point in the
+paper endpoint form and returns the nucleus split normal form directly.
+-/
+
+/-- One-cut bridge (paper → nucleus): split a paper `Icc` sum at an interior cut `k`.
+
+Concretely, assuming `m < k ≤ m + n`,
+
+`∑ i ∈ Icc (m+1) (m+n), f (i*d)`
+rewrites to
+`apSumOffset f d m (k-m) + apSumOffset f d k (m+n-k)`.
+-/
+lemma sum_Icc_eq_apSumOffset_split_at_of_lt (f : ℕ → ℤ) (d m n k : ℕ)
+    (hk : m < k) (hkn : k ≤ m + n) :
+    (Finset.Icc (m + 1) (m + n)).sum (fun i => f (i * d)) =
+      apSumOffset f d m (k - m) + apSumOffset f d k (m + n - k) := by
+  have hmk : m ≤ k := Nat.le_of_lt hk
+  calc
+    (Finset.Icc (m + 1) (m + n)).sum (fun i => f (i * d))
+        = apSumOffset f d m n := by
+            simpa using (sum_Icc_eq_apSumOffset (f := f) (d := d) (m := m) (n := n))
+    _ = apSumOffset f d m (k - m) + apSumOffset f d k (m + n - k) := by
+            simpa using
+              (apSumOffset_split_at (f := f) (d := d) (m := m) (k := k) (n := n) hmk hkn)
+
 /-- Split an offset AP sum `apSumOffset f d m n` at an interior cut `k`, proved by splitting the
 paper-style `Icc` sum `∑ i ∈ Icc (m+1) (m+n), f (i*d)` at `k` and immediately rewriting back to
 the nucleus normal form.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Cut-at-k API coherence (paper endpoints): add a stable wrapper that takes a paper-style cut hypothesis `m < k ∧ k ≤ m+n` and produces the nucleus cut form with all endpoint arithmetic normalized, so downstream code can stay in `Icc` notation and still use the nucleus `cut` lemmas in one `rw`.

What changed
- Added `sum_Icc_eq_apSumOffset_split_at_of_lt`: a stable-surface wrapper that rewrites a paper `Icc` sum split at an interior cut `k` (with paper-style `m < k ≤ m+n`) directly into the nucleus `apSumOffset` split normal form.
- Added a compile-only regression example under `MoltResearch/Discrepancy/NormalFormExamples.lean` (imports `MoltResearch.Discrepancy`).

Notes
- This is intentionally a thin wrapper around existing `sum_Icc_eq_apSumOffset` + `apSumOffset_split_at` (no new opportunistic lemmas).
