### PR TITLE
Track C: expose apSumFrom-start NNF in minimal entry

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryCore.lean
@@ -120,23 +120,9 @@ theorem stage3_not_exists_forall_natAbs_apSumOffset_le (f : ℕ → ℤ) (hf : I
         (d := out.out2.d) (m := out.out2.m)).1
       hunb
 
-/-- Consumer-facing normal form: there is no uniform bound on the affine-tail nuclei
-`Int.natAbs (apSumFrom f start d n)` at the deterministic Stage-2 parameters stored in `stage3Out`.
-
-Negation normal form:
-`¬ ∃ B, ∀ n, Int.natAbs (apSumFrom f start d n) ≤ B`.
--/
-theorem stage3_not_exists_forall_natAbs_apSumFrom_start_le (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    ¬ ∃ B : ℕ,
-        ∀ n : ℕ,
-          Int.natAbs
-              (apSumFrom f
-                (stage3Out (f := f) (hf := hf)).out2.start
-                (stage3Out (f := f) (hf := hf)).out2.d n) ≤ B := by
-  let out := stage3Out (f := f) (hf := hf)
-  -- Delegate to the Stage-2 core-extras normal form on the carried Stage-2 output.
-  simpa [out] using
-    (Stage2Output.not_exists_forall_natAbs_apSumFrom_start_le (f := f) out.out2)
+-- Note: `stage3_not_exists_forall_natAbs_apSumFrom_start_le` now lives in
+-- `Conjectures.C0002_erdos_discrepancy.src.TrackCStage3EntryMinimal` so the hard-gate minimal
+-- Stage-3 entry point exposes this tail-nucleus normal form without importing Stage-2 core extras.
 
 /-- Paper-notation normal form: there is no uniform bound on the shifted progression sums
 `∑ i ∈ Icc (m+1) (m+n), f (i*d)` at the deterministic Stage-2 parameters stored in `stage3Out`.

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -412,6 +412,40 @@ theorem stage3_not_exists_forall_discOffset_le_d_m (f : ℕ → ℤ) (hf : IsSig
     (unboundedDiscOffset_iff_not_exists_forall_discOffset_le (f := f) (d := out.d) (m := out.m)).1
       hunb
 
+/-- Consumer-facing normal form: there is no uniform bound on the affine-tail nuclei
+`Int.natAbs (apSumFrom f start d n)` at the deterministic Stage-2 parameters stored in `stage3Out`.
+
+Negation normal form:
+`¬ ∃ B, ∀ n, Int.natAbs (apSumFrom f start d n) ≤ B`.
+
+This is the `discOffset` boundedness-negation witness `stage3_not_exists_forall_discOffset_le_d_m`
+rewritten using the Stage-3 normal form
+`discOffset f d m n = Int.natAbs (apSumFrom f (m*d) d n)`.
+-/
+theorem stage3_not_exists_forall_natAbs_apSumFrom_start_le (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    ¬ ∃ B : ℕ,
+        ∀ n : ℕ,
+          Int.natAbs
+              (apSumFrom f
+                (stage3Out (f := f) (hf := hf)).out2.start
+                (stage3Out (f := f) (hf := hf)).out2.d n) ≤ B := by
+  set out := stage3Out (f := f) (hf := hf) with hout
+  have hndisc :
+      ¬ ∃ B : ℕ, ∀ n : ℕ, discOffset f out.d out.m n ≤ B := by
+    -- `stage3_not_exists_forall_discOffset_le_d_m` is stated in terms of `stage3Out`; rewrite via `hout`.
+    simpa [hout] using (stage3_not_exists_forall_discOffset_le_d_m (f := f) (hf := hf))
+
+  intro h
+  rcases h with ⟨B, hB⟩
+  apply hndisc
+  refine ⟨B, ?_⟩
+  intro n
+  have hn : Int.natAbs (apSumFrom f out.start out.d n) ≤ B := by
+    -- Rewrite the `stage3Out`-statement to the local constant `out`.
+    simpa [hout, Stage3Output.start, Stage3Output.d] using hB n
+  -- Rewrite the `discOffset` wrapper to the affine-tail nucleus normal form.
+  simpa [out.discOffset_eq_natAbs_apSumFrom_start (f := f) (n := n)] using hn
+
 /-- Existential packaging: Stage 3 yields concrete parameters `d, m` with `d > 0` such that the
 bundled offset discrepancy family `discOffset f d m` is unbounded.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Moved the stage3 apSumFrom-start no-uniform-bound normal form into the hard-gate minimal Stage-3 entry module.
- This lets downstream code access the tail-nucleus negation-normal-form witness without importing Stage-2 core extras.
- Left TrackCStage3EntryCore with a note pointing to the new location, avoiding duplicate lemma definitions.
