### PR TITLE
Discrepancy: Bool sign encoding bridge for discOffset

### DIFF
--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -38,6 +38,12 @@ example {α : Type} [CoeTC α ℤ] (g : ℕ → α) (hg : ∀ n, (g n : ℤ) = 1
     IsSignSequence (fun n => (g n : ℤ)) := by
   simpa using (isSignSequence_coe (f := g) hg)
 
+-- NEW (Track B): bool/Fin2-style sign encodings can be swapped in `discOffset` statements.
+example (f : ℕ → ℤ) (d m n : ℕ) (b : ℕ → Bool) (h : ∀ t, f t = boolToSign (b t)) :
+    discOffset f d m n = discOffset (fun t => boolToSign (b t)) d m n := by
+  simpa using
+    (discOffset_congr_boolToSign (f := f) (b := b) (d := d) (m := m) (n := n) h)
+
 variable (f : ℕ → ℤ) (a b d k m n n₁ n₂ p C : ℕ)
 
 /-!

--- a/MoltResearch/Discrepancy/SignSequenceCoercions.lean
+++ b/MoltResearch/Discrepancy/SignSequenceCoercions.lean
@@ -12,6 +12,45 @@ These lemmas make it easy to reuse existing data without rewriting everything by
 
 namespace MoltResearch
 
+/-!
+## Bool / Fin2 sign encodings (Track B)
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — `discOffset` invariance under swapping `ℤ`
+sign encoding.
+
+Later stages often encode sign sequences as `Bool` or `Fin 2`. The nucleus API is written for
+`f : ℕ → ℤ`, so we provide a tiny, explicit coercion and a `discOffset`-level congruence wrapper
+that lets you swap representations in *statements* without touching downstream lemmas.
+-/
+
+/-- Boolean sign encoding: `true ↦ 1`, `false ↦ -1`. -/
+def boolToSign : Bool → ℤ
+  | true => 1
+  | false => -1
+
+@[simp] lemma boolToSign_true : boolToSign true = (1 : ℤ) := rfl
+@[simp] lemma boolToSign_false : boolToSign false = (-1 : ℤ) := rfl
+
+/-- Any boolean sequence yields an `IsSignSequence` after decoding via `boolToSign`. -/
+lemma isSignSequence_boolToSign (b : ℕ → Bool) : IsSignSequence (fun n => boolToSign (b n)) := by
+  intro n
+  -- Unfolding `boolToSign` produces a `match`; splitting on `b n` discharges both cases.
+  cases h : b n <;> simp [boolToSign, h]
+
+/-- Discrepancy-level representation swap: replace `f : ℕ → ℤ` by a `Bool`-encoded sequence.
+
+If `f` is pointwise equal to the decoded boolean sign sequence, then all offset discrepancies agree.
+This packages the index bookkeeping so later stages can change sign encodings without rewriting
+`discOffset` statements by hand.
+-/
+lemma discOffset_congr_boolToSign (f : ℕ → ℤ) (b : ℕ → Bool) (d m n : ℕ)
+    (h : ∀ t, f t = boolToSign (b t)) :
+    discOffset f d m n = discOffset (fun t => boolToSign (b t)) d m n := by
+  -- Use the pointwise congruence wrapper; the hypothesis `h` discharges every accessed index.
+  apply discOffset_congr (f := f) (g := fun t => boolToSign (b t)) (d := d) (m := m) (n := n)
+  intro i hi
+  simpa using (h ((m + i + 1) * d))
+
 /-- A bundled ±1 value in `ℤ`, intended as a convenient source type for sign sequences.
 
 Users can write `f : ℕ → SignZ` and then coerce to `ℤ` via `(f n : ℤ)`.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `discOffset` invariance under swapping `ℤ` sign encoding: package a lemma allowing replacement of a sign sequence `f : ℕ → ℤ` by an equivalent `g : ℕ → Bool`/`Fin 2` encoding (with a chosen coercion) *at the level of discrepancy statements*, so later stages can interoperate with combinatorial encodings without rewriting every lemma.

What changed:
- Added an explicit `boolToSign : Bool → ℤ` decoder (`true ↦ 1`, `false ↦ -1`).
- Added `discOffset_congr_boolToSign` to swap representations in `discOffset` statements via the existing `discOffset_congr` bookkeeping.
- Added a stable-surface regression `example` in `NormalFormExamples.lean`.

Notes:
- This is purely a representation/statement-level bridge; no new discrepancy facts beyond congruence.
