### PR TITLE
Track C: stage3OutWith d ≠ 0 lemma

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -345,6 +345,15 @@ theorem stage3OutWith_d_pos (inst : Stage2Assumption) (f : ℕ → ℤ) (hf : Is
     simpa using (Stage2Output.one_le_d (out := stage2OutWith inst (f := f) (hf := hf)))
   exact lt_of_lt_of_le Nat.zero_lt_one h1
 
+/-- Convenience lemma: the explicit-assumption-with-local-instance Stage-3 reduced step size is
+nonzero.
+
+This is the `stage3OutWith` analogue of `stage3Out_d_ne_zero`.
+-/
+theorem stage3OutWith_d_ne_zero (inst : Stage2Assumption) (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    (stage3OutWith inst (f := f) (hf := hf)).d ≠ 0 := by
+  exact Nat.ne_of_gt (stage3OutWith_d_pos (inst := inst) (f := f) (hf := hf))
+
 /-- Convenience lemma: the explicit-assumption Stage-3 reduced step size is at least `1`.
 
 This is the explicit-assumption analogue of `stage3_one_le_d`.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Added stage3OutWith_d_ne_zero: a tiny convenience lemma giving d ≠ 0 under an explicit Stage2Assumption.
- Mirrors existing nonzero lemmas for stage3Out and stage3OutOf, keeping downstream arithmetic side conditions uniform.
