### PR TITLE
Track C: derive erdos_discrepancy from ¬BoundedDiscrepancy

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
@@ -50,8 +50,10 @@ Track-C output `¬ BoundedDiscrepancy f`.
 -/
 theorem erdos_discrepancy (f : ℕ → ℤ) (hf : IsSignSequence f) :
     ∀ C : ℕ, HasDiscrepancyAtLeast f C := by
-  -- Delegate to the minimal Stage-3 entry-point API.
-  exact Tao2015.stage3_forall_hasDiscrepancyAtLeast (f := f) (hf := hf)
+  -- Convert from the core Track-C output `¬ BoundedDiscrepancy f` using the verified equivalence.
+  have hnb : ¬ BoundedDiscrepancy f :=
+    erdos_discrepancy_notBounded (f := f) (hf := hf)
+  exact (erdos_discrepancy_forall_hasDiscrepancyAtLeast_iff_notBounded (f := f)).2 hnb
 
 /-- Specialization of `erdos_discrepancy` at a fixed threshold `C`.
 


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: C
Checklist item: N/A

- Re-prove erdos_discrepancy by converting the Stage-3 output not BoundedDiscrepancy via the verified core equivalence.
- Tighten the dependency direction: the surface statement now follows from erdos_discrepancy_notBounded plus the core bridge lemma.
