### PR TITLE
Track C: restate boundedness bridge

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
@@ -26,6 +26,17 @@ theorem erdos_discrepancy_notBounded (f : ℕ → ℤ) (hf : IsSignSequence f) :
   -- Delegate to the minimal Stage-3 entry-point API.
   exact Tao2015.stage3_notBounded (f := f) (hf := hf)
 
+/-- Bridge lemma: the usual “unbounded discrepancy” surface statement is equivalent to negating the
+boundedness predicate `BoundedDiscrepancy`.
+
+This equivalence lives in the verified core as
+`forall_hasDiscrepancyAtLeast_iff_not_boundedDiscrepancy`, but we restate it here so consumers of
+the Track‑C hard‑gate file can access it without hunting imports.
+-/
+theorem erdos_discrepancy_forall_hasDiscrepancyAtLeast_iff_notBounded (f : ℕ → ℤ) :
+    (∀ C : ℕ, HasDiscrepancyAtLeast f C) ↔ ¬ BoundedDiscrepancy f := by
+  exact forall_hasDiscrepancyAtLeast_iff_not_boundedDiscrepancy f
+
 /-- Stable boundedness-negation packaging of the Stage-3 offset-discrepancy witness.
 
 Normal form:


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Added a small bridge lemma in the hard-gate ErdosDiscrepancy file restating the equivalence between unbounded discrepancy (forall C, HasDiscrepancyAtLeast) and not BoundedDiscrepancy.
- This makes it easy for Track C consumers to convert between the core not-bounded output and the usual surface statement from the same import.
