### PR TITLE
Track C: dedupe Stage-3 convenience lemmas

### DIFF
--- a/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/ErdosDiscrepancy.lean
@@ -55,18 +55,6 @@ theorem erdos_discrepancy (f : ℕ → ℤ) (hf : IsSignSequence f) :
     erdos_discrepancy_notBounded (f := f) (hf := hf)
   exact (erdos_discrepancy_forall_hasDiscrepancyAtLeast_iff_notBounded (f := f)).2 hnb
 
-/-- Witness form of the Erdős discrepancy theorem.
-
-Normal form:
-`∀ C, ∃ d n, d > 0 ∧ discrepancy f d n > C`.
-
-This is a tiny wrapper around the Stage-3 boundary lemma
-`Tao2015.stage3_forall_exists_discrepancy_gt`.
--/
-theorem erdos_discrepancy_forall_exists_discrepancy_gt (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    ∀ C : ℕ, ∃ d n : ℕ, d > 0 ∧ discrepancy f d n > C := by
-  exact Tao2015.stage3_forall_exists_discrepancy_gt (f := f) (hf := hf)
-
 /-- Specialization of `erdos_discrepancy` at a fixed threshold `C`.
 
 This is a tiny convenience lemma: it avoids an extra application at the call site.

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Core.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Core.lean
@@ -128,13 +128,13 @@ theorem g_eq_fun (out : Stage3Output f) :
 /-- Convenience projection: positivity of the reduced step size. -/
 @[simp] abbrev hd (out : Stage3Output f) : out.d > 0 := out.out2.hd
 
-/-- Convenience lemma: the reduced step size is nonzero.
+/-!
+Note: `Stage3Output.d_ne_zero` is already defined in
+`Conjectures.C0002_erdos_discrepancy.src.TrackCStage3`.
 
-We intentionally delegate this to the Stage-2 boundary API lemma (`Stage2Output.d_ne_zero`), so
-Stage 3 doesn't re-prove arithmetic facts about its projections.
+We avoid re-declaring it here so `TrackCStage3Core` can be imported alongside `TrackCStage3`
+without name clashes.
 -/
-theorem d_ne_zero (out : Stage3Output f) : out.d ≠ 0 := by
-  simpa [Stage3Output.d] using (Stage2Output.d_ne_zero (f := f) out.out2)
 
 /-- Convenience lemma: the reduced step size is at least `1`.
 

--- a/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Entry.lean
+++ b/Conjectures/C0002_erdos_discrepancy/src/TrackCStage3Entry.lean
@@ -162,22 +162,12 @@ theorem stage3_g_eq_fun (f : ℕ → ℤ) (hf : IsSignSequence f) :
 ## Stage-3 output (`stage3Out`) arithmetic conveniences
 
 These lemmas are not needed by the Track-C hard-gate target
-`Conjectures.C0002_erdos_discrepancy.src.ErdosDiscrepancy`, so we keep them out of the minimal
-entry-point module `TrackCStage3EntryMinimal`.
+`Conjectures.C0002_erdos_discrepancy.src.ErdosDiscrepancy`.
+
+Note: some small `stage3Out` arithmetic wrappers already live in
+`Conjectures.C0002_erdos_discrepancy.src.TrackCStage3EntryMinimal`. We avoid re-declaring them
+here so this module can be imported alongside the minimal entry point without name clashes.
 -/
-
-/-- The Stage-3 start index is a multiple of the Stage-3 reduced step size. -/
-theorem stage3Out_d_dvd_start (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    (stage3Out (f := f) (hf := hf)).d ∣ (stage3Out (f := f) (hf := hf)).start := by
-  exact Stage3Output.d_dvd_start (f := f) (out := stage3Out (f := f) (hf := hf))
-
-/-- The Stage-3 start index has remainder `0` modulo the reduced step size.
-
-This is often the most convenient normal form of `stage3Out_d_dvd_start`.
--/
-theorem stage3Out_start_mod_d (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    (stage3Out (f := f) (hf := hf)).start % (stage3Out (f := f) (hf := hf)).d = 0 := by
-  exact Nat.mod_eq_zero_of_dvd (stage3Out_d_dvd_start (f := f) (hf := hf))
 
 /-- Adding the start index does not change residues modulo the step size.
 
@@ -194,14 +184,6 @@ theorem stage3Out_start_add_mod_d (f : ℕ → ℤ) (hf : IsSignSequence f) (n :
     ((stage3Out (f := f) (hf := hf)).start + n) % (stage3Out (f := f) (hf := hf)).d =
       n % (stage3Out (f := f) (hf := hf)).d := by
   exact Stage3Output.start_add_mod_d (f := f) (out := stage3Out (f := f) (hf := hf)) n
-
-/-- Convenience lemma: the Stage-3 reduced sequence is a sign sequence.
-
-This is a tiny wrapper around the Stage-2 core projection lemma `Stage2Output.hg`.
--/
-theorem stage3Out_hg (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    IsSignSequence (stage3Out (f := f) (hf := hf)).g := by
-  exact Stage2Output.hg (out := (stage3Out (f := f) (hf := hf)).out2)
 
 /-- Adding the start index increases quotients by the offset parameter.
 
@@ -227,27 +209,6 @@ theorem stage3Out_start_add_div_d (f : ℕ → ℤ) (hf : IsSignSequence f) (n :
       simp [Nat.add_comm]
     _ = n / (stage3Out (f := f) (hf := hf)).d + (stage3Out (f := f) (hf := hf)).m := by
       simpa using stage3Out_add_start_div_d (f := f) (hf := hf) (n := n)
-
-/-- Recover the offset parameter `m` by dividing the Stage-3 start index `start` by the step size `d`.
-
-This is a tiny arithmetic convenience lemma: `start = m*d` by definition.
--/
-theorem stage3Out_start_div_d (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    (stage3Out (f := f) (hf := hf)).start / (stage3Out (f := f) (hf := hf)).d =
-      (stage3Out (f := f) (hf := hf)).m := by
-  have hd' : 0 < (stage3Out (f := f) (hf := hf)).d := stage3Out_d_pos (f := f) (hf := hf)
-  rw [stage3Out_start_eq_m_mul_d (f := f) (hf := hf)]
-  exact Nat.mul_div_left (stage3Out (f := f) (hf := hf)).m hd'
-
-/-- Convenience lemma: the Stage-3 reduced step size is nonzero.
-
-This is sometimes the right normal form for downstream stages that treat `d` as a denominator (or
-simply want to avoid rewriting strict inequalities).
--/
-theorem stage3Out_d_ne_zero (f : ℕ → ℤ) (hf : IsSignSequence f) :
-    (stage3Out (f := f) (hf := hf)).d ≠ 0 := by
-  -- Delegate to the Stage-2 core lemma; avoids re-proving arithmetic facts.
-  simpa using (Stage2Output.d_ne_zero (out := (stage3Out (f := f) (hf := hf)).out2))
 
 /-!
 The lemma `stage3_unboundedDiscrepancyAlong_core` is provided by


### PR DESCRIPTION
Card: N/A
Track: N/A
Checklist item: N/A

This PR is a small consolidation pass after recent automation merges:

- Remove a duplicate witness-form wrapper from `ErdosDiscrepancy.lean` (it already exists in `ErdosDiscrepancyWitnesses.lean`).
- Avoid re-declaring `stage3Out_*` arithmetic wrappers in `TrackCStage3Entry.lean` when they already live in `TrackCStage3EntryMinimal` (prevents name clashes when both modules are imported).
- Avoid re-declaring `Stage3Output.d_ne_zero` in `TrackCStage3Core.lean` (already provided by `TrackCStage3`).

`lake build Conjectures.C0002_erdos_discrepancy.src.ErdosDiscrepancy` succeeds locally (warnings only).