### PR TITLE
Track C: add Stage3Output add_start_div_d

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
@@ -108,6 +108,20 @@ theorem start_add_mod_d (out : Stage3Output f) (n : ℕ) :
   rw [Nat.add_comm]
   exact out.add_start_mod_d (f := f) (n := n)
 
+/-- Adding the start index increases quotients by the offset parameter.
+
+Since `out.start = out.m * out.d`, we have
+`(n + out.start) / out.d = n / out.d + out.m`.
+-/
+theorem add_start_div_d (out : Stage3Output f) (n : ℕ) :
+    (n + out.start) / out.d = n / out.d + out.m := by
+  have hd : 0 < out.d := by
+    -- `out.d` is definitionally the Stage-2 step size.
+    simpa [Stage3Output.d] using (out.out2.hd : out.out2.d > 0)
+  -- Rewrite `out.start` to the normal form `out.m * out.d` and apply the standard arithmetic lemma.
+  simpa [out.start_eq_m_mul_d] using
+    (Nat.add_mul_div_right (x := n) (y := out.m) (z := out.d) hd)
+
 /-- Normal form: the bundled offset discrepancy wrapper `discOffset f out.d out.m n` is the
 absolute value of the affine-tail nucleus `apSumFrom f out.start out.d n`.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add Stage3Output.add_start_div_d: quotient normal form (n + start) / d = n / d + m
- Keeps Stage-3 hard-gate surface ergonomic for downstream arithmetic rewrites involving the start index
