### PR TITLE
Discrepancy: add apSupportUpTo support wrapper

### DIFF
--- a/Learning/EDUCATIONAL_OVERLAYS.md
+++ b/Learning/EDUCATIONAL_OVERLAYS.md
@@ -180,6 +180,12 @@ The goal is to pair verified artifacts with learning scaffolding.
   For unfold-free membership reasoning, use `mem_apSupport_iff`, or the binder-notation variant `mem_apSupport` when you want to feed the result directly to `simp`/`rcases` as `∃ i < n, ...`.
   If you want the *paper endpoint convention* (`m < i ∧ i ≤ m+n` with accessed index `i*d`), use `mem_apSupport_iff_exists_endpoints`.
   If you want to expose the underlying `Finset.range` image form of the support (to map/filter/count over it) without unfolding the definition, rewrite via `apSupport_eq_image_range`.
+- **API note (`apSupportUpTo` for max-length families):** when you need a single support set covering all `apSupport d m n` with
+  `n ≤ N` (e.g. to control rewrites for `discOffsetUpTo f d m N`), use `apSupportUpTo d m N`.
+  It is definitionally `apSupport d m N`, and the stable surface provides:
+  - `apSupport_subset_apSupportUpTo` for monotonicity (`n ≤ N`),
+  - `mem_apSupportUpTo` for the existential membership normal form, and
+  - `card_apSupportUpTo_le` / `card_apSupportUpTo_eq` for cardinality bounds.
 - **API note (`apSupport` canonical membership):** if your membership goal is already in the normal form
   `((m + i + 1) * d) ∈ apSupport d m n`, and you have `hd : d > 0`, then `simp [mem_apSupport_index_iff (m := m) (n := n) (i := i) hd]` reduces it to the expected bound `i < n`.
 - **API note (`apSupport` concatenation):** to split the support of a length `(n+k)` block into its first `n` and last `k` pieces, use

--- a/MoltResearch/Discrepancy/Basic.lean
+++ b/MoltResearch/Discrepancy/Basic.lean
@@ -357,6 +357,26 @@ def apSupport (d m n : ℕ) : Finset ℕ :=
   (Finset.range n).image (fun i => (m + i + 1) * d)
 
 /-!
+### Support finset up to a cutoff (Track B)
+
+`discOffsetUpTo f d m N` ranges over all lengths `n ≤ N`. For “local surgery” arguments, it is
+useful to name a single finitary support set containing all indices accessed by any such length.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — `apSupportUpTo`.
+-/
+
+/-- `apSupportUpTo d m N` is the support finset for AP sums of step `d`, start-offset `m`,
+of any length `n ≤ N`.
+
+Concretely, this is just `apSupport d m N`, since `apSupport d m n ⊆ apSupport d m N` whenever
+`n ≤ N`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — `apSupportUpTo`.
+-/
+def apSupportUpTo (d m N : ℕ) : Finset ℕ :=
+  apSupport d m N
+
+/-!
 ### “Offset is just tail” packaging lemma (Track B)
 
 Downstream, we often want to push `apSupport d m n` into the explicit `Finset.range` image form
@@ -441,6 +461,46 @@ lemma mem_apSupport {d m n x : ℕ} :
     x ∈ apSupport d m n ↔ ∃ i < n, x = (m + i + 1) * d := by
   simpa [and_left_comm, and_assoc, and_comm] using
     (mem_apSupport_iff (d := d) (m := m) (n := n) (x := x))
+
+/-!
+### Basic lemmas for `apSupportUpTo` (Track B)
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — `apSupportUpTo`.
+-/
+
+/-- Monotonicity: shorter supports are contained in the cutoff support.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — `apSupportUpTo`.
+-/
+lemma apSupport_subset_apSupportUpTo {d m n N : ℕ} (hn : n ≤ N) :
+    apSupport d m n ⊆ apSupportUpTo d m N := by
+  intro x hx
+  rcases (mem_apSupport_iff (d := d) (m := m) (n := n) (x := x)).1 hx with ⟨i, hi, rfl⟩
+  have hiN : i < N := lt_of_lt_of_le hi hn
+  exact (mem_apSupport_iff (d := d) (m := m) (n := N) (x := (m + i + 1) * d)).2 ⟨i, hiN, rfl⟩
+
+/-- Stable-surface membership characterization for `apSupportUpTo`.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — `apSupportUpTo`.
+-/
+lemma mem_apSupportUpTo {d m N x : ℕ} :
+    x ∈ apSupportUpTo d m N ↔ ∃ i < N, x = (m + i + 1) * d := by
+  unfold apSupportUpTo
+  simpa using (mem_apSupport (d := d) (m := m) (n := N) (x := x))
+
+/-- Cardinality bound: `apSupportUpTo d m N` contains at most `N` indices.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — `apSupportUpTo`.
+-/
+lemma card_apSupportUpTo_le (d m N : ℕ) : (apSupportUpTo d m N).card ≤ N := by
+  simpa [apSupportUpTo] using (card_apSupport_le (d := d) (m := m) (n := N))
+
+/-- Exact cardinality when the step is positive.
+
+Checklist item: Problems/erdos_discrepancy.md (Track B) — `apSupportUpTo`.
+-/
+lemma card_apSupportUpTo_eq (d m N : ℕ) (hd : d > 0) : (apSupportUpTo d m N).card = N := by
+  simpa [apSupportUpTo] using (card_apSupport_eq (d := d) (m := m) (n := N) hd)
 
 /-!
 ### Canonical membership normal form (Track B)

--- a/MoltResearch/Discrepancy/NormalFormExamples.lean
+++ b/MoltResearch/Discrepancy/NormalFormExamples.lean
@@ -101,6 +101,29 @@ example (g : ℕ → ℤ) (h : ∀ x ∈ apSupport d m n, f x = g x) :
   simpa using (discOffset_congr_support (f := f) (g := g) (d := d) (m := m) (n := n) h)
 
 /-!
+### NEW (Track B): stable-surface regression for `apSupportUpTo`
+
+Compile-only regression tests: downstream code should be able to talk about the indices touched by
+any length `n ≤ N` without re-opening `Finset.range` / `Finset.image` algebra.
+-/
+
+-- (1) Monotonicity: a shorter support is contained in the cutoff support.
+example (N : ℕ) (hN : n ≤ N) : apSupport d m n ⊆ apSupportUpTo d m N := by
+  simpa using (apSupport_subset_apSupportUpTo (d := d) (m := m) (n := n) (N := N) hN)
+
+-- (2) Membership: stable-surface existential normal form.
+example (N x : ℕ) :
+    x ∈ apSupportUpTo d m N ↔ ∃ i < N, x = (m + i + 1) * d := by
+  simpa using (mem_apSupportUpTo (d := d) (m := m) (N := N) (x := x))
+
+-- (3) Cardinality bounds.
+example (N : ℕ) : (apSupportUpTo d m N).card ≤ N := by
+  simpa using (card_apSupportUpTo_le (d := d) (m := m) (N := N))
+
+example (N : ℕ) (hd : d > 0) : (apSupportUpTo d m N).card = N := by
+  simpa using (card_apSupportUpTo_eq (d := d) (m := m) (N := N) hd)
+
+/-!
 ### NEW (Track B): step/offset coercion normal form (`discOffset`)
 
 Compile-only regression test: if the input sequence is shifted by a multiple of the step `d`, the


### PR DESCRIPTION
Card: Problems/erdos_discrepancy.md
Track: B
Checklist item: `apSupportUpTo` (support union for `UpTo`): define a finitary support set capturing all indices touched by the family

Implements `apSupportUpTo d m N` as the finitary support set covering all indices accessed by any `apSupport d m n` with `n ≤ N`, plus a small interface:
- `apSupport_subset_apSupportUpTo` (monotonicity)
- `mem_apSupportUpTo` (stable membership normal form)
- `card_apSupportUpTo_le` / `card_apSupportUpTo_eq`

Adds stable-surface regression examples in `MoltResearch/Discrepancy/NormalFormExamples.lean`.

Testing:
- `make ci`
