### PR TITLE
Track C: simplify Stage-3 tail witness lemma

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -511,38 +511,18 @@ theorem stage3_forall_exists_natAbs_apSumFrom_start_gt_witness_pos (f : ℕ → 
               (apSumFrom f
                 (stage3Out (f := f) (hf := hf)).start
                 (stage3Out (f := f) (hf := hf)).d n) > B := by
-  classical
   intro B
   set out := stage3Out (f := f) (hf := hf) with hout
-  have hnb :
-      ¬ ∃ B0 : ℕ, ∀ n : ℕ, Int.natAbs (apSumFrom f out.start out.d n) ≤ B0 := by
-    simpa [hout] using
-      (stage3_not_exists_forall_natAbs_apSumFrom_start_le' (f := f) (hf := hf))
-  have hex : ∃ n : ℕ, Int.natAbs (apSumFrom f out.start out.d n) > B := by
-    by_contra h
-    have hle : ∀ n : ℕ, Int.natAbs (apSumFrom f out.start out.d n) ≤ B := by
-      intro n
-      have hnot : ¬ Int.natAbs (apSumFrom f out.start out.d n) > B := by
-        intro hn
-        exact h ⟨n, hn⟩
-      exact le_of_not_gt hnot
-    exact hnb ⟨B, hle⟩
-  rcases hex with ⟨n, hn⟩
-  have hn0 : n ≠ 0 := by
-    intro h0
-    subst h0
-    have hzero : Int.natAbs (apSumFrom f out.start out.d 0) = 0 := by
-      simp
-    have hn0gt : (0 : ℕ) > B := by
-      have hn0gt' := hn
-      rw [hzero] at hn0gt'
-      exact hn0gt'
-    have hlt : B < 0 := (gt_iff_lt).1 hn0gt
-    exact (Nat.not_lt_zero B) hlt
-  refine ⟨n, Nat.pos_of_ne_zero hn0, ?_⟩
-  have hn' := hn
-  simp [hout] at hn'
-  exact hn'
+  have hunb : UnboundedDiscOffset f out.d out.m := by
+    simpa [hout] using stage3_unboundedDiscOffset (f := f) (hf := hf)
+  rcases
+      (UnboundedDiscOffset.forall_exists_natAbs_apSumFrom_mul_gt_witness_pos
+        (f := f) (d := out.d) (m := out.m) hunb B)
+    with ⟨n, hnpos, hn⟩
+  refine ⟨n, hnpos, ?_⟩
+  have hn' : Int.natAbs (apSumFrom f out.start out.d n) > B := by
+    simpa [Stage3Output.start, Stage3Output.d, Stage3Output.m, Stage2Output.start] using hn
+  simpa [hout] using hn'
 
 /-- Existential packaging: Stage 3 yields concrete parameters `d, m` with `d > 0` such that the
 bundled offset discrepancy family `discOffset f d m` is unbounded.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Refactor stage3_forall_exists_natAbs_apSumFrom_start_gt_witness_pos to reuse the existing UnboundedDiscOffset witness-positivity lemma.
- Removes the manual classical contraposition proof, keeping the Stage-3 entry-point module thinner and more maintainable.
