### PR TITLE
Track C: stage3OutWith_d_pos helper

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -334,6 +334,17 @@ theorem stage3Out_d_ne_zero (f : ℕ → ℤ) (hf : IsSignSequence f) :
     (stage3Out (f := f) (hf := hf)).d ≠ 0 := by
   exact Nat.ne_of_gt (stage3Out_d_pos (f := f) (hf := hf))
 
+/-- Convenience lemma: the explicit-assumption-with-local-instance Stage-3 reduced step size is
+positive.
+
+This is the `stage3OutWith` analogue of `stage3Out_d_pos`.
+-/
+theorem stage3OutWith_d_pos (inst : Stage2Assumption) (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    (stage3OutWith inst (f := f) (hf := hf)).d > 0 := by
+  have h1 : 1 ≤ (stage3OutWith inst (f := f) (hf := hf)).d := by
+    simpa using (Stage2Output.one_le_d (out := stage2OutWith inst (f := f) (hf := hf)))
+  exact lt_of_lt_of_le Nat.zero_lt_one h1
+
 /-- Convenience lemma: the explicit-assumption Stage-3 reduced step size is at least `1`.
 
 This is the explicit-assumption analogue of `stage3_one_le_d`.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add lemma stage3OutWith_d_pos giving d > 0 for stage3OutWith inst.
- Simplifies downstream arithmetic that uses an explicit Stage2Assumption via stage3OutWith.
