### PR TITLE
Track C: Stage2Output constructor for unbounded discrepancy

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Boundary.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Boundary.lean
@@ -46,6 +46,25 @@ namespace Stage2Output
 
 variable {f : ℕ → ℤ}
 
+/-- Constructor: build a Stage-2 output from a Stage-1 reduction output plus unbounded fixed-step
+(discrepancy) along the reduced sequence.
+
+This is the most direct constructor for the Stage-2 boundary record.
+-/
+def ofUnboundedDiscrepancyAlong (out1 : Tao2015.ReductionOutput f)
+    (hunb : Tao2015.UnboundedDiscrepancyAlong out1.g out1.d) : Tao2015.Stage2Output f :=
+  ⟨out1, hunb⟩
+
+@[simp] theorem ofUnboundedDiscrepancyAlong_out1 (out1 : Tao2015.ReductionOutput f)
+    (hunb : Tao2015.UnboundedDiscrepancyAlong out1.g out1.d) :
+    (ofUnboundedDiscrepancyAlong (f := f) out1 hunb).out1 = out1 := by
+  rfl
+
+@[simp] theorem ofUnboundedDiscrepancyAlong_unbounded (out1 : Tao2015.ReductionOutput f)
+    (hunb : Tao2015.UnboundedDiscrepancyAlong out1.g out1.d) :
+    (ofUnboundedDiscrepancyAlong (f := f) out1 hunb).unbounded = hunb := by
+  rfl
+
 /-- Constructor: build a Stage-2 output from a Stage-1 reduction output plus an unbounded bundled
 offset discrepancy witness for the original sequence at the parameters carried by the reduction.
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Stub.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Stub.lean
@@ -181,7 +181,9 @@ noncomputable def stage2Stub_out (f : ℕ → ℤ) (hf : IsSignSequence f) : Sta
   have hunbOffset : Tao2015.UnboundedDiscOffset f out1.d out1.m := by
     -- TODO (real Tao2015 Stage 2): replace `stage2Stub_unboundedDiscOffset` with the first verified reduction step.
     simpa [out1] using (stage2Stub_unboundedDiscOffset (f := f) (hf := hf))
-  exact Stage2Output.ofUnboundedDiscOffset (f := f) out1 hunbOffset
+  have hunb : Tao2015.UnboundedDiscrepancyAlong out1.g out1.d :=
+    ((out1.unboundedDiscrepancyAlong_iff_unboundedDiscOffset (f := f))).2 hunbOffset
+  exact Stage2Output.ofUnboundedDiscrepancyAlong (f := f) out1 hunb
 
 /-- The Stage-1 reduction packaged inside the default Stage-2 stub output is `stage2Stub_out1`.
 
@@ -192,7 +194,7 @@ exposing the axiom stub in definitional reductions).
 @[simp] theorem stage2Stub_out_out1 (f : ℕ → ℤ) (hf : IsSignSequence f) :
     (stage2Stub_out (f := f) (hf := hf)).out1 = stage2Stub_out1 (f := f) (hf := hf) := by
   classical
-  simp [stage2Stub_out, Stage2Output.ofUnboundedDiscOffset]
+  simp [stage2Stub_out, Stage2Output.ofUnboundedDiscrepancyAlong]
 
 instance (priority := 10000) instStage2Assumption : Stage2Assumption where
   stage2_nonempty f hf := by


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a direct Stage2Output constructor from a ReductionOutput plus UnboundedDiscrepancyAlong (with tiny simp projection lemmas).
- Refactor the default Stage-2 stub output to use the new constructor, keeping the single axiom stub unchanged and still deriving unboundedness via the Stage-1 contract.
