### PR TITLE
Track C: stage3 discOffset NNF wrapper

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
@@ -54,12 +54,7 @@ theorem erdos_discrepancy_not_exists_forall_discOffset_le (f : ℕ → ℤ) (hf 
         discOffset f
           (Tao2015.stage3Out (f := f) (hf := hf)).d
           (Tao2015.stage3Out (f := f) (hf := hf)).m n ≤ B := by
-  set out := Tao2015.stage3Out (f := f) (hf := hf) with hout
-  have hunb : Tao2015.UnboundedDiscOffset f out.d out.m := by
-    simpa [hout] using (Tao2015.stage3_unboundedDiscOffset (f := f) (hf := hf))
-  simpa [hout] using
-    (Tao2015.unboundedDiscOffset_iff_not_exists_forall_discOffset_le (f := f) (d := out.d) (m := out.m)).1
-      hunb
+  exact Tao2015.stage3_not_exists_forall_discOffset_le_d_m (f := f) (hf := hf)
 
 /-- Existential packaging of `erdos_discrepancy_not_exists_boundedDiscOffset`.
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -391,6 +391,27 @@ theorem stage3OutOf_unboundedDiscOffset (inst : Stage2Assumption) (f : ℕ → �
   let out := stage3OutOf inst (f := f) (hf := hf)
   exact out.unboundedDiscOffset (f := f)
 
+/-- Negation-normal-form packaging of the Stage-3 offset-discrepancy witness family.
+
+Normal form:
+`¬ ∃ B, ∀ n, discOffset f (stage3Out ...).d (stage3Out ...).m n ≤ B`.
+
+This is a small convenience wrapper around `stage3_unboundedDiscOffset` and the equivalence
+`unboundedDiscOffset_iff_not_exists_forall_discOffset_le`.
+-/
+theorem stage3_not_exists_forall_discOffset_le_d_m (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    ¬ ∃ B : ℕ,
+        ∀ n : ℕ,
+          discOffset f
+              (stage3Out (f := f) (hf := hf)).d
+              (stage3Out (f := f) (hf := hf)).m n ≤ B := by
+  set out := stage3Out (f := f) (hf := hf) with hout
+  have hunb : UnboundedDiscOffset f out.d out.m := by
+    simpa [hout] using stage3_unboundedDiscOffset (f := f) (hf := hf)
+  simpa [hout] using
+    (unboundedDiscOffset_iff_not_exists_forall_discOffset_le (f := f) (d := out.d) (m := out.m)).1
+      hunb
+
 /-- Existential packaging: Stage 3 yields concrete parameters `d, m` with `d > 0` such that the
 bundled offset discrepancy family `discOffset f d m` is unbounded.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a Stage-3 convenience lemma giving the discOffset unboundedness statement directly in terms of (stage3Out ...).d and (stage3Out ...).m.
- Simplify ErdosDiscrepancy.lean by delegating its discOffset negation-normal-form wrapper to the new Stage-3 entry-point lemma.
