### PR TITLE
Track C: slim hard-gate ErdosDiscrepancy

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
@@ -5,6 +5,10 @@ A conjecture-style stub for the Erdős discrepancy theorem (Tao 2015).
 
 This file is **Conjectures-only**: it may rely on axiom stubs (notably the Stage-2 stub). Verified,
 reusable definitions belong in `MoltResearch/`.
+
+Design goal: keep this module as small as possible so the Track‑C hard‑gate build compiles quickly.
+Witness-form corollaries and additional packaging live in
+`Conjectures.C0002_erdos_discrepancy.src.ErdosDiscrepancyWitnesses`.
 -/
 
 namespace MoltResearch
@@ -31,137 +35,11 @@ boundedness predicate `BoundedDiscrepancy`.
 
 This equivalence lives in the verified core as
 `forall_hasDiscrepancyAtLeast_iff_not_boundedDiscrepancy`, but we restate it here so consumers of
-the Track‑C hard‑gate file can access it without hunting imports.
+this hard‑gate module can access it without hunting imports.
 -/
 theorem erdos_discrepancy_forall_hasDiscrepancyAtLeast_iff_notBounded (f : ℕ → ℤ) :
     (∀ C : ℕ, HasDiscrepancyAtLeast f C) ↔ ¬ BoundedDiscrepancy f := by
   exact forall_hasDiscrepancyAtLeast_iff_not_boundedDiscrepancy f
-
-/-- Stable boundedness-negation packaging of the Stage-3 offset-discrepancy witness.
-
-Normal form:
-`¬ ∃ B, BoundedDiscOffset f (stage3Out ...).d (stage3Out ...).m B`.
-
-This is a small convenience wrapper around `Tao2015.stage3_not_exists_boundedDiscOffset`.
--/
-theorem erdos_discrepancy_not_exists_boundedDiscOffset (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    ¬ ∃ B : ℕ,
-      BoundedDiscOffset f
-        (Tao2015.stage3Out (f := f) (hf := hf)).d
-        (Tao2015.stage3Out (f := f) (hf := hf)).m B := by
-  exact Tao2015.stage3_not_exists_boundedDiscOffset (f := f) (hf := hf)
-
-/-- Negation-normal-form packaging of the Stage-3 offset-discrepancy witness family.
-
-Normal form:
-`¬ ∃ B, ∀ n, discOffset f (stage3Out ...).d (stage3Out ...).m n ≤ B`.
-
-This is a small convenience wrapper around `Tao2015.stage3_unboundedDiscOffset` and the
-equivalence `Tao2015.unboundedDiscOffset_iff_not_exists_forall_discOffset_le`.
--/
-theorem erdos_discrepancy_not_exists_forall_discOffset_le (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    ¬ ∃ B : ℕ,
-      ∀ n : ℕ,
-        discOffset f
-          (Tao2015.stage3Out (f := f) (hf := hf)).d
-          (Tao2015.stage3Out (f := f) (hf := hf)).m n ≤ B := by
-  exact Tao2015.stage3_not_exists_forall_discOffset_le_d_m (f := f) (hf := hf)
-
-/-- Negation-normal-form packaging of the Stage-3 affine-tail witness, stated at the deterministic
-Stage-3 parameters `start` and `d`.
-
-Normal form:
-`¬ ∃ B, ∀ n, Int.natAbs (apSumFrom f (stage3Out ...).start (stage3Out ...).d n) ≤ B`.
-
-This is a small convenience wrapper around
-`Tao2015.stage3_not_exists_forall_natAbs_apSumFrom_start_le'`.
--/
-theorem erdos_discrepancy_not_exists_forall_natAbs_apSumFrom_start_le (f : ℕ → ℤ)
-    (hf : IsSignSequence f) :
-    ¬ ∃ B : ℕ,
-      ∀ n : ℕ,
-        Int.natAbs
-            (apSumFrom f
-              (Tao2015.stage3Out (f := f) (hf := hf)).start
-              (Tao2015.stage3Out (f := f) (hf := hf)).d n) ≤ B := by
-  exact Tao2015.stage3_not_exists_forall_natAbs_apSumFrom_start_le' (f := f) (hf := hf)
-
-/-- Existential packaging of `erdos_discrepancy_not_exists_boundedDiscOffset`.
-
-Normal form:
-`∃ d m, 1 ≤ d ∧ ¬ ∃ B, BoundedDiscOffset f d m B`.
-
-This is a small convenience wrapper around
-`Tao2015.stage3_exists_params_one_le_not_exists_boundedDiscOffset`.
--/
-theorem erdos_discrepancy_exists_params_one_le_not_exists_boundedDiscOffset (f : ℕ → ℤ)
-    (hf : IsSignSequence f) :
-    ∃ d m : ℕ, 1 ≤ d ∧ ¬ ∃ B : ℕ, BoundedDiscOffset f d m B := by
-  exact Tao2015.stage3_exists_params_one_le_not_exists_boundedDiscOffset (f := f) (hf := hf)
-
-/-- Stable packaging of the Stage-3 offset-discrepancy unboundedness witness.
-
-Normal form:
-`UnboundedDiscOffset f (stage3Out ...).d (stage3Out ...).m`.
-
-This is a small convenience wrapper around `Tao2015.stage3_unboundedDiscOffset`.
--/
-theorem erdos_discrepancy_unboundedDiscOffset (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    Tao2015.UnboundedDiscOffset f
-      (Tao2015.stage3Out (f := f) (hf := hf)).d
-      (Tao2015.stage3Out (f := f) (hf := hf)).m := by
-  exact Tao2015.stage3_unboundedDiscOffset (f := f) (hf := hf)
-
-/-- Existential packaging of `erdos_discrepancy_unboundedDiscOffset`.
-
-Normal form:
-`∃ d m, d > 0 ∧ UnboundedDiscOffset f d m`.
-
-This is a small convenience wrapper around `Tao2015.stage3_exists_params_unboundedDiscOffset`.
--/
-theorem erdos_discrepancy_exists_params_unboundedDiscOffset (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    ∃ d m : ℕ, d > 0 ∧ Tao2015.UnboundedDiscOffset f d m := by
-  exact Tao2015.stage3_exists_params_unboundedDiscOffset (f := f) (hf := hf)
-
-/-- Existential packaging of `erdos_discrepancy_unboundedDiscOffset`.
-
-Normal form:
-`∃ d m, 1 ≤ d ∧ UnboundedDiscOffset f d m`.
-
-This is a small convenience wrapper around
-`Tao2015.stage3_exists_params_one_le_unboundedDiscOffset`.
--/
-theorem erdos_discrepancy_exists_params_one_le_unboundedDiscOffset (f : ℕ → ℤ)
-    (hf : IsSignSequence f) :
-    ∃ d m : ℕ, 1 ≤ d ∧ Tao2015.UnboundedDiscOffset f d m := by
-  exact Tao2015.stage3_exists_params_one_le_unboundedDiscOffset (f := f) (hf := hf)
-
-/-- Negation-normal-form packaging of the Stage-3 affine-tail witness.
-
-Normal form:
-`∃ d m, 1 ≤ d ∧ ¬ ∃ B, ∀ n, Int.natAbs (apSumFrom f (m*d) d n) ≤ B`.
-
-This is `erdos_discrepancy_exists_params_one_le_unboundedDiscOffset` rewritten using
-`Tao2015.UnboundedDiscOffset.iff_not_exists_forall_natAbs_apSumFrom_mul_le`.
--/
-theorem erdos_discrepancy_exists_params_one_le_not_exists_forall_natAbs_apSumFrom_mul_le
-    (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    ∃ d m : ℕ, 1 ≤ d ∧
-      ¬ ∃ B : ℕ, ∀ n : ℕ, Int.natAbs (apSumFrom f (m * d) d n) ≤ B := by
-  exact Tao2015.stage3_exists_params_one_le_not_exists_forall_natAbs_apSumFrom_mul_le
-    (f := f) (hf := hf)
-
-/-- Track C pipeline witness: Stage 3 yields unbounded discrepancy along the reduced sequence,
-stated using the verified core predicate `MoltResearch.UnboundedDiscrepancyAlong`.
-
-This is a small convenience wrapper around
-`Tao2015.Stage3Output.unboundedDiscrepancyAlong_core`.
--/
-theorem erdos_discrepancy_unboundedDiscrepancyAlong_core (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    UnboundedDiscrepancyAlong
-      (Tao2015.stage3Out (f := f) (hf := hf)).g
-      (Tao2015.stage3Out (f := f) (hf := hf)).d := by
-  exact Tao2015.stage3_unboundedDiscrepancyAlong_core (f := f) (hf := hf)
 
 /-- Erdős discrepancy theorem.
 
@@ -175,41 +53,6 @@ theorem erdos_discrepancy (f : ℕ → ℤ) (hf : IsSignSequence f) :
   -- Delegate to the minimal Stage-3 entry-point API.
   exact Tao2015.stage3_forall_hasDiscrepancyAtLeast (f := f) (hf := hf)
 
-/-- Witness form of `erdos_discrepancy` directly in terms of the nucleus `apSum`.
-
-Normal form:
-`∀ C, ∃ d n, d ≥ 1 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C`.
-
-This is the most pipeline-friendly witness normal form: it avoids the `discrepancy` wrapper.
--/
-theorem erdos_discrepancy_forall_exists_d_ge_one_witness_pos (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    ∀ C : ℕ, ∃ d n : ℕ, d ≥ 1 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C := by
-  exact Tao2015.stage3_forall_exists_d_ge_one_witness_pos (f := f) (hf := hf)
-
-/-- Witness form of `erdos_discrepancy`, stated using the `discrepancy` wrapper.
-
-Normal form:
-`∀ C, ∃ d n, d > 0 ∧ discrepancy f d n > C`.
-
-This is the most direct discrepancy-wrapper witness form.
--/
-theorem erdos_discrepancy_forall_exists_discrepancy_gt (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    ∀ C : ℕ, ∃ d n : ℕ, d > 0 ∧ discrepancy f d n > C := by
-  exact Tao2015.stage3_forall_exists_discrepancy_gt (f := f) (hf := hf)
-
-/-- Positive-length witness form of `erdos_discrepancy_forall_exists_discrepancy_gt`.
-
-Normal form:
-`∀ C, ∃ d n, d > 0 ∧ n > 0 ∧ discrepancy f d n > C`.
-
-We keep this lemma in the hard-gate file since it is a common consumption pattern, and it does not
-require importing the larger witness-corollary module.
--/
-theorem erdos_discrepancy_forall_exists_discrepancy_gt_witness_pos (f : ℕ → ℤ)
-    (hf : IsSignSequence f) :
-    ∀ C : ℕ, ∃ d n : ℕ, d > 0 ∧ n > 0 ∧ discrepancy f d n > C := by
-  exact Tao2015.stage3_forall_exists_discrepancy_gt_witness_pos (f := f) (hf := hf)
-
 /-- Specialization of `erdos_discrepancy` at a fixed threshold `C`.
 
 This is a tiny convenience lemma: it avoids an extra application at the call site.
@@ -217,12 +60,5 @@ This is a tiny convenience lemma: it avoids an extra application at the call sit
 theorem erdos_discrepancy_hasDiscrepancyAtLeast (f : ℕ → ℤ) (hf : IsSignSequence f) (C : ℕ) :
     HasDiscrepancyAtLeast f C := by
   exact (erdos_discrepancy (f := f) (hf := hf)) C
-
-/-!
-Additional witness-form corollaries live in
-`Conjectures.C0002_erdos_discrepancy.src.ErdosDiscrepancyWitnesses`.
-
-We keep this file minimal so the Track-C hard-gate build can compile quickly.
--/
 
 end MoltResearch

--- a/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancyWitnesses.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancyWitnesses.lean
@@ -13,6 +13,42 @@ Track-C hard-gate build compiles quickly.
 
 namespace MoltResearch
 
+/-!
+## Witness-form wrappers (Stage 3 → common surface normal forms)
+
+These are small convenience wrappers around the Stage-3 entry-point API.
+They previously lived in `Conjectures.C0002_erdos_discrepancy.src.ErdosDiscrepancy`, but were moved
+here so the Track‑C hard‑gate build stays minimal.
+-/
+
+/-- Witness form of `erdos_discrepancy` directly in terms of the nucleus `apSum`.
+
+Normal form:
+`∀ C, ∃ d n, d ≥ 1 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C`.
+-/
+theorem erdos_discrepancy_forall_exists_d_ge_one_witness_pos (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    ∀ C : ℕ, ∃ d n : ℕ, d ≥ 1 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C := by
+  exact Tao2015.stage3_forall_exists_d_ge_one_witness_pos (f := f) (hf := hf)
+
+/-- Witness form of `erdos_discrepancy` using the `discrepancy` wrapper.
+
+Normal form:
+`∀ C, ∃ d n, d > 0 ∧ discrepancy f d n > C`.
+-/
+theorem erdos_discrepancy_forall_exists_discrepancy_gt (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    ∀ C : ℕ, ∃ d n : ℕ, d > 0 ∧ discrepancy f d n > C := by
+  exact Tao2015.stage3_forall_exists_discrepancy_gt (f := f) (hf := hf)
+
+/-- Positive-length witness form of `erdos_discrepancy_forall_exists_discrepancy_gt`.
+
+Normal form:
+`∀ C, ∃ d n, d > 0 ∧ n > 0 ∧ discrepancy f d n > C`.
+-/
+theorem erdos_discrepancy_forall_exists_discrepancy_gt_witness_pos (f : ℕ → ℤ)
+    (hf : IsSignSequence f) :
+    ∀ C : ℕ, ∃ d n : ℕ, d > 0 ∧ n > 0 ∧ discrepancy f d n > C := by
+  exact Tao2015.stage3_forall_exists_discrepancy_gt_witness_pos (f := f) (hf := hf)
+
 /-- Paper-notation witness form for the concrete Stage-3 offset parameters.
 
 Normal form:
@@ -91,7 +127,7 @@ This is the most pipeline-friendly surface statement:
 -/
 theorem erdos_discrepancy_apSum (f : ℕ → ℤ) (hf : IsSignSequence f) :
     ∀ C : ℕ, ∃ d n : ℕ, d ≥ 1 ∧ n > 0 ∧ Int.natAbs (apSum f d n) > C := by
-  -- Reuse the hard-gate lemma from `ErdosDiscrepancy.lean`.
+  -- Reuse the Stage-3 wrapper lemma (now kept out of the hard-gate module).
   exact erdos_discrepancy_forall_exists_d_ge_one_witness_pos (f := f) (hf := hf)
 
 /-- Variant of `erdos_discrepancy_apSum` writing the step-size side condition as `d > 0`.
@@ -122,7 +158,7 @@ Normal form:
 -/
 theorem erdos_discrepancy_discrepancy (f : ℕ → ℤ) (hf : IsSignSequence f) :
     ∀ C : ℕ, ∃ d n : ℕ, d > 0 ∧ discrepancy f d n > C := by
-  -- Reuse the hard-gate lemma from `ErdosDiscrepancy.lean`.
+  -- Reuse the Stage-3 wrapper lemma (now kept out of the hard-gate module).
   exact erdos_discrepancy_forall_exists_discrepancy_gt (f := f) (hf := hf)
 
 /-- Variant of `erdos_discrepancy_discrepancy` writing the step-size side condition as `d ≥ 1`.
@@ -152,7 +188,7 @@ This is sometimes convenient when downstream stages want to rule out the degener
 -/
 theorem erdos_discrepancy_discrepancy_witness_pos (f : ℕ → ℤ) (hf : IsSignSequence f) :
     ∀ C : ℕ, ∃ d n : ℕ, d > 0 ∧ n > 0 ∧ discrepancy f d n > C := by
-  -- Reuse the hard-gate lemma from `ErdosDiscrepancy.lean`.
+  -- Reuse the Stage-3 wrapper lemma (now kept out of the hard-gate module).
   exact erdos_discrepancy_forall_exists_discrepancy_gt_witness_pos (f := f) (hf := hf)
 
 /-- Track-C pipeline witness form (Tao 2015 plane): there exist concrete parameters `d, m` such that
@@ -178,8 +214,104 @@ theorem erdos_discrepancy_exists_params_d_ne_zero_unboundedDiscOffset (f : ℕ �
     ⟨d, m, hd, hunb⟩
   exact ⟨d, m, Nat.ne_of_gt hd, hunb⟩
 
--- Note: the packaging lemma `erdos_discrepancy_exists_params_one_le_unboundedDiscOffset` lives in
--- `Conjectures.C0002_erdos_discrepancy.src.ErdosDiscrepancy`.
+/-- Variant of `erdos_discrepancy_exists_params_unboundedDiscOffset` packaging the step-size side
+condition as `1 ≤ d`.
+
+Many later stages prefer the normal form `1 ≤ d` rather than `d > 0`.
+-/
+theorem erdos_discrepancy_exists_params_one_le_unboundedDiscOffset (f : ℕ → ℤ)
+    (hf : IsSignSequence f) :
+    ∃ d m : ℕ, 1 ≤ d ∧ Tao2015.UnboundedDiscOffset f d m := by
+  exact Tao2015.stage3_exists_params_one_le_unboundedDiscOffset (f := f) (hf := hf)
+
+/-- Existential packaging version of the stable boundedness-negation normal form.
+
+Normal form:
+`∃ d m, 1 ≤ d ∧ ¬ ∃ B, BoundedDiscOffset f d m B`.
+-/
+theorem erdos_discrepancy_exists_params_one_le_not_exists_boundedDiscOffset (f : ℕ → ℤ)
+    (hf : IsSignSequence f) :
+    ∃ d m : ℕ, 1 ≤ d ∧ ¬ ∃ B : ℕ, BoundedDiscOffset f d m B := by
+  exact Tao2015.stage3_exists_params_one_le_not_exists_boundedDiscOffset (f := f) (hf := hf)
+
+/-- Existential packaging of the affine-tail boundedness-negation normal form.
+
+Normal form:
+`∃ d m, 1 ≤ d ∧ ¬ ∃ B, ∀ n, Int.natAbs (apSumFrom f (m*d) d n) ≤ B`.
+-/
+theorem erdos_discrepancy_exists_params_one_le_not_exists_forall_natAbs_apSumFrom_mul_le
+    (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    ∃ d m : ℕ, 1 ≤ d ∧
+      ¬ ∃ B : ℕ, ∀ n : ℕ, Int.natAbs (apSumFrom f (m * d) d n) ≤ B := by
+  exact Tao2015.stage3_exists_params_one_le_not_exists_forall_natAbs_apSumFrom_mul_le
+    (f := f) (hf := hf)
+
+/-!
+## Negation-normal-form wrappers at deterministic Stage-3 parameters
+
+These package the unboundedness conclusions in stable boundedness-negation normal forms, using the
+deterministic Stage‑3 parameters bundled in `Tao2015.stage3Out`.
+-/
+
+/-- Stable boundedness-negation normal form at the deterministic Stage-3 parameters.
+
+Normal form:
+`¬ ∃ B, BoundedDiscOffset f (stage3Out ...).d (stage3Out ...).m B`.
+-/
+theorem erdos_discrepancy_not_exists_boundedDiscOffset (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    ¬ ∃ B : ℕ,
+      BoundedDiscOffset f
+        (Tao2015.stage3Out (f := f) (hf := hf)).d
+        (Tao2015.stage3Out (f := f) (hf := hf)).m B := by
+  exact Tao2015.stage3_not_exists_boundedDiscOffset (f := f) (hf := hf)
+
+/-- Stable `discOffset` boundedness-negation normal form at the deterministic Stage-3 parameters.
+
+Normal form:
+`¬ ∃ B, ∀ n, discOffset f (stage3Out ...).d (stage3Out ...).m n ≤ B`.
+-/
+theorem erdos_discrepancy_not_exists_forall_discOffset_le (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    ¬ ∃ B : ℕ,
+      ∀ n : ℕ,
+        discOffset f
+          (Tao2015.stage3Out (f := f) (hf := hf)).d
+          (Tao2015.stage3Out (f := f) (hf := hf)).m n ≤ B := by
+  exact Tao2015.stage3_not_exists_forall_discOffset_le_d_m (f := f) (hf := hf)
+
+/-- Stable `apSumFrom` boundedness-negation normal form at the deterministic Stage-3 parameters.
+
+Normal form:
+`¬ ∃ B, ∀ n, Int.natAbs (apSumFrom f (stage3Out ...).start (stage3Out ...).d n) ≤ B`.
+-/
+theorem erdos_discrepancy_not_exists_forall_natAbs_apSumFrom_start_le (f : ℕ → ℤ)
+    (hf : IsSignSequence f) :
+    ¬ ∃ B : ℕ,
+      ∀ n : ℕ,
+        Int.natAbs
+            (apSumFrom f
+              (Tao2015.stage3Out (f := f) (hf := hf)).start
+              (Tao2015.stage3Out (f := f) (hf := hf)).d n) ≤ B := by
+  exact Tao2015.stage3_not_exists_forall_natAbs_apSumFrom_start_le' (f := f) (hf := hf)
+
+/-- Stable packaging of the Stage-3 offset-discrepancy unboundedness witness.
+
+Normal form:
+`UnboundedDiscOffset f (stage3Out ...).d (stage3Out ...).m`.
+-/
+theorem erdos_discrepancy_unboundedDiscOffset (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    Tao2015.UnboundedDiscOffset f
+      (Tao2015.stage3Out (f := f) (hf := hf)).d
+      (Tao2015.stage3Out (f := f) (hf := hf)).m := by
+  exact Tao2015.stage3_unboundedDiscOffset (f := f) (hf := hf)
+
+/-- Track C pipeline witness: Stage 3 yields unbounded discrepancy along the reduced sequence,
+stated using the verified core predicate `MoltResearch.UnboundedDiscrepancyAlong`.
+-/
+theorem erdos_discrepancy_unboundedDiscrepancyAlong_core (f : ℕ → ℤ) (hf : IsSignSequence f) :
+    UnboundedDiscrepancyAlong
+      (Tao2015.stage3Out (f := f) (hf := hf)).g
+      (Tao2015.stage3Out (f := f) (hf := hf)).d := by
+  exact Tao2015.stage3_unboundedDiscrepancyAlong_core (f := f) (hf := hf)
 
 /-- Track-C pipeline witness form (Tao 2015 plane): there exist concrete parameters `d, m` such that
   the bundled offset discrepancy family `discOffset f d m` takes arbitrarily large values.


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Slimmed the hard-gate module ErdosDiscrepancy to just the core statements (not bounded + surface form) plus a small bridge lemma.
- Moved common witness / packaging wrappers into ErdosDiscrepancyWitnesses so downstream consumers can import them without bloating the hard-gate build.
- Removed a duplicate-name overlap between ErdosDiscrepancy and ErdosDiscrepancyWitnesses for the exists-params unbounded-discOffset packaging.
