### PR TITLE
Track C: stage3 affine-tail NNF packaging

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
@@ -118,13 +118,8 @@ theorem erdos_discrepancy_exists_params_one_le_not_exists_forall_natAbs_apSumFro
     (f : ℕ → ℤ) (hf : IsSignSequence f) :
     ∃ d m : ℕ, 1 ≤ d ∧
       ¬ ∃ B : ℕ, ∀ n : ℕ, Int.natAbs (apSumFrom f (m * d) d n) ≤ B := by
-  rcases erdos_discrepancy_exists_params_one_le_unboundedDiscOffset (f := f) (hf := hf) with
-    ⟨d, m, hd, hunb⟩
-  refine ⟨d, m, hd, ?_⟩
-  exact
-    (Tao2015.UnboundedDiscOffset.iff_not_exists_forall_natAbs_apSumFrom_mul_le (f := f)
-        (d := d) (m := m)).1
-      hunb
+  exact Tao2015.stage3_exists_params_one_le_not_exists_forall_natAbs_apSumFrom_mul_le
+    (f := f) (hf := hf)
 
 /-- Track C pipeline witness: Stage 3 yields unbounded discrepancy along the reduced sequence,
 stated using the verified core predicate `MoltResearch.UnboundedDiscrepancyAlong`.

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -26,6 +26,8 @@ It provides the minimal Stage-3 entry point API needed by the Track-C hard-gate 
 - `stage3_exists_params_unboundedDiscOffset` : existential packaging of `stage3_unboundedDiscOffset`
 - `stage3_exists_params_one_le_unboundedDiscOffset` : existential packaging of
   `stage3_unboundedDiscOffset` with the side condition `1 ≤ d`
+- `stage3_exists_params_one_le_not_exists_forall_natAbs_apSumFrom_mul_le` : existential packaging of
+  the affine-tail unboundedness normal form at concrete `d, m`
 - `stage3_unboundedDiscrepancyAlong_core` : Track-C fixed-step unboundedness witness along the
   reduced sequence, phrased using `MoltResearch.UnboundedDiscrepancyAlong`
 - `stage3_exists_params_one_le_not_exists_boundedDiscOffset` : existential packaging of
@@ -506,6 +508,26 @@ theorem stage3_exists_params_one_le_unboundedDiscOffset (f : ℕ → ℤ) (hf : 
   refine ⟨out.d, out.m, ?_, ?_⟩
   · exact stage3_one_le_d (f := f) (hf := hf)
   · exact stage3_unboundedDiscOffset (f := f) (hf := hf)
+
+/-- Existential packaging: Stage 3 yields concrete parameters `d, m` with `1 ≤ d` such that there is
+no uniform bound on the affine-tail nuclei `Int.natAbs (apSumFrom f (m*d) d n)`.
+
+Normal form:
+`∃ d m, 1 ≤ d ∧ ¬ ∃ B, ∀ n, Int.natAbs (apSumFrom f (m*d) d n) ≤ B`.
+
+This is `stage3_exists_params_one_le_unboundedDiscOffset` rewritten using
+`Tao2015.UnboundedDiscOffset.iff_not_exists_forall_natAbs_apSumFrom_mul_le`.
+-/
+theorem stage3_exists_params_one_le_not_exists_forall_natAbs_apSumFrom_mul_le
+    (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    ∃ d m : ℕ, 1 ≤ d ∧
+      ¬ ∃ B : ℕ, ∀ n : ℕ, Int.natAbs (apSumFrom f (m * d) d n) ≤ B := by
+  rcases stage3_exists_params_one_le_unboundedDiscOffset (f := f) (hf := hf) with ⟨d, m, hd, hunb⟩
+  refine ⟨d, m, hd, ?_⟩
+  exact
+    (Tao2015.UnboundedDiscOffset.iff_not_exists_forall_natAbs_apSumFrom_mul_le (f := f)
+        (d := d) (m := m)).1
+      hunb
 
 /-- Existential packaging: Stage 3 yields concrete parameters `d, m` with `1 ≤ d` such that there is
 no bundled offset bound at those parameters.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add a minimal-entry Stage 3 lemma packaging the affine-tail unboundedness normal form under explicit parameters d, m.
- Refactor ErdosDiscrepancy to reuse the Stage-3 entry lemma, reducing duplicated proof glue in the hard-gate target.
- Update the Stage-3 minimal entry module docstring to list the new API lemma.
