### PR TITLE
Track C: simp lemmas for Stage2Output.ofUnboundedDiscOffset

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Boundary.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Boundary.lean
@@ -78,6 +78,17 @@ def ofUnboundedDiscOffset (out1 : Tao2015.ReductionOutput f)
     unbounded :=
       ((out1.unboundedDiscrepancyAlong_iff_unboundedDiscOffset (f := f))).2 hunbOffset }
 
+@[simp] theorem ofUnboundedDiscOffset_out1 (out1 : Tao2015.ReductionOutput f)
+    (hunbOffset : Tao2015.UnboundedDiscOffset f out1.d out1.m) :
+    (ofUnboundedDiscOffset (f := f) out1 hunbOffset).out1 = out1 := by
+  rfl
+
+@[simp] theorem ofUnboundedDiscOffset_unbounded (out1 : Tao2015.ReductionOutput f)
+    (hunbOffset : Tao2015.UnboundedDiscOffset f out1.d out1.m) :
+    (ofUnboundedDiscOffset (f := f) out1 hunbOffset).unbounded =
+      ((out1.unboundedDiscrepancyAlong_iff_unboundedDiscOffset (f := f))).2 hunbOffset := by
+  rfl
+
 end Stage2Output
 
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Added simp lemmas for Stage2Output.ofUnboundedDiscOffset projections (out1 and unbounded).
- Makes Stage-2 stub and downstream rewrites quieter when constructing Stage2Output from an UnboundedDiscOffset witness.
