### PR TITLE
Track C: stage3Out_hg convenience lemma

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -358,6 +358,15 @@ theorem stage3Out_d_ne_zero (f : ℕ → ℤ) (hf : IsSignSequence f) :
     (stage3Out (f := f) (hf := hf)).d ≠ 0 := by
   exact Nat.ne_of_gt (stage3Out_d_pos (f := f) (hf := hf))
 
+/-- Convenience lemma: the Stage-3 reduced sequence is a sign sequence.
+
+This is a tiny wrapper around the Stage-2 projection lemma `Stage2Output.hg`.
+-/
+theorem stage3Out_hg (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    IsSignSequence (stage3Out (f := f) (hf := hf)).g := by
+  simpa [Stage3Output.g] using
+    (Stage2Output.hg (f := f) (out := (stage3Out (f := f) (hf := hf)).out2))
+
 /-- Convenience lemma: the explicit-assumption-with-local-instance Stage-3 reduced step size is
 positive.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add stage3Out_hg: the Stage-3 reduced sequence (stage3Out ...).g is a sign sequence.
- Proof is a thin wrapper around the Stage-2 projection lemma Stage2Output.hg, keeping the minimal entry-point API self-contained.
