### PR TITLE
Track C: stage-3 entry rewrite cleanup

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -534,7 +534,9 @@ theorem stage3_forall_exists_natAbs_apSumFrom_start_gt_witness_pos (f : ℕ → 
     have hzero : Int.natAbs (apSumFrom f out.start out.d 0) = 0 := by
       simp
     have hn0gt : (0 : ℕ) > B := by
-      simpa [hzero] using hn
+      have hn0gt' := hn
+      rw [hzero] at hn0gt'
+      exact hn0gt'
     have hlt : B < 0 := (gt_iff_lt).1 hn0gt
     exact (Nat.not_lt_zero B) hlt
   refine ⟨n, Nat.pos_of_ne_zero hn0, ?_⟩


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- In TrackCStage3EntryMinimal, replace a simpa step with an explicit rewrite using hzero.
- This keeps the stage-3 entry proof a bit more robust and removes an unnecessarySimpa lint suggestion at that spot.
