### PR TITLE
Track C: Stage2 start_add_div_d in core

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2Core.lean
@@ -109,6 +109,11 @@ theorem add_start_div_d (out : Stage2Output f) (n : ℕ) :
   simpa [Stage2Output.start] using
     (Nat.add_mul_div_right (x := n) (y := out.m) (z := out.d) hd)
 
+/-- Variant of `add_start_div_d` with the start index on the left. -/
+theorem start_add_div_d (out : Stage2Output f) (n : ℕ) :
+    (out.start + n) / out.d = n / out.d + out.m := by
+  simpa [Nat.add_comm] using out.add_start_div_d (f := f) (n := n)
+
 /-- Convenience projection: positivity of the reduced step size. -/
 @[simp] abbrev hd (out : Stage2Output f) : out.d > 0 := out.out1.hd
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2CoreExtras.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage2CoreExtras.lean
@@ -122,10 +122,8 @@ theorem boundedDiscOffset_iff_forall_natAbs_apSumFrom_start_le (out : Stage2Outp
 -- Note: `Stage2Output.add_start_div_d` now lives in
 -- `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Core` (hard-gate surface).
 
-/-- Variant of `add_start_div_d` with the start index on the left. -/
-theorem start_add_div_d (out : Stage2Output f) (n : ℕ) :
-    (out.start + n) / out.d = n / out.d + out.m := by
-  simpa [Nat.add_comm] using out.add_start_div_d (f := f) (n := n)
+-- Note: `Stage2Output.start_add_div_d` now lives in
+-- `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Core` (hard-gate surface).
 
 -- Note: `Stage2Output.start_div_d` lives in
 -- `Conjectures.C0002_erdos_discrepancy.src.TrackCStage2Core` (hard-gate surface).


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Add the symmetric arithmetic lemma Stage2Output.start_add_div_d to the Stage-2 core surface.
- Remove the duplicate definition from TrackCStage2CoreExtras (now just a note pointing to the core lemma).
