### PR TITLE
Track C: Stage 3 tail-nucleus NNF lemma

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
@@ -211,6 +211,30 @@ theorem not_exists_forall_discOffset_le (out : Stage3Output f) :
         (d := out.d) (m := out.m)).1
       hunb
 
+/-- Negation-normal form: there is no uniform bound on the affine-tail nuclei
+`Int.natAbs (apSumFrom f (m*d) d n)` at the deterministic Stage-3 parameters `out.d` and `out.m`.
+
+This is `unboundedDiscOffset` rewritten using
+`Tao2015.UnboundedDiscOffset.iff_not_exists_forall_natAbs_apSumFrom_mul_le`.
+-/
+theorem not_exists_forall_natAbs_apSumFrom_mul_le (out : Stage3Output f) :
+    ¬ ∃ B : ℕ, ∀ n : ℕ, Int.natAbs (apSumFrom f (out.m * out.d) out.d n) ≤ B := by
+  have hunb : UnboundedDiscOffset f out.d out.m := out.unboundedDiscOffset (f := f)
+  exact
+    (_root_.MoltResearch.Tao2015.UnboundedDiscOffset.iff_not_exists_forall_natAbs_apSumFrom_mul_le
+        (f := f) (d := out.d) (m := out.m)).1
+      hunb
+
+/-- Start-index phrasing of `not_exists_forall_natAbs_apSumFrom_mul_le`.
+
+This replaces the explicit arithmetic form `out.m * out.d` with the bundled start index `out.start`
+to reduce noise in downstream stages.
+-/
+theorem not_exists_forall_natAbs_apSumFrom_start_le (out : Stage3Output f) :
+    ¬ ∃ B : ℕ, ∀ n : ℕ, Int.natAbs (apSumFrom f out.start out.d n) ≤ B := by
+  simpa [Stage3Output.start, Stage2Output.start] using
+    out.not_exists_forall_natAbs_apSumFrom_mul_le (f := f)
+
 /-- Deterministic Stage-3 completion: a Stage-2 output already contains enough information to
 contradict any global boundedness hypothesis.
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -430,21 +430,8 @@ theorem stage3_not_exists_forall_natAbs_apSumFrom_start_le (f : ℕ → ℤ) (hf
                 (stage3Out (f := f) (hf := hf)).out2.start
                 (stage3Out (f := f) (hf := hf)).out2.d n) ≤ B := by
   set out := stage3Out (f := f) (hf := hf) with hout
-  have hndisc :
-      ¬ ∃ B : ℕ, ∀ n : ℕ, discOffset f out.d out.m n ≤ B := by
-    -- `stage3_not_exists_forall_discOffset_le_d_m` is stated in terms of `stage3Out`; rewrite via `hout`.
-    simpa [hout] using (stage3_not_exists_forall_discOffset_le_d_m (f := f) (hf := hf))
-
-  intro h
-  rcases h with ⟨B, hB⟩
-  apply hndisc
-  refine ⟨B, ?_⟩
-  intro n
-  have hn : Int.natAbs (apSumFrom f out.start out.d n) ≤ B := by
-    -- Rewrite the `stage3Out`-statement to the local constant `out`.
-    simpa [hout, Stage3Output.start, Stage3Output.d] using hB n
-  -- Rewrite the `discOffset` wrapper to the affine-tail nucleus normal form.
-  simpa [out.discOffset_eq_natAbs_apSumFrom_start (f := f) (n := n)] using hn
+  simpa [hout, Stage3Output.start, Stage3Output.d] using
+    (Stage3Output.not_exists_forall_natAbs_apSumFrom_start_le (f := f) out)
 
 /-- Existential packaging: Stage 3 yields concrete parameters `d, m` with `d > 0` such that the
 bundled offset discrepancy family `discOffset f d m` is unbounded.

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Output.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Output.lean
@@ -408,24 +408,9 @@ theorem exists_params_one_le_forall_exists_natAbs_apSumFrom_mul_gt_witness_pos (
   simpa [Stage3Output.d, Stage3Output.m] using
     out.forall_exists_natAbs_apSumFrom_mul_gt_witness_pos (f := f) C
 
-/-- Negation-normal form of `forall_exists_natAbs_apSumFrom_mul_gt`: there is no uniform bound on
-the affine-tail nuclei at the concrete Stage-1 parameters bundled in Stage 3.
-
-This is a thin wrapper around `Stage2Output.not_exists_forall_natAbs_apSumFrom_mul_le`.
--/
-theorem not_exists_forall_natAbs_apSumFrom_mul_le (out : Stage3Output f) :
-    ¬ ∃ B : ℕ, ∀ n : ℕ, Int.natAbs (apSumFrom f (out.m * out.d) out.d n) ≤ B := by
-  simpa [Stage3Output.d, Stage3Output.m] using
-    (Stage2Output.not_exists_forall_natAbs_apSumFrom_mul_le (f := f) out.out2)
-
-/-- Start-index phrasing of `not_exists_forall_natAbs_apSumFrom_mul_le`.
-
-This replaces the explicit arithmetic form `out.m * out.d` with the bundled start index
-`out.start = out.m * out.d` to reduce noise in downstream stages.
--/
-theorem not_exists_forall_natAbs_apSumFrom_start_le (out : Stage3Output f) :
-    ¬ ∃ B : ℕ, ∀ n : ℕ, Int.natAbs (apSumFrom f out.start out.d n) ≤ B := by
-  simpa [Stage3Output.start] using out.not_exists_forall_natAbs_apSumFrom_mul_le (f := f)
+-- Note: the boundedness-negation normal forms for affine-tail nuclei
+-- (`not_exists_forall_natAbs_apSumFrom_mul_le` / `..._start_le`) now live in
+-- `Conjectures.C0002_erdos_discrepancy.src.TrackCStage3` (hard-gate boundary layer).
 
 end Stage3Output
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add Stage-3 boundary lemmas giving the affine-tail nucleus boundedness-negation normal forms (mul and start index).
- Simplify the hard-gate minimal Stage-3 entry point to reuse the new boundary lemma.
- Remove the duplicated tail-nucleus boundedness-negation lemmas from the larger Stage-3 output convenience module.