### PR TITLE
Track C: add stage3OutWith start-div lemma

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3EntryMinimal.lean
@@ -298,6 +298,12 @@ theorem stage3Out_start_div_d (f : ℕ → ℤ) (hf : IsSignSequence f) :
       (stage3Out (f := f) (hf := hf)).m := by
   exact Stage3Output.start_div_d (f := f) (out := stage3Out (f := f) (hf := hf))
 
+/-- Explicit-assumption-with-local-instance analogue of `stage3Out_start_div_d`. -/
+theorem stage3OutWith_start_div_d (inst : Stage2Assumption) (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    (stage3OutWith inst (f := f) (hf := hf)).start / (stage3OutWith inst (f := f) (hf := hf)).d =
+      (stage3OutWith inst (f := f) (hf := hf)).m := by
+  exact Stage3Output.start_div_d (f := f) (out := stage3OutWith inst (f := f) (hf := hf))
+
 /-- Explicit-assumption analogue of `stage3Out_start_div_d`. -/
 theorem stage3OutOf_start_div_d (inst : Stage2Assumption) (f : ℕ → ℤ) (hf : IsSignSequence f) :
     (stage3OutOf inst (f := f) (hf := hf)).start / (stage3OutOf inst (f := f) (hf := hf)).d =


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Added stage3OutWith_start_div_d, a local-instance analogue of stage3Out_start_div_d
- Keeps the Stage 3 minimal entry point symmetric across stage3Out, stage3OutWith, and stage3OutOf
- Helps downstream code recover the offset parameter m from start and d without switching APIs
