### PR TITLE
Track C: Stage 3 apSumFrom-start normal form

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
@@ -68,6 +68,16 @@ This is just the corresponding Stage-2 projection lemma, rewritten to use the St
 theorem start_eq_m_mul_d (out : Stage3Output f) : out.start = out.m * out.d := by
   rfl
 
+/-- Normal form: the affine-tail nucleus at `out.start` is the bundled offset nucleus at `out.m`.
+
+This is `Tao2015.apSumFrom_mul_eq_apSumOffset` rewritten using the Stage-3 start index
+`out.start = out.m * out.d`.
+-/
+theorem apSumFrom_start_eq_apSumOffset (out : Stage3Output f) (n : ℕ) :
+    apSumFrom f out.start out.d n = apSumOffset f out.d out.m n := by
+  simpa [Stage3Output.start, Stage3Output.d, Stage3Output.m, Stage2Output.start] using
+    (apSumFrom_mul_eq_apSumOffset (f := f) (d := out.d) (m := out.m) (n := n))
+
 /-- Recover the offset parameter `out.m` by dividing the start index `out.start` by the step size
 `out.d`.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a Stage 3 normal-form lemma relating the affine-tail nucleus apSumFrom f start d n to the bundled offset nucleus apSumOffset f d m n.
- Keeps consumer code able to switch between start-index and (d,m) formulations without unfolding Stage-2 internals.
