### PR TITLE
Track C: start-index nucleus rewrite lemma

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
@@ -160,6 +160,19 @@ theorem hasDiscrepancyAtLeast (out : Stage2Output f) (C : ℕ) : HasDiscrepancyA
 ## Offset-discrepancy normal forms used by Stage 3
 -/
 
+/-- Normal form: the affine-tail nucleus starting at the bundled start index `out.start`
+is the bundled offset nucleus at the bundled offset parameter `out.m`.
+
+This is `Tao2015.apSumFrom_mul_eq_apSumOffset` rewritten using `out.start = out.m * out.d`.
+
+We keep this lemma in the core surface because Stage 3 imports only `TrackCStage2Core.lean`, and
+this rewrite is a common normalization step when consuming Stage 2 through Stage 3.
+-/
+theorem apSumFrom_start_eq_apSumOffset (out : Stage2Output f) (n : ℕ) :
+    apSumFrom f out.start out.d n = apSumOffset f out.d out.m n := by
+  simpa [Stage2Output.start] using
+    (apSumFrom_mul_eq_apSumOffset (f := f) (d := out.d) (m := out.m) (n := n))
+
 /-- Stage 2 output implies unbounded bundled offset discrepancy for the original sequence
 at the concrete parameters `out.d` and `out.m`.
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3.lean
@@ -77,13 +77,13 @@ This is just the corresponding Stage-2 projection lemma, rewritten to use the St
 
 /-- Normal form: the affine-tail nucleus at `out.start` is the bundled offset nucleus at `out.m`.
 
-This is `Tao2015.apSumFrom_mul_eq_apSumOffset` rewritten using the Stage-3 start index
-`out.start = out.m * out.d`.
+This is the corresponding Stage-2 core rewrite lemma, transported to Stage 3 by rewriting the
+projections `out.start`, `out.d`, and `out.m`.
 -/
 theorem apSumFrom_start_eq_apSumOffset (out : Stage3Output f) (n : ℕ) :
     apSumFrom f out.start out.d n = apSumOffset f out.d out.m n := by
-  simpa [Stage3Output.start, Stage3Output.d, Stage3Output.m, Stage2Output.start] using
-    (apSumFrom_mul_eq_apSumOffset (f := f) (d := out.d) (m := out.m) (n := n))
+  simpa [Stage3Output.start, Stage3Output.d, Stage3Output.m] using
+    (Stage2Output.apSumFrom_start_eq_apSumOffset (f := f) (out := out.out2) (n := n))
 
 /-- Recover the offset parameter `out.m` by dividing the start index `out.start` by the step size
 `out.d`.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Added a Stage-2 core rewrite lemma expressing the start-index affine-tail nucleus as the offset nucleus.
- Refactored the Stage-3 wrapper lemma to reuse the Stage-2 core lemma (less duplicated wiring).
