### PR TITLE
Track C: simp lemma for Stage3 start

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
@@ -65,7 +65,7 @@ abbrev start (out : Stage3Output f) : ℕ :=
 
 This is just the corresponding Stage-2 projection lemma, rewritten to use the Stage-3 projections.
 -/
-theorem start_eq_m_mul_d (out : Stage3Output f) : out.start = out.m * out.d := by
+@[simp] theorem start_eq_m_mul_d (out : Stage3Output f) : out.start = out.m * out.d := by
   rfl
 
 /-- Normal form: the affine-tail nucleus at `out.start` is the bundled offset nucleus at `out.m`.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Marked Tao2015.Stage3Output.start_eq_m_mul_d as a simp lemma.
- This reduces downstream rewriting noise when working with the Stage-3 bundled start index.
