### PR TITLE
Discrepancy: cut-at-k paper endpoint coherence

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -269,6 +269,12 @@ example (hk : m < k) (hkn : k ≤ m + n) :
   simpa using
     (sum_Icc_eq_apSumOffset_split_at_of_lt (f := f) (d := d) (m := m) (n := n) (k := k) hk hkn)
 
+-- Same cut, but as the packaged `discOffset`-native triangle bound.
+example (hk : m < k) (hkn : k ≤ m + n) :
+    discOffset f d m n ≤ discOffset f d m (k - m) + discOffset f d k (m + n - k) := by
+  simpa using
+    (discOffset_split_at_of_lt_le (f := f) (d := d) (m := m) (n := n) (k := k) hk hkn)
+
 -- NEW (Track B): nucleus API coherence (argument order) for `discOffsetUpTo`.
 example : discOffsetUpTo' f m d n = discOffsetUpTo f d m n := by
   rfl

--- a/MoltResearch/Discrepancy/Offset.lean
+++ b/MoltResearch/Discrepancy/Offset.lean
@@ -2860,6 +2860,22 @@ lemma discOffset_split_at_le (f : ℕ → ℤ) (d : ℕ) {m k n : ℕ}
   simpa [h] using
     (Int.natAbs_add_le (apSumOffset f d m (k - m)) (apSumOffset f d k (m + n - k)))
 
+/-- Discrepancy-level companion to `sum_Icc_eq_apSumOffset_split_at_of_lt`.
+
+This takes the paper-style interior-cut hypotheses `m < k ∧ k ≤ m+n` and returns the canonical
+triangle-inequality bound in `discOffset` normal form.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — Cut-at-`k` API coherence (paper endpoints).
+-/
+lemma discOffset_split_at_of_lt_le (f : ℕ → ℤ) (d : ℕ) (m n k : ℕ)
+    (hk : m < k) (hkn : k ≤ m + n) :
+    discOffset f d m n ≤ discOffset f d m (k - m) + discOffset f d k (m + n - k) := by
+  -- Convert the strict lower bound to the weak form expected by the nucleus split lemma.
+  simpa using
+    (discOffset_split_at_le (f := f) (d := d) (m := m) (k := k) (n := n)
+      (hmk := Nat.le_of_lt hk) (hkn := hkn))
+
+
 /-!
 ### Cut then normalize → canonical triangle bound (paper notation)
 

--- a/Problems/erdos_discrepancy.md
+++ b/Problems/erdos_discrepancy.md
@@ -543,7 +543,7 @@ Goal: build a *directed* lemma scaffold (not lemma-sprawl). Each checkbox should
   i.e. “head + affine tail” per residue class; this is the form used by the triangle-inequality wrapper
   `discOffset_mul_len_succ_le_sum_range_natAbs`.
 
-- [ ] Cut-at-k API coherence (paper endpoints): add a stable wrapper that takes a paper-style cut hypothesis `m < k ∧ k ≤ m+n` and produces the nucleus cut form with all endpoint arithmetic normalized, so downstream code can stay in `Icc` notation and still use the nucleus `cut` lemmas in one `rw`.
+- [x] Cut-at-k API coherence (paper endpoints): add a stable wrapper that takes a paper-style cut hypothesis `m < k ∧ k ≤ m+n` and produces the nucleus cut form with all endpoint arithmetic normalized, so downstream code can stay in `Icc` notation and still use the nucleus `cut` lemmas in one `rw`.
 
 - [ ] `discOffset` invariance under swapping `ℤ` sign encoding: package a lemma allowing replacement of a sign sequence `f : ℕ → ℤ` by an equivalent `g : ℕ → Bool`/`Fin 2` encoding (with a chosen coercion) *at the level of discrepancy statements*, so later stages can interoperate with combinatorial encodings without rewriting every lemma.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: Cut-at-k API coherence (paper endpoints): add a stable wrapper that takes a paper-style cut hypothesis `m < k ∧ k ≤ m+n` and produces the nucleus cut form with all endpoint arithmetic normalized, so downstream code can stay in `Icc` notation and still use the nucleus `cut` lemmas in one `rw`.

What changed
- Marked the checklist item complete.
- Added `discOffset_split_at_of_lt_le`, a paper-endpoint wrapper (strict interior-cut hypothesis) returning the canonical `discOffset` triangle bound.
- Added a stable-surface regression example under `import MoltResearch.Discrepancy`.

CI
- `make ci`
